### PR TITLE
Fix: Issue #15 - [Frontend] Client-side file size validation

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,3 +8,6 @@ VITE_FIREBASE_APP_ID=your_app_id
 VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 # Backend API URL (optional, uses proxy in development)
 VITE_API_URL=http://localhost:5000
+
+# File Upload Configuration
+VITE_MAX_SIZE_MB=5

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,13 +1,28 @@
 import { useCallback } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { Upload, FileText } from 'lucide-react'
+import toast from 'react-hot-toast'
 
-export default function FileUpload({ onFileSelect, disabled = false }) {
-  const onDrop = useCallback((acceptedFiles) => {
+export default function FileUpload({ onFileSelect, disabled = false, maxSizeMB = 10 }) {
+  const maxSizeBytes = maxSizeMB * 1024 * 1024
+
+  const onDrop = useCallback((acceptedFiles, rejectedFiles) => {
+    if (rejectedFiles && rejectedFiles.length > 0) {
+      rejectedFiles.forEach((file) => {
+        if (file.file.size > maxSizeBytes) {
+          const fileSizeMB = (file.file.size / (1024 * 1024)).toFixed(2)
+          toast.error(
+            `File "${file.file.name}" (${fileSizeMB}MB) exceeds the maximum limit of ${maxSizeMB}MB`
+          )
+        }
+      })
+      return
+    }
+
     if (acceptedFiles.length > 0) {
       onFileSelect(acceptedFiles[0])
     }
-  }, [onFileSelect])
+  }, [onFileSelect, maxSizeBytes, maxSizeMB])
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -15,7 +30,7 @@ export default function FileUpload({ onFileSelect, disabled = false }) {
       'application/pdf': ['.pdf']
     },
     maxFiles: 1,
-    maxSize: 5 * 1024 * 1024, // 5MB
+    maxSize: maxSizeBytes,
     disabled
   })
 
@@ -50,7 +65,7 @@ export default function FileUpload({ onFileSelect, disabled = false }) {
             <p className="text-sm text-neutral-500 mb-4">or click to browse</p>
             <div className="inline-flex items-center gap-2 px-4 py-2 bg-neutral-800 rounded-lg">
               <FileText className="w-4 h-4 text-neutral-500" />
-              <span className="text-xs text-neutral-500">PDF files only • Max 5MB</span>
+              <span className="text-xs text-neutral-500">PDF files only • Max {maxSizeMB}MB</span>
             </div>
           </>
         )}

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -3,7 +3,7 @@ import { useDropzone } from 'react-dropzone'
 import { Upload, FileText } from 'lucide-react'
 import toast from 'react-hot-toast'
 
-export default function FileUpload({ onFileSelect, disabled = false, maxSizeMB = 10 }) {
+export default function FileUpload({ onFileSelect, disabled = false, maxSizeMB = 5 }) {
   const maxSizeBytes = maxSizeMB * 1024 * 1024
 
   const onDrop = useCallback((acceptedFiles, rejectedFiles) => {

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -6,6 +6,14 @@ import { uploadApi, resumeApi } from '../services/api'
 import FileUpload from '../components/FileUpload'
 import { FileText, Upload as UploadIcon, CheckCircle, Target, BarChart3, Zap } from 'lucide-react'
 
+// Configuration for file size validation
+const FILE_SIZE_CONFIG = {
+  maxSizeMB: parseInt(import.meta.env.VITE_MAX_SIZE_MB || '10'),
+  get maxSizeBytes() {
+    return this.maxSizeMB * 1024 * 1024
+  }
+}
+
 export default function Upload() {
   const navigate = useNavigate()
 
@@ -13,7 +21,27 @@ export default function Upload() {
   const [loading, setLoading] = useState(false)
   const [uploadComplete, setUploadComplete] = useState(false)
 
+  /**
+   * Validates file size before upload
+   * @param {File} file - The file to validate
+   * @returns {boolean} - True if valid, false otherwise
+   */
+  const validateFileSize = (file) => {
+    if (file.size > FILE_SIZE_CONFIG.maxSizeBytes) {
+      const fileSizeMB = (file.size / (1024 * 1024)).toFixed(2)
+      toast.error(
+        `File size (${fileSizeMB}MB) exceeds the maximum limit of ${FILE_SIZE_CONFIG.maxSizeMB}MB. Please upload a smaller file.`
+      )
+      return false
+    }
+    return true
+  }
+
   const handleFileSelect = async (selectedFile) => {
+    if (!validateFileSize(selectedFile)) {
+      return
+    }
+
     setFile(selectedFile)
     setLoading(true)
 
@@ -126,6 +154,7 @@ export default function Upload() {
             <FileUpload
               onFileSelect={handleFileSelect}
               disabled={loading}
+              maxSizeMB={FILE_SIZE_CONFIG.maxSizeMB}
             />
             {loading && (
               <div className="flex flex-col items-center justify-center gap-3 mt-6">

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -30,7 +30,7 @@ export default function Upload() {
     if (file.size > FILE_SIZE_CONFIG.maxSizeBytes) {
       const fileSizeMB = (file.size / (1024 * 1024)).toFixed(2)
       toast.error(
-        `File size (${fileSizeMB}MB) exceeds the maximum limit of ${FILE_SIZE_CONFIG.maxSizeMB}MB. Please upload a smaller file.`
+        `File size (${fileSizeMB}MB) exceeds the maximum limit of ${FILE_SIZE_CONFIG.maxSizeMB}MB.`
       )
       return false
     }

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -8,7 +8,7 @@ import { FileText, Upload as UploadIcon, CheckCircle, Target, BarChart3, Zap } f
 
 // Configuration for file size validation
 const FILE_SIZE_CONFIG = {
-  maxSizeMB: parseInt(import.meta.env.VITE_MAX_SIZE_MB || '10'),
+  maxSizeMB: parseInt(import.meta.env.VITE_MAX_SIZE_MB || '5'),
   get maxSizeBytes() {
     return this.maxSizeMB * 1024 * 1024
   }
@@ -29,9 +29,7 @@ export default function Upload() {
   const validateFileSize = (file) => {
     if (file.size > FILE_SIZE_CONFIG.maxSizeBytes) {
       const fileSizeMB = (file.size / (1024 * 1024)).toFixed(2)
-      toast.error(
-        `File size (${fileSizeMB}MB) exceeds the maximum limit of ${FILE_SIZE_CONFIG.maxSizeMB}MB.`
-      )
+      toast.error(`File size (${fileSizeMB}MB) exceeds the maximum limit of ${FILE_SIZE_CONFIG.maxSizeMB}MB.`)
       return false
     }
     return true


### PR DESCRIPTION
- Configurable limit - Set via VITE_MAX_SIZE_MB environment variable
- Default 5MB - Falls back to 5MB if not configured
- Immediate feedback - Toast error appears before any API call
- User-friendly messages - Shows actual file size and limit
- Dual validation - Both FileUpload component and Upload page validate
- No breaking changes - Backward compatible with existing code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File uploads now enforce a configurable maximum file size limit
  * Added error notifications when uploaded files exceed the configured size limit
  * Upload UI now displays the actual enforced file size limit instead of a fixed value

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->