### PR TITLE
fixed text overflow in community cards

### DIFF
--- a/frontend/src/components/community/PostCard.jsx
+++ b/frontend/src/components/community/PostCard.jsx
@@ -137,9 +137,9 @@ export default function PostCard({ post, currentUser, onLike, onCommentAdded }) 
         <div className="prose prose-sm prose-invert max-w-none text-neutral-400">
           {shouldTruncate && !showFullContent ? (
             <>
-              <ReactMarkdown>
-                {previewText + '...'}
-              </ReactMarkdown>
+              <ReactMarkdown className="break-words">
+  {preview.content}
+</ReactMarkdown>
               <button
                 onClick={() => setShowFullContent(true)}
                 className="text-indigo-400 hover:text-indigo-300 font-medium text-sm"
@@ -148,7 +148,7 @@ export default function PostCard({ post, currentUser, onLike, onCommentAdded }) 
               </button>
             </>
           ) : (
-            <ReactMarkdown className="break-all">
+            <ReactMarkdown className="break-words">
   {post.content}
 </ReactMarkdown>
           )}

--- a/frontend/src/components/community/PostCard.jsx
+++ b/frontend/src/components/community/PostCard.jsx
@@ -148,7 +148,9 @@ export default function PostCard({ post, currentUser, onLike, onCommentAdded }) 
               </button>
             </>
           ) : (
-            <ReactMarkdown>{post.content}</ReactMarkdown>
+            <ReactMarkdown className="break-all">
+  {post.content}
+</ReactMarkdown>
           )}
         </div>
 

--- a/frontend/src/pages/Community.jsx
+++ b/frontend/src/pages/Community.jsx
@@ -478,7 +478,7 @@ function CreateChannelModal({ onClose, onCreate }) {
             <label className="block text-sm font-medium text-neutral-400 mb-2">
               Visibility
             </label>
-            <div className="flex gap-4">
+            <div className="flex gap-4 min-w-0">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="radio"


### PR DESCRIPTION
Changes made-

* Added proper text wrapping for post content rendered through `ReactMarkdown`
* Prevented long URLs and continuous strings from breaking the card layout
* Improved responsiveness and maintained container structure on smaller screens

 Result-

Community posts now wrap correctly without overflowing or stretching the UI containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved post content word-breaking and rendering for better readability.
  * Enhanced modal layout responsiveness in the channel creation visibility section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->