### PR TITLE
fix(frontend): add active state to navbar and sidebar tabs

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { isNavActive } from '../lib/nav'
 import {
   Zap,
   Search,
@@ -38,8 +39,6 @@ export default function Navbar() {
     }
   }
 
-  const isActive = (path) => location.pathname === path
-
   const navLinks = [
     { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { path: '/jobs', label: 'Find Jobs', icon: Search },
@@ -75,9 +74,9 @@ export default function Navbar() {
                   <Link
                     key={path}
                     to={path}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${isActive(path)
-                      ? 'bg-zinc-800 text-white'
-                      : 'text-zinc-400 hover:text-white hover:bg-zinc-900'
+                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all border-b-2 ${isNavActive(path, location.pathname)
+                      ? 'bg-zinc-800 text-white border-indigo-400'
+                      : 'text-zinc-400 hover:text-white hover:bg-zinc-900 border-transparent'
                       }`}
                   >
                     <Icon className="w-4 h-4" />
@@ -167,9 +166,9 @@ export default function Navbar() {
                     key={path}
                     to={path}
                     onClick={() => setMobileMenuOpen(false)}
-                    className={`flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all ${isActive(path)
-                      ? 'bg-zinc-800 text-white'
-                      : 'text-zinc-400 hover:bg-zinc-900 hover:text-white'
+                    className={`flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all border-l-2 ${isNavActive(path, location.pathname)
+                      ? 'bg-zinc-800 text-white border-indigo-400'
+                      : 'text-zinc-400 hover:bg-zinc-900 hover:text-white border-transparent'
                       }`}
                   >
                     <Icon className="w-5 h-5" />

--- a/frontend/src/components/ui/Sidebar.jsx
+++ b/frontend/src/components/ui/Sidebar.jsx
@@ -1,4 +1,5 @@
 import { cn } from "../../lib/utils";
+import { isNavActive } from "../../lib/nav";
 import { Link, useLocation } from "react-router-dom";
 import { useState, createContext, useContext } from "react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -141,17 +142,19 @@ export const SidebarLink = ({
 }) => {
     const { open, animate } = useSidebar();
     const location = useLocation();
-    const isActive = active !== undefined ? active : location.pathname === link.href;
+    const isActive =
+        active !== undefined ? active : isNavActive(link.href, location.pathname);
 
     return (
         <Link
             to={link.href}
             onClick={onClick}
+            aria-current={isActive ? "page" : undefined}
             className={cn(
-                "flex items-center justify-start gap-3 group/sidebar py-3 px-3 rounded-xl transition-all duration-200",
+                "flex items-center justify-start gap-3 group/sidebar py-3 px-3 rounded-xl transition-all duration-200 border-l-2",
                 isActive
-                    ? "bg-indigo-500/10 text-indigo-400 border border-indigo-500/20"
-                    : "text-neutral-400 hover:text-white hover:bg-neutral-800/50",
+                    ? "bg-indigo-500/10 text-indigo-400 border-indigo-400 border border-indigo-500/20"
+                    : "text-neutral-400 hover:text-white hover:bg-neutral-800/50 border-transparent",
                 className
             )}
             {...props}

--- a/frontend/src/lib/nav.js
+++ b/frontend/src/lib/nav.js
@@ -1,0 +1,5 @@
+export function isNavActive(path, pathname) {
+  if (pathname === path) return true;
+  if (path !== "/" && pathname.startsWith(`${path}/`)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
Fixes #106

- Add `isNavActive()` so nested routes (e.g. `/fellowship/...`) keep the parent tab highlighted
- Desktop navbar: accent bottom border on the active tab
- Mobile navbar: left border accent on the active item
- App sidebar: left border accent + `aria-current="page"` for accessibility

## Test plan
- [ ] Visit `/dashboard`, `/jobs`, `/fellowship` — matching nav item is highlighted
- [ ] Open a nested fellowship route — Fellowship tab stays active
- [ ] Check mobile drawer and collapsed sidebar behavior