### PR TITLE
chore(frontend): remove debug console.log from socket client

### DIFF
--- a/frontend/src/services/socket.js
+++ b/frontend/src/services/socket.js
@@ -27,16 +27,8 @@ export const initializeSocket = async () => {
     timeout: 10000
   });
 
-  socket.on('connect', () => {
-    console.log('✅ Socket connected:', socket.id);
-  });
-
   socket.on('connect_error', (error) => {
     console.error('❌ Socket connection error:', error.message);
-  });
-
-  socket.on('disconnect', (reason) => {
-    console.log('🔌 Socket disconnected:', reason);
   });
 
   socket.on('error', (error) => {


### PR DESCRIPTION
## Summary
Fixes #105

Removes leftover `console.log` debug statements from `frontend/src/services/socket.js` (connect/disconnect handlers). Error logging via `console.error` is unchanged.

## Test plan
- [ ] Community chat still connects via socket
- [ ] No connect/disconnect noise in browser console during normal use