### PR TITLE
fix(frontend): action-oriented labels for message and reply buttons

### DIFF
--- a/frontend/src/components/EmptyJobState.jsx
+++ b/frontend/src/components/EmptyJobState.jsx
@@ -10,7 +10,7 @@ const stageMessages = {
   applied: {
     emoji: '✉️',
     headline: 'No applications sent',
-    sub: 'Hit submit on your first application and watch this board come alive.',
+    sub: 'Apply to your first role and watch this board come alive.',
   },
   interviewing: {
     emoji: '🎤',

--- a/frontend/src/components/community/CommentSection.jsx
+++ b/frontend/src/components/community/CommentSection.jsx
@@ -120,12 +120,19 @@ function CommentItem({ comment, currentUser, onReply, onLike, depth = 0 }) {
               <button
                 type="submit"
                 disabled={!replyContent.trim() || isSubmitting}
+                aria-label={isSubmitting ? "Posting reply" : "Post reply"}
                 className="px-3 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isSubmitting ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                    <span className="sr-only">Posting reply</span>
+                  </>
                 ) : (
-                  <Send className="w-4 h-4" />
+                  <>
+                    <Send className="w-4 h-4" aria-hidden="true" />
+                    <span className="sr-only">Post reply</span>
+                  </>
                 )}
               </button>
             </form>

--- a/frontend/src/components/community/MessageInput.jsx
+++ b/frontend/src/components/community/MessageInput.jsx
@@ -265,9 +265,11 @@ export default function MessageInput({ channelId, channelName, onTyping, replyTo
           <button
             type="submit"
             disabled={!content.trim() && attachments.length === 0}
+            aria-label="Send message"
             className="p-2.5 bg-indigo-600 text-white rounded-xl hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
           >
-            <Send className="w-5 h-5" />
+            <Send className="w-5 h-5" aria-hidden="true" />
+            <span className="sr-only">Send message</span>
           </button>
         </div>
       </form>

--- a/frontend/src/pages/fellowship/FellowshipChat.jsx
+++ b/frontend/src/pages/fellowship/FellowshipChat.jsx
@@ -344,12 +344,19 @@ export default function FellowshipChat() {
                     <button
                         type="submit"
                         disabled={!newMessage.trim() || sending}
+                        aria-label={sending ? "Sending message" : "Send message"}
                         className="px-4 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
                     >
                         {sending ? (
-                            <Loader2 className="w-5 h-5 animate-spin" />
+                            <>
+                                <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+                                <span className="sr-only">Sending message</span>
+                            </>
                         ) : (
-                            <Send className="w-5 h-5" />
+                            <>
+                                <Send className="w-5 h-5" aria-hidden="true" />
+                                <span className="sr-only">Send message</span>
+                            </>
                         )}
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
Fixes #107 (remaining icon-only controls)

Most forms already use specific labels (`Create Alert`, `Publish Post`, `Create Channel`, etc.). This PR updates icon-only submit buttons to expose clear action text via `aria-label` / screen-reader labels (`Send message`, `Post reply`) and improves empty-state copy on the applied jobs board.

## Test plan
- [ ] Community channel: send button announces "Send message"
- [ ] Fellowship chat: send button has accessible name
- [ ] Post comments: reply button labeled "Post reply"
- [ ] Applied jobs empty state no longer mentions generic "submit"