### PR TITLE
docs: add cURL and Postman API test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,21 @@ npm run dev
 - Backend API: http://localhost:5000
 - Health Check: http://localhost:5000/health
 
+### Quick API checks (cURL)
+
+With the backend running locally:
+
+```bash
+# Health check (no auth)
+curl -s http://localhost:5000/health | jq
+
+# Authenticated route example (replace TOKEN with a Firebase ID token)
+curl -s -H "Authorization: Bearer TOKEN" \
+  http://localhost:5000/api/auth/verify | jq
+```
+
+In [Postman](https://www.postman.com/), create a GET request to `http://localhost:5000/health`, or set **Authorization → Bearer Token** for protected `/api/*` routes. See [API_DOCS/README.md](./API_DOCS/README.md) for the full route list.
+
 ---
 
 ## 📁 Project Structure


### PR DESCRIPTION
## Summary
Fixes #101

Adds a **Quick API checks (cURL)** subsection under Getting Started with examples for `GET /health` and an authenticated `GET /api/auth/verify` call, plus a Postman pointer to the API docs.

## Test plan
- [ ] Run `curl http://localhost:5000/health` against a local backend