### PR TITLE
fix(job-tracker): validate applyLink is a valid http/https URL on POS…

### DIFF
--- a/backend/src/routes/jobTracker.js
+++ b/backend/src/routes/jobTracker.js
@@ -3,12 +3,21 @@ import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import TrackedJob from '../models/TrackedJob.model.js';
 
+function isValidWebUrl(str) {
+  try {
+    const url = new URL(str);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 const router = express.Router();
 
 // Get all tracked jobs for a user
 router.get('/', verifyToken, asyncHandler(async (req, res) => {
   const userId = req.user.uid;
-  
+
   const userJobs = await TrackedJob.find({ userId })
     .sort({ createdAt: -1 })
     .lean();
@@ -30,7 +39,7 @@ router.get('/', verifyToken, asyncHandler(async (req, res) => {
 // Get tracker stats for a user
 router.get('/stats', verifyToken, asyncHandler(async (req, res) => {
   const userId = req.user.uid;
-  
+
   // Use MongoDB aggregation for efficient stats calculation
   const statsPipeline = [
     { $match: { userId } },
@@ -43,7 +52,7 @@ router.get('/stats', verifyToken, asyncHandler(async (req, res) => {
   ];
 
   const results = await TrackedJob.aggregate(statsPipeline);
-  
+
   // Build stats object
   const stats = {
     total: 0,
@@ -68,10 +77,10 @@ router.get('/stats', verifyToken, asyncHandler(async (req, res) => {
 // Track a new job
 router.post('/', verifyToken, asyncHandler(async (req, res) => {
   const userId = req.user.uid;
-  const { 
+  const {
     jobId,
-    title, 
-    company, 
+    title,
+    company,
     location,
     jobType,
     salary,
@@ -82,6 +91,10 @@ router.post('/', verifyToken, asyncHandler(async (req, res) => {
 
   if (!title || !company) {
     throw new ApiError(400, 'Job title and company are required');
+  }
+
+  if (applyLink && !isValidWebUrl(applyLink)) {
+    throw new ApiError(400, 'applyLink must be a valid URL starting with http:// or https://');
   }
 
   // Check if job already tracked (handled by unique index, but check explicitly for better error message)
@@ -150,11 +163,11 @@ router.put('/:trackerId', verifyToken, asyncHandler(async (req, res) => {
   }
 
   const updateData = {};
-  
+
   if (status) {
     updateData.status = status;
   }
-  
+
   if (notes) {
     updateData.$push = {
       notes: {


### PR DESCRIPTION
Closes #86

Hi, I'm a GSSOC 2026 contributor and I picked up this issue.

The POST /api/job-tracker endpoint was accepting any string for applyLink with no validation, so things like "google.com" or "not a url" would get saved to the database without any error.

What I did:
- Added a small isValidWebUrl() helper using Node's built in URL class, so no new packages needed
- The POST handler now throws a 400 with a clear message if applyLink is provided but isn't a valid http/https URL
- If applyLink is not provided at all it still works fine since the field is optional

Could not test the full server locally since it needs Gemini and other API keys to run, but the validation itself is self contained and doesn't touch anything else in the codebase.

Let me know if anything needs changing, happy to update it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure job apply links contain valid HTTP/HTTPS URLs. Invalid URLs will now be rejected with a 400 error response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->