### PR TITLE
fix(fellowships): sanitize chat message content before save

### DIFF
--- a/backend/src/routes/fellowships.js
+++ b/backend/src/routes/fellowships.js
@@ -7,6 +7,7 @@ import Challenge from '../models/Challenge.model.js';
 import Proposal from '../models/Proposal.model.js';
 import { FellowshipChatRoom, FellowshipMessage } from '../models/FellowshipChat.model.js';
 import { sendProposalApprovalEmail, sendVerificationEmail } from '../services/mailService.js';
+import { sanitizeMessageContent } from '../utils/sanitizeMessage.js';
 
 const router = express.Router();
 
@@ -548,7 +549,8 @@ router.post('/chat/rooms/:roomId/messages', verifyToken, asyncHandler(async (req
     }
 
     const { content } = req.body;
-    if (!content || content.trim().length === 0) {
+    const sanitizedContent = sanitizeMessageContent(content);
+    if (!sanitizedContent) {
         throw new ApiError(400, 'Message content is required');
     }
 
@@ -559,7 +561,7 @@ router.post('/chat/rooms/:roomId/messages', verifyToken, asyncHandler(async (req
         senderId: req.user.uid,
         senderName: req.user.name || 'User',
         senderRole: profile?.role || 'student',
-        content: content.trim()
+        content: sanitizedContent
     });
 
     room.lastMessageAt = new Date();

--- a/backend/src/utils/sanitizeMessage.js
+++ b/backend/src/utils/sanitizeMessage.js
@@ -1,0 +1,13 @@
+/**
+ * Strip HTML/script tags from chat message content before persistence.
+ */
+export function sanitizeMessageContent(content) {
+  if (typeof content !== "string") {
+    return "";
+  }
+
+  return content
+    .replace(/<[^>]*>/g, "")
+    .replace(/javascript:/gi, "")
+    .trim();
+}


### PR DESCRIPTION
## Summary
- Add `sanitizeMessageContent` utility to strip HTML tags from chat payloads
- Apply sanitization in POST `/chat/rooms/:roomId/messages` before persisting

Fixes #122

## Test plan
- [ ] POST message with `<script>alert(1)</script>` stores plain text without tags
- [ ] Empty/whitespace-only content after sanitization returns 400
- [ ] Normal text messages save unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced chat message validation with improved content sanitization to ensure message safety and prevent malicious input in conversations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->