### PR TITLE
feat(api): add unauthenticated GET /api/ping health check

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -72,6 +72,13 @@ app.use(helmet({
   crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' }
 }));
 
+app.get('/api/ping', (req, res) => {
+  res.status(200).json({
+    message: 'Pong!',
+    timestamp: new Date().toISOString(),
+  });
+});
+
 const limiter = rateLimit({
   windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
   max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000, // increased for development


### PR DESCRIPTION
## Summary

Adds `GET /api/ping` returning `Pong!` and an ISO timestamp for external uptime checks. Registered before the `/api/` rate limiter so monitors are not throttled.

Note: `/health` already exists with a richer payload; this satisfies the issue’s `/api/ping` contract.

Closes #90

## Test plan

- [ ] `curl http://localhost:5000/api/ping` → 200 with `message: "Pong!"` and `timestamp`
- [ ] Verify route works without `Authorization` header