### PR TITLE
fix(backend): BullMQ docs, salary caps, and MongoDB 503 handling

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -20,6 +20,7 @@ import interviewRoutes from './routes/interview.js';
 import paymentRoutes from './routes/payments.js';
 
 import { errorHandler } from './middleware/errorHandler.js';
+import { requireDatabase } from './middleware/requireDatabase.js';
 
 import { initializeSocket } from './config/socket.js';
 
@@ -93,6 +94,8 @@ app.get('/health', (req, res) => {
     environment: process.env.NODE_ENV
   });
 });
+
+app.use('/api', requireDatabase);
 
 app.use('/api/auth', authRoutes);
 app.use('/api/upload', uploadRoutes);

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -69,6 +69,20 @@ export const errorHandler = (err, req, res, next) => {
     });
   }
 
+  // MongoDB selection / socket timeouts — respond quickly instead of hanging
+  if (
+    err.name === 'MongoServerSelectionError' ||
+    err.name === 'MongooseServerSelectionError' ||
+    err.name === 'MongoNetworkTimeoutError' ||
+    err.name === 'MongoTimeoutError' ||
+    (typeof err.message === 'string' && err.message.toLowerCase().includes('timed out'))
+  ) {
+    return res.status(503).json({
+      success: false,
+      error: 'Database temporarily unavailable. Please try again shortly.',
+    });
+  }
+
   // Handle validation errors
   if (err.name === 'ValidationError') {
     return res.status(400).json({

--- a/backend/src/middleware/requireDatabase.js
+++ b/backend/src/middleware/requireDatabase.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+/**
+ * Returns 503 when MongoDB is not connected so API handlers do not hang
+ * waiting on a dead socket.
+ */
+export const requireDatabase = (req, res, next) => {
+  if (mongoose.connection.readyState === 1) {
+    return next();
+  }
+
+  return res.status(503).json({
+    success: false,
+    error: 'Database temporarily unavailable. Please try again shortly.',
+  });
+};

--- a/backend/src/models/TrackedJob.model.js
+++ b/backend/src/models/TrackedJob.model.js
@@ -1,5 +1,9 @@
 import mongoose from 'mongoose';
 
+/** Maximum numeric salary represented in a tracked job (prevents overflow / junk). */
+export const MAX_TRACKED_SALARY_VALUE = 999_999_999;
+export const MAX_TRACKED_SALARY_STRING_LENGTH = 64;
+
 const noteSchema = new mongoose.Schema({
     text: {
         type: String,
@@ -41,7 +45,21 @@ const trackedJobSchema = new mongoose.Schema({
     },
     salary: {
         type: String,
-        default: null
+        default: null,
+        maxlength: [
+            MAX_TRACKED_SALARY_STRING_LENGTH,
+            `Salary must be at most ${MAX_TRACKED_SALARY_STRING_LENGTH} characters`,
+        ],
+        validate: {
+            validator(value) {
+                if (value == null || value === '') return true;
+                const digitsOnly = value.replace(/[^\d]/g, '');
+                if (!digitsOnly) return true;
+                const numeric = Number(digitsOnly);
+                return Number.isFinite(numeric) && numeric <= MAX_TRACKED_SALARY_VALUE;
+            },
+            message: `Salary must not exceed ${MAX_TRACKED_SALARY_VALUE.toLocaleString('en-US')}`,
+        },
     },
     applyLink: {
         type: String,

--- a/backend/src/routes/jobTracker.js
+++ b/backend/src/routes/jobTracker.js
@@ -1,9 +1,31 @@
 import express from 'express';
 import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
-import TrackedJob from '../models/TrackedJob.model.js';
+import TrackedJob, {
+  MAX_TRACKED_SALARY_STRING_LENGTH,
+  MAX_TRACKED_SALARY_VALUE,
+} from '../models/TrackedJob.model.js';
 
 const router = express.Router();
+
+const normalizeSalary = (salary) => {
+  if (salary == null || salary === '') return null;
+  const trimmed = String(salary).trim();
+  if (!trimmed) return null;
+
+  const digitsOnly = trimmed.replace(/[^\d]/g, '');
+  if (digitsOnly) {
+    const numeric = Number(digitsOnly);
+    if (!Number.isFinite(numeric) || numeric > MAX_TRACKED_SALARY_VALUE) {
+      throw new ApiError(
+        400,
+        `Salary must not exceed ${MAX_TRACKED_SALARY_VALUE.toLocaleString('en-US')}`,
+      );
+    }
+  }
+
+  return trimmed.slice(0, MAX_TRACKED_SALARY_STRING_LENGTH);
+};
 
 // Get all tracked jobs for a user
 router.get('/', verifyToken, asyncHandler(async (req, res) => {
@@ -84,6 +106,8 @@ router.post('/', verifyToken, asyncHandler(async (req, res) => {
     throw new ApiError(400, 'Job title and company are required');
   }
 
+  const normalizedSalary = normalizeSalary(salary);
+
   // Check if job already tracked (handled by unique index, but check explicitly for better error message)
   const existingJob = jobId
     ? await TrackedJob.findOne({ userId, jobId })
@@ -99,7 +123,7 @@ router.post('/', verifyToken, asyncHandler(async (req, res) => {
     company,
     location: location || 'Remote',
     jobType: jobType || 'Full-time',
-    salary: salary || null,
+    salary: normalizedSalary,
     applyLink: applyLink || null,
     description: description || null,
     status,

--- a/backend/src/services/jobAlertQueue.js
+++ b/backend/src/services/jobAlertQueue.js
@@ -10,12 +10,17 @@ let redisConnection = null;
 let jobAlertQueue = null;
 let redisUrl = null; // Store the URL for creating worker connections
 
-// Rate limiter configuration
+/**
+ * Worker-side pacing for external job-search API calls. BullMQ may run multiple
+ * workers in other deployments; these values keep RapidAPI usage under quota.
+ */
 export const RATE_LIMIT_CONFIG = {
-    maxConcurrent: 1,        // Process one job at a time
-    delayBetweenJobs: 2000,  // 2 seconds between API calls
+    /** BullMQ worker concurrency — one alert fetch at a time per process. */
+    maxConcurrent: 1,
+    /** Stagger between enqueue operations (see addBatchAlertsToQueue). */
+    delayBetweenJobs: 2000,
     maxRequestsPerMinute: 30,
-    maxRequestsPerDay: 500   // Conservative daily limit
+    maxRequestsPerDay: 500,
 };
 
 /**
@@ -93,19 +98,23 @@ export const initializeQueue = async () => {
         jobAlertQueue = new Queue('job-alerts', {
             connection: redisConnection,
             defaultJobOptions: {
+                /** Retry transient Redis/API failures without losing the alert payload. */
                 attempts: 3,
+                /** Exponential backoff: 5s, then 10s, then 20s between retries. */
                 backoff: {
                     type: 'exponential',
-                    delay: 5000
+                    delay: 5000,
                 },
+                /** Trim completed jobs after 24h (max 1000 retained) to bound Redis memory. */
                 removeOnComplete: {
                     age: 24 * 3600,
-                    count: 1000
+                    count: 1000,
                 },
+                /** Keep failed jobs for 7 days for post-mortem / manual replay. */
                 removeOnFail: {
-                    age: 7 * 24 * 3600
-                }
-            }
+                    age: 7 * 24 * 3600,
+                },
+            },
         });
 
         // Queue events for monitoring


### PR DESCRIPTION
## Summary

- **#89:** Document BullMQ `defaultJobOptions` retry/backoff/cleanup and `RATE_LIMIT_CONFIG` pacing in `jobAlertQueue.js`.
- **#91:** Cap tracked-job `salary` at 64 characters and reject numeric values above 999,999,999 at the model and `POST /api/job-tracker` route.
- **#92:** Add `requireDatabase` middleware and map MongoDB timeout/selection errors to **503 Service Unavailable**.

## Test plan

- [ ] `POST /api/job-tracker` with salary `9999999999999` → 400
- [ ] Stop MongoDB, call any `/api/*` route → 503 JSON (not hang)
- [ ] Review `jobAlertQueue.js` comment clarity

Closes #89
Closes #91
Closes #92