### PR TITLE
fix(api): standardize job fetch 400/401 error JSON

### DIFF
--- a/backend/src/controllers/jobFetch.js
+++ b/backend/src/controllers/jobFetch.js
@@ -6,11 +6,14 @@ export const getJobs = async (req, res) => {
   try {
     const user = req.user;
     if (!user) {
-      return res.status(401).json({ message: "Unauthorized" });
+      return res.status(401).json({ success: false, error: "Unauthorized" });
     }
     const { query, jobType, experienceLevel, location } = req.query;
     if (!query) {
-      return res.status(400).json({ message: "Query parameter is required" });
+      return res.status(400).json({
+        success: false,
+        error: "Query parameter is required",
+      });
     }
 
     const querystring = {
@@ -19,33 +22,32 @@ export const getJobs = async (req, res) => {
       ...(experienceLevel && { experience_level: experienceLevel }),
       ...(location && { location: location.trim() || undefined }),
     };
-    
+
     const jobsData = await fetchJobs(querystring);
-    
-    // Check if there was an API error
+
     if (jobsData.error) {
       const statusCode = jobsData.statusCode || 500;
       return res.status(statusCode).json({
         success: false,
-        message: jobsData.error,
+        error: jobsData.error,
         data: [],
-        count: 0
+        count: 0,
       });
     }
-    
+
     const jobs = Array.isArray(jobsData.data) ? jobsData.data : [];
-    
+
     return res.status(200).json({
       success: true,
       message: "Jobs fetched successfully",
       data: jobs,
-      count: jobs.length
+      count: jobs.length,
     });
   } catch (error) {
     console.error("Error fetching jobs:", error);
     return res.status(500).json({
       success: false,
-      message: "Failed to fetch jobs. Please try again later."
+      error: "Failed to fetch jobs. Please try again later.",
     });
   }
 };
@@ -57,28 +59,28 @@ export const getJobById = async (req, res) => {
     if (!mongoose.Types.ObjectId.isValid(jobId)) {
       return res.status(400).json({
         success: false,
-        message: "Invalid jobId format"
+        error: "Invalid jobId format",
       });
     }
-    
+
     const job = await Job.findById(jobId);
-    
+
     if (!job) {
       return res.status(404).json({
         success: false,
-        message: "Job not found"
+        error: "Job not found",
       });
     }
-    
+
     return res.status(200).json({
       success: true,
-      data: job
+      data: job,
     });
   } catch (error) {
     console.error("Error fetching job:", error);
     return res.status(500).json({
-      success: false, 
-      message: "Failed to fetch job details"
+      success: false,
+      error: "Failed to fetch job details",
     });
   }
 };


### PR DESCRIPTION
## Summary

- Align `jobFetch` controller error responses with `{ success: false, error: '...' }`
- Covers missing query (400), unauthorized (401), invalid job id (400), and related failure paths

Closes #87

## Test plan

- [ ] `GET /api/jobs` without `query` → 400 with `{ success: false, error }`
- [ ] Unauthenticated request → 401 with `{ success: false, error: 'Unauthorized' }`
- [ ] Invalid `jobId` → 400 with `{ success: false, error: 'Invalid jobId format' }`