### PR TITLE
[Backend/Frontend] Add email notification preferences settings closes #20

### DIFF
--- a/backend/src/models/User.model.js
+++ b/backend/src/models/User.model.js
@@ -33,6 +33,11 @@ const userSchema = new mongoose.Schema({
     type: [String],
     required: true,
   },
+  notificationPreferences: {
+  jobAlerts: { type: Boolean, default: true },
+  directMessages: { type: Boolean, default: true },
+  proposalUpdates: { type: Boolean, default: true },
+}
 });
 
 const User = mongoose.model('User', userSchema);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -53,10 +53,14 @@ router.put('/notification-preferences', verifyToken, asyncHandler(async (req, re
   const User = (await import('../models/User.model.js')).default;
   const { jobAlerts, directMessages, proposalUpdates } = req.body;
 
+  if (typeof jobAlerts !== 'boolean' || typeof directMessages !== 'boolean' || typeof proposalUpdates !== 'boolean') {
+    return res.status(400).json({ success: false, error: 'Invalid preference values' });
+  }
+
   await User.findOneAndUpdate(
     { email: req.user.email },
     { notificationPreferences: { jobAlerts, directMessages, proposalUpdates } },
-    { upsert: true, new: true }
+    { new: true }
   );
 
   res.json({ success: true, message: 'Preferences updated!' });

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -34,5 +34,32 @@ router.get('/profile', verifyToken, asyncHandler(async (req, res) => {
     user: req.user
   });
 }));
+// Get notification preferences
+router.get('/notification-preferences', verifyToken, asyncHandler(async (req, res) => {
+  const User = (await import('../models/User.model.js')).default;
+  let user = await User.findOne({ email: req.user.email });
+  
+  const preferences = user?.notificationPreferences || {
+    jobAlerts: true,
+    directMessages: true,
+    proposalUpdates: true,
+  };
+
+  res.json({ success: true, preferences });
+}));
+
+// Update notification preferences
+router.put('/notification-preferences', verifyToken, asyncHandler(async (req, res) => {
+  const User = (await import('../models/User.model.js')).default;
+  const { jobAlerts, directMessages, proposalUpdates } = req.body;
+
+  await User.findOneAndUpdate(
+    { email: req.user.email },
+    { notificationPreferences: { jobAlerts, directMessages, proposalUpdates } },
+    { upsert: true, new: true }
+  );
+
+  res.json({ success: true, message: 'Preferences updated!' });
+}));
 
 export default router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import InterviewPrep from './pages/InterviewPrep'
 import FellowshipLayout from './pages/fellowship/FellowshipLayout'
 import Onboarding from './pages/fellowship/Onboarding'
 import Challenges from './pages/fellowship/Challenges'
+import Settings from './pages/Settings'
 import ChallengeDetail from './pages/fellowship/ChallengeDetail'
 import CreateChallenge from './pages/fellowship/CreateChallenge'
 import MyProposals from './pages/fellowship/MyProposals'
@@ -113,7 +114,7 @@ function App() {
             <Route path="/job-tracker" element={<ProtectedRoute><JobTracker /></ProtectedRoute>} />
             <Route path="/community" element={<ProtectedRoute><Community /></ProtectedRoute>} />
             <Route path="/interview-prep" element={<ProtectedRoute><InterviewPrep /></ProtectedRoute>} />
-
+            <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
             <Route path="/fellowship" element={<ProtectedRoute><FellowshipLayout /></ProtectedRoute>}>
               <Route index element={<Challenges />} />
               <Route path="onboarding" element={<Onboarding />} />

--- a/frontend/src/components/AppSidebar.jsx
+++ b/frontend/src/components/AppSidebar.jsx
@@ -59,6 +59,11 @@ const navLinks = [
         href: "/upload",
         icon: <FileText className="w-5 h-5 flex-shrink-0" />,
     },
+     {
+        label: "Settings",
+        href: "/settings",
+        icon: <Settings className="w-5 h-5 flex-shrink-0" />,
+    },
 ];
 
 function Logo() {

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -41,8 +41,10 @@ export default function Settings() {
     }
   }
 
-  const Toggle = ({ value, onChange }) => (
+const Toggle = ({ value, onChange }) => (
     <button
+      role="switch"
+      aria-checked={value}
       onClick={() => onChange(!value)}
       className={`relative w-12 h-6 rounded-full transition-colors cursor-pointer ${
         value ? 'bg-indigo-500' : 'bg-neutral-700'

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import { Bell, Mail, MessageSquare, FileText, Save } from 'lucide-react'
+import { notificationApi } from '../services/api'
+import Button from '../components/Button'
+import toast from 'react-hot-toast'
+
+export default function Settings() {
+  const [preferences, setPreferences] = useState({
+    jobAlerts: true,
+    directMessages: true,
+    proposalUpdates: true,
+  })
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    loadPreferences()
+  }, [])
+
+  const loadPreferences = async () => {
+    try {
+      const data = await notificationApi.getPreferences()
+      setPreferences(data.preferences)
+    } catch (error) {
+      toast.error('Failed to load preferences')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      await notificationApi.updatePreferences(preferences)
+      toast.success('Preferences saved!')
+    } catch (error) {
+      toast.error('Failed to save preferences')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const Toggle = ({ value, onChange }) => (
+    <button
+      onClick={() => onChange(!value)}
+      className={`relative w-12 h-6 rounded-full transition-colors cursor-pointer ${
+        value ? 'bg-indigo-500' : 'bg-neutral-700'
+      }`}
+    >
+      <span className={`absolute top-1 w-4 h-4 bg-white rounded-full transition-all ${
+        value ? 'left-7' : 'left-1'
+      }`} />
+    </button>
+  )
+
+  if (loading) return (
+    <div className="flex items-center justify-center min-h-screen bg-black">
+      <p className="text-neutral-400">Loading...</p>
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-black">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
+          <h1 className="text-3xl font-bold text-white mb-2">Settings</h1>
+          <p className="text-neutral-400 mb-8">Manage your email notification preferences</p>
+
+          <div className="p-6 rounded-2xl bg-neutral-900/50 border border-neutral-800 space-y-6">
+            <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+              <Bell className="w-5 h-5 text-indigo-400" />
+              Email Notifications
+            </h2>
+
+            {/* Job Alerts */}
+            <div className="flex items-center justify-between py-4 border-b border-neutral-800">
+              <div className="flex items-center gap-3">
+                <Mail className="w-5 h-5 text-indigo-400" />
+                <div>
+                  <p className="text-white font-medium">Job Alerts</p>
+                  <p className="text-neutral-400 text-sm">Get notified when new jobs match your alerts</p>
+                </div>
+              </div>
+              <Toggle
+                value={preferences.jobAlerts}
+                onChange={(val) => setPreferences({ ...preferences, jobAlerts: val })}
+              />
+            </div>
+
+            {/* Direct Messages */}
+            <div className="flex items-center justify-between py-4 border-b border-neutral-800">
+              <div className="flex items-center gap-3">
+                <MessageSquare className="w-5 h-5 text-purple-400" />
+                <div>
+                  <p className="text-white font-medium">Direct Messages</p>
+                  <p className="text-neutral-400 text-sm">Get notified when you receive a DM</p>
+                </div>
+              </div>
+              <Toggle
+                value={preferences.directMessages}
+                onChange={(val) => setPreferences({ ...preferences, directMessages: val })}
+              />
+            </div>
+
+            {/* Proposal Updates */}
+            <div className="flex items-center justify-between py-4">
+              <div className="flex items-center gap-3">
+                <FileText className="w-5 h-5 text-green-400" />
+                <div>
+                  <p className="text-white font-medium">Proposal Updates</p>
+                  <p className="text-neutral-400 text-sm">Get notified on fellowship proposal changes</p>
+                </div>
+              </div>
+              <Toggle
+                value={preferences.proposalUpdates}
+                onChange={(val) => setPreferences({ ...preferences, proposalUpdates: val })}
+              />
+            </div>
+
+            <Button
+              onClick={handleSave}
+              loading={saving}
+              variant="gradient"
+              className="w-full flex items-center justify-center gap-2"
+            >
+              <Save className="w-4 h-4" />
+              Save Preferences
+            </Button>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -864,4 +864,26 @@ export const paymentApi = {
     })
     return handleResponse(response)
   }
+  
+}
+// ============ NOTIFICATION PREFERENCES API ============
+export const notificationApi = {
+  async getPreferences() {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/auth/notification-preferences`, {
+      method: 'GET',
+      headers
+    })
+    return handleResponse(response)
+  },
+
+  async updatePreferences(preferences) {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/auth/notification-preferences`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(preferences)
+    })
+    return handleResponse(response)
+  }
 }


### PR DESCRIPTION
Closes #20

Changes made:
- Added notificationPreferences field to User model (jobAlerts, directMessages, proposalUpdates)
- Added GET /auth/notification-preferences API route
- Added PUT /auth/notification-preferences API route
- Added notificationApi to frontend services/api.js
- Created new Settings page with toggle switches for each preference
- Added Settings route to App.jsx
- Added Settings link to AppSidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Settings page to manage notification preferences.
  * Users can independently toggle Job Alerts, Direct Messages, and Proposal Updates (defaults ON).
  * Preferences persist per account and are retrievable on load.
  * Settings reachable from the main navigation sidebar.
  * UI shows loading state on fetch and a save button with success/error feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->