### PR TITLE
fix: change job alert cron schedule to every 2 days (#446)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The **AI Resume Builder & Career Platform** is a comprehensive full-stack applic
 - **Employment Type Selection**: Full-time, Part-time, Contract, Internship
 - **Email Notifications**: Receive new job matches directly in your inbox
 - **Real-time Socket Updates**: Instant in-app notifications when new jobs match
+> **Note:** Job alerts run every 2 days (`0 0 */2 * *`) to reduce API costs.
 
 ### 📊 Job Application Tracker
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The **AI Resume Builder & Career Platform** is a comprehensive full-stack applic
 - **Employment Type Selection**: Full-time, Part-time, Contract, Internship
 - **Email Notifications**: Receive new job matches directly in your inbox
 - **Real-time Socket Updates**: Instant in-app notifications when new jobs match
-> **Note:** Job alerts run every 2 days (`0 0 */2 * *`) to reduce API costs.
+> **Note:** By default, job alerts use the cron schedule `0 0 */2 * *` to reduce API costs. This means they run at midnight on every other day of the month (a day-of-month step), not on a strict 48-hour interval, so behavior can differ around month boundaries. You can override this schedule with the `ALERT_CRON_SCHEDULE` environment variable.
 
 ### 📊 Job Application Tracker
 

--- a/backend/src/services/jobFetcher.js
+++ b/backend/src/services/jobFetcher.js
@@ -477,7 +477,7 @@ export const scheduleAlertChecks = () => {
 
     // PRODUCTION MODE: Run every 24 hours at midnight (0 0 * * *)
     // Custom schedule can be set via ALERT_CRON_SCHEDULE env var
-    const schedule = process.env.ALERT_CRON_SCHEDULE || '0 0 * * *';
+    const schedule = process.env.ALERT_CRON_SCHEDULE || '0 0 */2 * *'; // Default: every 2 days at midnight
     
     console.log(`🏭 PRODUCTION MODE: Job alerts scheduled with cron: ${schedule} (runs every 24 hours)`);
 


### PR DESCRIPTION
Fixes #446

Changes:
- Updated cron in jobFetcher.js L480 from `0 0 * * *` to `0 0 */2 * *`
- Updated README with new cron schedule docs

Reason: Reduces RapidAPI calls by 50% to cut API costs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect job alerts now run every 2 days instead of daily.

* **Updates**
  * Adjusted job alert scheduling frequency to every 2 days to optimize resource usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->