### PR TITLE
feat(community): add post scheduling for later publishing

### DIFF
--- a/backend/src/controllers/communityFirebaseController.js
+++ b/backend/src/controllers/communityFirebaseController.js
@@ -3,6 +3,7 @@ import { presenceService } from '../services/presenceService.js';
 import { getIO } from '../config/socket.js';
 import { ApiError } from '../middleware/errorHandler.js';
 import { FieldValue } from 'firebase-admin/firestore';
+import { schedulePostJob, cancelPostJob, isSchedulerAvailable } from '../services/postScheduler.js';
 
 // Collection references
 const channelsRef = db.collection('channels');
@@ -295,16 +296,19 @@ export const getPosts = async (req, res, next) => {
 
     const snapshot = await query.get();
 
-    const posts = snapshot.docs.map(doc => {
-      const data = doc.data();
-      const likes = data.likes || [];
-      return {
-        id: doc.id,
-        ...data,
-        likeCount: likes.length,
-        createdAt: data.createdAt?.toDate?.() || data.createdAt
-      };
-    });
+    const posts = snapshot.docs
+      .map(doc => {
+        const data = doc.data();
+        const likes = data.likes || [];
+        return {
+          id: doc.id,
+          ...data,
+          likeCount: likes.length,
+          createdAt: data.createdAt?.toDate?.() || data.createdAt
+        };
+      })
+      // Exclude posts that are still waiting for their scheduled publish time
+      .filter(post => !post.status || post.status === 'published');
 
     res.json({
       success: true,
@@ -354,10 +358,19 @@ export const getPost = async (req, res, next) => {
   }
 };
 
-// Create post
+// Create post (supports optional scheduledAt for deferred publishing)
 export const createPost = async (req, res, next) => {
   try {
-    const { title, content, tags = [], category = 'discussion', attachments = [] } = req.body;
+    const { title, content, tags = [], category = 'discussion', attachments = [], scheduledAt } = req.body;
+
+    const isScheduled = Boolean(scheduledAt);
+
+    if (isScheduled) {
+      const scheduleDate = new Date(scheduledAt);
+      if (isNaN(scheduleDate.getTime()) || scheduleDate.getTime() <= Date.now()) {
+        throw new ApiError(400, 'scheduledAt must be a valid future datetime');
+      }
+    }
 
     const postData = {
       title,
@@ -380,22 +393,94 @@ export const createPost = async (req, res, next) => {
       isAnnouncement: false,
       isEdited: false,
       isDeleted: false,
+      status: isScheduled ? 'scheduled' : 'published',
+      ...(isScheduled && { scheduledAt: new Date(scheduledAt).toISOString() }),
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp()
     };
 
     const docRef = await postsRef.add(postData);
-    const newPost = { id: docRef.id, ...postData, createdAt: new Date(), updatedAt: new Date() };
+    const newPost = {
+      id: docRef.id,
+      ...postData,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
 
-    // Notify subscribers
-    try {
-      const io = getIO();
-      io.to('posts:feed').emit('new_post', { post: newPost });
-    } catch (e) {
-      // Socket might not be initialized
+    if (isScheduled) {
+      const jobId = await schedulePostJob(docRef.id, scheduledAt);
+      if (!jobId && !isSchedulerAvailable()) {
+        // Redis unavailable — immediately publish instead of silently dropping
+        await postsRef.doc(docRef.id).update({ status: 'published', scheduledAt: null });
+        newPost.status = 'published';
+        newPost.scheduledAt = null;
+      }
+    } else {
+      // Notify feed subscribers for instant-publish posts
+      try {
+        const io = getIO();
+        io.to('posts:feed').emit('new_post', { post: newPost });
+      } catch {
+        // Socket might not be initialized
+      }
     }
 
     res.status(201).json({ success: true, post: newPost });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Get current user's scheduled posts
+export const getScheduledPosts = async (req, res, next) => {
+  try {
+    const snapshot = await postsRef
+      .where('author.uid', '==', req.user.uid)
+      .where('status', '==', 'scheduled')
+      .where('isDeleted', '==', false)
+      .orderBy('scheduledAt', 'asc')
+      .get();
+
+    const posts = snapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data(),
+      createdAt: doc.data().createdAt?.toDate?.() || doc.data().createdAt
+    }));
+
+    res.json({ success: true, posts });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Cancel a scheduled post — reverts to draft and removes the queue job
+export const cancelScheduledPost = async (req, res, next) => {
+  try {
+    const doc = await postsRef.doc(req.params.postId).get();
+
+    if (!doc.exists) {
+      throw new ApiError(404, 'Post not found');
+    }
+
+    const post = doc.data();
+
+    if (post.author.uid !== req.user.uid) {
+      throw new ApiError(403, 'Not authorized to modify this post');
+    }
+
+    if (post.status !== 'scheduled') {
+      throw new ApiError(400, 'Post is not in scheduled state');
+    }
+
+    await cancelPostJob(req.params.postId);
+
+    await postsRef.doc(req.params.postId).update({
+      status: 'draft',
+      scheduledAt: null,
+      updatedAt: FieldValue.serverTimestamp()
+    });
+
+    res.json({ success: true, message: 'Scheduled post cancelled and reverted to draft' });
   } catch (error) {
     next(error);
   }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -24,6 +24,7 @@ import { errorHandler } from './middleware/errorHandler.js';
 import { initializeSocket } from './config/socket.js';
 
 import { initializeDefaultChannels } from './controllers/communityFirebaseController.js';
+import { initializePostScheduler } from './services/postScheduler.js';
 
 import mongoose from 'mongoose';
 import { initJobFetcher } from './services/jobFetcher.js';
@@ -133,6 +134,12 @@ const startServer = async () => {
       console.log('💬 Community channels initialized');
     } catch (channelError) {
       console.warn('⚠️ Could not initialize default channels:', channelError.message);
+    }
+
+    try {
+      await initializePostScheduler();
+    } catch (schedulerError) {
+      console.warn('⚠️ Post scheduler initialization skipped:', schedulerError.message);
     }
 
     const allowDevDbMutations = process.env.ALLOW_DEV_DB_MUTATIONS === 'true';

--- a/backend/src/routes/community.js
+++ b/backend/src/routes/community.js
@@ -15,6 +15,9 @@ import {
   updatePost,
   deletePost,
   toggleLikePost,
+  // Post scheduling
+  getScheduledPosts,
+  cancelScheduledPost,
   // Comments
   getComments,
   createComment,
@@ -45,11 +48,13 @@ router.get('/channels/:channelId/messages', getChannelMessages);
 
 // ============ POST ROUTES ============
 router.get('/posts', getPosts);
+router.get('/posts/scheduled/mine', getScheduledPosts);
 router.get('/posts/:postId', getPost);
 router.post('/posts', createPost);
 router.put('/posts/:postId', updatePost);
 router.delete('/posts/:postId', deletePost);
 router.post('/posts/:postId/like', toggleLikePost);
+router.delete('/posts/:postId/schedule', cancelScheduledPost);
 
 // ============ COMMENT ROUTES ============
 router.get('/posts/:postId/comments', getComments);

--- a/backend/src/services/postScheduler.js
+++ b/backend/src/services/postScheduler.js
@@ -1,0 +1,179 @@
+import { Queue, Worker } from 'bullmq';
+import IORedis from 'ioredis';
+import dotenv from 'dotenv';
+import { db } from '../config/firebase.js';
+import { FieldValue } from 'firebase-admin/firestore';
+import { getIO } from '../config/socket.js';
+
+dotenv.config();
+
+let redisAvailable = false;
+let redisConnection = null;
+let postSchedulerQueue = null;
+let redisUrl = null;
+
+const QUEUE_NAME = 'post-scheduler';
+const postsRef = db.collection('posts');
+
+const createWorkerConnection = () => {
+    if (!redisUrl) return null;
+    return new IORedis(redisUrl, {
+        maxRetriesPerRequest: null,
+        enableReadyCheck: false,
+        retryStrategy: (times) => {
+            if (times > 3) return null;
+            return Math.min(times * 200, 1000);
+        }
+    });
+};
+
+/**
+ * Initialize the post scheduler queue and worker.
+ * Gracefully no-ops if REDIS_URL is not configured.
+ */
+export const initializePostScheduler = async () => {
+    redisUrl = process.env.REDIS_URL;
+
+    if (!redisUrl) {
+        console.log('ℹ️  REDIS_URL not configured - post scheduler disabled');
+        return false;
+    }
+
+    try {
+        redisConnection = new IORedis(redisUrl, {
+            maxRetriesPerRequest: null,
+            enableReadyCheck: false,
+            retryStrategy: (times) => {
+                if (times > 3) return null;
+                return Math.min(times * 200, 1000);
+            }
+        });
+
+        await new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Redis connection timeout')), 5000);
+            redisConnection.once('ready', () => { clearTimeout(timeout); resolve(); });
+            redisConnection.once('error', (err) => { clearTimeout(timeout); reject(err); });
+        });
+
+        postSchedulerQueue = new Queue(QUEUE_NAME, {
+            connection: redisConnection,
+            defaultJobOptions: {
+                attempts: 3,
+                backoff: { type: 'exponential', delay: 5000 },
+                removeOnComplete: { age: 7 * 24 * 3600, count: 500 },
+                removeOnFail: { age: 30 * 24 * 3600 }
+            }
+        });
+
+        postSchedulerQueue.on('error', (err) => {
+            console.error('❌ Post scheduler queue error:', err.message);
+        });
+
+        const workerConnection = createWorkerConnection();
+        if (workerConnection) {
+            const worker = new Worker(
+                QUEUE_NAME,
+                async (job) => {
+                    const { postId } = job.data;
+                    const postRef = postsRef.doc(postId);
+                    const doc = await postRef.get();
+
+                    if (!doc.exists) {
+                        console.warn(`⚠️  Scheduled post ${postId} not found, skipping`);
+                        return;
+                    }
+
+                    const post = doc.data();
+
+                    // Guard: only publish if still in scheduled state
+                    if (post.status !== 'scheduled') {
+                        console.log(`ℹ️  Post ${postId} status is "${post.status}", skipping publish`);
+                        return;
+                    }
+
+                    await postRef.update({
+                        status: 'published',
+                        publishedAt: FieldValue.serverTimestamp(),
+                        updatedAt: FieldValue.serverTimestamp()
+                    });
+
+                    try {
+                        const io = getIO();
+                        io.to('posts:feed').emit('new_post', {
+                            post: {
+                                id: postId,
+                                ...post,
+                                status: 'published',
+                                publishedAt: new Date()
+                            }
+                        });
+                    } catch {
+                        // socket may not be initialized
+                    }
+
+                    console.log(`✅ Scheduled post ${postId} published`);
+                },
+                { connection: workerConnection }
+            );
+
+            worker.on('completed', (job) => {
+                console.log(`✅ Post scheduler job ${job.id} completed`);
+            });
+            worker.on('failed', (job, err) => {
+                console.error(`❌ Post scheduler job ${job?.id} failed: ${err.message}`);
+            });
+        }
+
+        redisAvailable = true;
+        console.log('✅ Post scheduler initialized');
+        return true;
+    } catch (err) {
+        console.warn('⚠️ Post scheduler could not connect to Redis:', err.message);
+        redisAvailable = false;
+        return false;
+    }
+};
+
+/**
+ * Enqueue a delayed publish job for a post.
+ * Uses the postId as a stable jobId so it can be retrieved and removed later.
+ */
+export const schedulePostJob = async (postId, scheduledAt) => {
+    if (!redisAvailable || !postSchedulerQueue) {
+        return null;
+    }
+
+    const delay = new Date(scheduledAt).getTime() - Date.now();
+    if (delay <= 0) {
+        throw new Error('Scheduled time must be in the future');
+    }
+
+    const job = await postSchedulerQueue.add(
+        'publish-post',
+        { postId },
+        { delay, jobId: `post:${postId}` }
+    );
+    return job.id;
+};
+
+/**
+ * Remove a scheduled post job from the queue.
+ * Returns true if the job was found and removed, false otherwise.
+ */
+export const cancelPostJob = async (postId) => {
+    if (!redisAvailable || !postSchedulerQueue) return false;
+
+    try {
+        const job = await postSchedulerQueue.getJob(`post:${postId}`);
+        if (job) {
+            await job.remove();
+            return true;
+        }
+        return false;
+    } catch (err) {
+        console.warn(`⚠️ Could not cancel post job for ${postId}: ${err.message}`);
+        return false;
+    }
+};
+
+export const isSchedulerAvailable = () => redisAvailable;

--- a/frontend/src/components/community/PostCard.jsx
+++ b/frontend/src/components/community/PostCard.jsx
@@ -1,19 +1,21 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { formatDistanceToNow } from 'date-fns';
-import { 
-  Heart, 
-  MessageCircle, 
-  Share2, 
-  Bookmark, 
+import { formatDistanceToNow, format } from 'date-fns';
+import {
+  Heart,
+  MessageCircle,
+  Share2,
+  Bookmark,
   Eye,
   ChevronDown,
-  ChevronUp
+  ChevronUp,
+  Clock,
+  X
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import CommentSection from './CommentSection';
 
-export default function PostCard({ post, currentUser, onLike, onCommentAdded }) {
+export default function PostCard({ post, currentUser, onLike, onCommentAdded, onCancelSchedule }) {
   const [showFullContent, setShowFullContent] = useState(false);
   const [showComments, setShowComments] = useState(false);
   const [commentCount, setCommentCount] = useState(post.commentCount || 0);
@@ -125,7 +127,37 @@ export default function PostCard({ post, currentUser, onLike, onCommentAdded }) 
               📌 Pinned
             </span>
           )}
+          {post.status === 'scheduled' && post.scheduledAt && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-sky-500/20 text-sky-400">
+              <Clock className="w-3 h-3" />
+              Scheduled · {format(new Date(post.scheduledAt), 'MMM d, h:mm a')}
+            </span>
+          )}
+          {post.status === 'draft' && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-600/40 text-neutral-400">
+              Draft
+            </span>
+          )}
         </div>
+
+        {/* Cancel schedule banner — only visible to the post author */}
+        {post.status === 'scheduled' && isOwn && onCancelSchedule && (
+          <div className="mt-2 flex items-center justify-between px-3 py-2 bg-sky-500/10 border border-sky-500/20 rounded-lg">
+            <p className="text-xs text-sky-400">
+              This post will publish automatically on{' '}
+              <span className="font-medium">
+                {format(new Date(post.scheduledAt), "MMM d, yyyy 'at' h:mm a")}
+              </span>
+            </p>
+            <button
+              onClick={() => onCancelSchedule(post.id || post._id)}
+              className="flex items-center gap-1 text-xs text-neutral-400 hover:text-red-400 ml-3 flex-shrink-0 transition-colors"
+            >
+              <X className="w-3.5 h-3.5" />
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Content */}

--- a/frontend/src/components/community/PostEditor.jsx
+++ b/frontend/src/components/community/PostEditor.jsx
@@ -222,7 +222,7 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 border border-neutral-700 rounded-lg text-neutral-300 hover:bg-neutral-800 text-sm"
+                className="px-4 py-2 border border-border rounded-lg text-foreground hover:bg-muted text-sm"
               >
                 Cancel
               </button>
@@ -247,11 +247,11 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
               <button
                 type="submit"
                 disabled={loading || !title.trim() || !content.trim()}
-                className="flex items-center gap-2 px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+                className="flex items-center gap-2 px-5 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
               >
                 {loading ? (
                   <>
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                    <div className="w-4 h-4 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin" />
                     {scheduledAt ? 'Scheduling...' : 'Publishing...'}
                   </>
                 ) : (

--- a/frontend/src/components/community/PostEditor.jsx
+++ b/frontend/src/components/community/PostEditor.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
-import { X, Image as ImageIcon, Link, Hash, Send } from 'lucide-react';
+import { X, Image as ImageIcon, Link, Hash, Send, Clock } from 'lucide-react';
+import { format } from 'date-fns';
+import SchedulePost from './SchedulePost';
 
 const CATEGORIES = [
   { value: 'discussion', label: '💬 Discussion' },
@@ -18,24 +20,24 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
   const [tags, setTags] = useState(editPost?.tags?.join(', ') || '');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [showScheduler, setShowScheduler] = useState(false);
+  const [scheduledAt, setScheduledAt] = useState(null);
+
+  const buildPostData = () => ({
+    title: title.trim(),
+    content: content.trim(),
+    category,
+    tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+    ...(scheduledAt && { scheduledAt })
+  });
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
     if (!title.trim() || !content.trim()) return;
-
     setLoading(true);
     setError('');
-    
-    const postData = {
-      title: title.trim(),
-      content: content.trim(),
-      category,
-      tags: tags.split(',').map(t => t.trim()).filter(Boolean)
-    };
-
     try {
-      await onSubmit(postData);
+      await onSubmit(buildPostData());
     } catch (err) {
       console.error('Failed to submit post:', err);
       setError(err.message || 'Failed to submit post');
@@ -43,6 +45,13 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
       setLoading(false);
     }
   };
+
+  const handleScheduleConfirm = (isoString) => {
+    setScheduledAt(isoString);
+    setShowScheduler(false);
+  };
+
+  const clearSchedule = () => setScheduledAt(null);
 
   return (
     <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
@@ -168,6 +177,28 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
             </div>
           )}
 
+          {/* Scheduled time indicator */}
+          {scheduledAt && (
+            <div className="mx-6 mb-3 flex items-center justify-between px-3 py-2 bg-indigo-500/10 border border-indigo-500/30 rounded-lg">
+              <div className="flex items-center gap-2 text-sm text-indigo-300">
+                <Clock className="w-4 h-4 flex-shrink-0" />
+                <span>
+                  Scheduled for{' '}
+                  <span className="font-medium">
+                    {format(new Date(scheduledAt), "MMM d, yyyy 'at' h:mm a")}
+                  </span>
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={clearSchedule}
+                className="text-xs text-neutral-500 hover:text-white ml-3"
+              >
+                Remove
+              </button>
+            </div>
+          )}
+
           {/* Footer */}
           <div className="px-6 py-4 border-t border-neutral-800 bg-neutral-900 flex items-center justify-between">
             <div className="flex gap-2">
@@ -187,28 +218,46 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
               </button>
             </div>
 
-            <div className="flex gap-3">
+            <div className="flex gap-2">
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 border border-neutral-700 rounded-lg text-neutral-300 hover:bg-neutral-800"
+                className="px-4 py-2 border border-neutral-700 rounded-lg text-neutral-300 hover:bg-neutral-800 text-sm"
               >
                 Cancel
               </button>
+              {!editPost && (
+                <button
+                  type="button"
+                  onClick={() => setShowScheduler(true)}
+                  disabled={loading || !title.trim() || !content.trim()}
+                  className={`
+                    flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border transition-colors
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                    ${scheduledAt
+                      ? 'bg-indigo-500/20 border-indigo-500 text-indigo-300 hover:bg-indigo-500/30'
+                      : 'border-neutral-600 text-neutral-300 hover:bg-neutral-800'
+                    }
+                  `}
+                >
+                  <Clock className="w-4 h-4" />
+                  {scheduledAt ? 'Change time' : 'Schedule'}
+                </button>
+              )}
               <button
                 type="submit"
                 disabled={loading || !title.trim() || !content.trim()}
-                className="flex items-center gap-2 px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 px-5 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
               >
                 {loading ? (
                   <>
                     <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                    Publishing...
+                    {scheduledAt ? 'Scheduling...' : 'Publishing...'}
                   </>
                 ) : (
                   <>
-                    <Send className="w-4 h-4" />
-                    {editPost ? 'Update Post' : 'Publish Post'}
+                    {scheduledAt ? <Clock className="w-4 h-4" /> : <Send className="w-4 h-4" />}
+                    {editPost ? 'Update Post' : scheduledAt ? 'Confirm Schedule' : 'Publish Post'}
                   </>
                 )}
               </button>
@@ -216,6 +265,13 @@ export default function PostEditor({ onClose, onSubmit, editPost = null }) {
           </div>
         </form>
       </div>
+
+      {showScheduler && (
+        <SchedulePost
+          onClose={() => setShowScheduler(false)}
+          onSchedule={handleScheduleConfirm}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/community/PostsFeed.jsx
+++ b/frontend/src/components/community/PostsFeed.jsx
@@ -4,14 +4,16 @@ import { useSocket } from '../../context/SocketContext';
 import { communityApi } from '../../services/api';
 import PostCard from './PostCard';
 import PostEditor from './PostEditor';
-import { 
-  Plus, 
-  TrendingUp, 
-  Clock, 
+import {
+  Plus,
+  TrendingUp,
+  Clock,
   Heart,
   Filter,
   Search,
-  X
+  X,
+  ChevronDown,
+  ChevronUp
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 
@@ -31,6 +33,8 @@ export default function PostsFeed() {
   const { subscribe, subscribePosts, unsubscribePosts } = useSocket();
   
   const [posts, setPosts] = useState([]);
+  const [scheduledPosts, setScheduledPosts] = useState([]);
+  const [showScheduled, setShowScheduled] = useState(true);
   const [loading, setLoading] = useState(true);
   const [showEditor, setShowEditor] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState('all');
@@ -43,6 +47,11 @@ export default function PostsFeed() {
   useEffect(() => {
     fetchPosts();
   }, [selectedCategory, sortBy]);
+
+  // Fetch current user's scheduled posts on mount
+  useEffect(() => {
+    fetchScheduledPosts();
+  }, []);
 
   // Subscribe to real-time updates
   useEffect(() => {
@@ -118,14 +127,41 @@ export default function PostsFeed() {
     }
   };
 
+  const fetchScheduledPosts = async () => {
+    try {
+      const data = await communityApi.getScheduledPosts();
+      setScheduledPosts(data.posts || []);
+    } catch {
+      // Silently ignore — not critical
+    }
+  };
+
   const handleCreatePost = async (postData) => {
     try {
       const data = await communityApi.createPost(postData);
-      setPosts(prev => [data.post, ...prev]);
-      setShowEditor(false);
-      toast.success('Post created successfully!');
+      if (data.post.status === 'scheduled') {
+        setScheduledPosts(prev => [data.post, ...prev].sort(
+          (a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt)
+        ));
+        setShowEditor(false);
+        toast.success('Post scheduled successfully!');
+      } else {
+        setPosts(prev => [data.post, ...prev]);
+        setShowEditor(false);
+        toast.success('Post created successfully!');
+      }
     } catch (error) {
       toast.error(error.message);
+    }
+  };
+
+  const handleCancelScheduled = async (postId) => {
+    try {
+      await communityApi.cancelScheduledPost(postId);
+      setScheduledPosts(prev => prev.filter(p => (p.id || p._id) !== postId));
+      toast.success('Scheduled post cancelled');
+    } catch (error) {
+      toast.error(error.message || 'Failed to cancel scheduled post');
     }
   };
 
@@ -300,6 +336,41 @@ export default function PostsFeed() {
       {/* Posts List */}
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-3xl mx-auto space-y-4">
+          {/* Scheduled posts section — only shown to the post author */}
+          {scheduledPosts.length > 0 && (
+            <div className="border border-sky-500/20 rounded-xl overflow-hidden">
+              <button
+                onClick={() => setShowScheduled(prev => !prev)}
+                className="w-full flex items-center justify-between px-4 py-3 bg-sky-500/10 hover:bg-sky-500/15 transition-colors"
+              >
+                <div className="flex items-center gap-2 text-sky-400 text-sm font-medium">
+                  <Clock className="w-4 h-4" />
+                  Scheduled Posts ({scheduledPosts.length})
+                </div>
+                {showScheduled
+                  ? <ChevronUp className="w-4 h-4 text-sky-400" />
+                  : <ChevronDown className="w-4 h-4 text-sky-400" />
+                }
+              </button>
+              {showScheduled && (
+                <div className="divide-y divide-neutral-800/50 bg-neutral-900/50">
+                  {scheduledPosts.map(post => {
+                    const postId = post.id || post._id;
+                    return (
+                      <PostCard
+                        key={postId}
+                        post={post}
+                        currentUser={user}
+                        onLike={() => {}}
+                        onCancelSchedule={handleCancelScheduled}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
           {loading ? (
             [...Array(3)].map((_, i) => (
               <div key={i} className="bg-neutral-800 border border-neutral-700 rounded-xl p-6 animate-pulse">
@@ -328,6 +399,7 @@ export default function PostsFeed() {
                     currentUser={user}
                     onLike={handleLikePost}
                     onDelete={handleDeletePost}
+                    onCancelSchedule={handleCancelScheduled}
                     onCommentAdded={() => {
                       // Update comment count in local state
                       setPosts(prev => prev.map(p => {

--- a/frontend/src/components/community/SchedulePost.jsx
+++ b/frontend/src/components/community/SchedulePost.jsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import { X, Clock, Calendar, AlertCircle } from 'lucide-react';
+import { format, addMinutes } from 'date-fns';
+
+/**
+ * Modal for picking a future date/time to schedule a community post.
+ * Calls onSchedule(isoString) when the user confirms.
+ */
+export default function SchedulePost({ onClose, onSchedule }) {
+  // Default to 1 hour from now, rounded to the next 15-minute mark
+  const getDefaultTime = () => {
+    const now = new Date();
+    const oneHourLater = addMinutes(now, 60);
+    const minutes = oneHourLater.getMinutes();
+    const roundedMinutes = Math.ceil(minutes / 15) * 15;
+    oneHourLater.setMinutes(roundedMinutes, 0, 0);
+    return oneHourLater;
+  };
+
+  const defaultTime = getDefaultTime();
+
+  // datetime-local input requires "YYYY-MM-DDTHH:mm" format
+  const toInputValue = (date) => format(date, "yyyy-MM-dd'T'HH:mm");
+
+  // Minimum allowed time: 5 minutes from now
+  const minTime = toInputValue(addMinutes(new Date(), 5));
+
+  const [value, setValue] = useState(toInputValue(defaultTime));
+  const [error, setError] = useState('');
+
+  const handleConfirm = () => {
+    const chosen = new Date(value);
+
+    if (isNaN(chosen.getTime())) {
+      setError('Please enter a valid date and time.');
+      return;
+    }
+
+    if (chosen.getTime() <= Date.now() + 4 * 60 * 1000) {
+      setError('Please schedule at least 5 minutes into the future.');
+      return;
+    }
+
+    onSchedule(chosen.toISOString());
+  };
+
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const formattedPreview = value
+    ? format(new Date(value), "EEEE, MMMM d, yyyy 'at' h:mm a")
+    : '';
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[60] p-4">
+      <div className="bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl w-full max-w-sm">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-800">
+          <div className="flex items-center gap-2">
+            <Clock className="w-5 h-5 text-indigo-400" />
+            <h3 className="text-base font-semibold text-white">Schedule Post</h3>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 text-neutral-500 hover:text-white hover:bg-neutral-800 rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-neutral-300 mb-2">
+              <Calendar className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Publish date &amp; time
+            </label>
+            <input
+              type="datetime-local"
+              value={value}
+              min={minTime}
+              onChange={(e) => {
+                setValue(e.target.value);
+                setError('');
+              }}
+              className={`
+                w-full px-3 py-2.5 bg-neutral-800 border rounded-lg text-white text-sm
+                focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                [color-scheme:dark]
+                ${error ? 'border-red-500' : 'border-neutral-700'}
+              `}
+            />
+            {error && (
+              <p className="mt-1.5 flex items-center gap-1 text-xs text-red-400">
+                <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
+                {error}
+              </p>
+            )}
+          </div>
+
+          {/* Preview */}
+          {value && !error && (
+            <div className="bg-neutral-800 rounded-lg px-3 py-2.5 space-y-1">
+              <p className="text-xs text-neutral-500">Your post will go live on</p>
+              <p className="text-sm font-medium text-indigo-300">{formattedPreview}</p>
+              <p className="text-xs text-neutral-500">Timezone: {userTimezone}</p>
+            </div>
+          )}
+
+          <p className="text-xs text-neutral-500 leading-relaxed">
+            Your post will be saved as a draft and automatically published at the chosen time.
+            You can cancel it any time before it goes live.
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="flex gap-2 px-5 pb-5">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 border border-neutral-700 rounded-lg text-sm text-neutral-300 hover:bg-neutral-800 transition-colors"
+          >
+            Back
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!value}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <Clock className="w-4 h-4" />
+            Schedule
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -528,6 +528,24 @@ export const communityApi = {
     return handleResponse(response)
   },
 
+  async getScheduledPosts() {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/community/posts/scheduled/mine`, {
+      method: 'GET',
+      headers
+    })
+    return handleResponse(response)
+  },
+
+  async cancelScheduledPost(postId) {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/community/posts/${postId}/schedule`, {
+      method: 'DELETE',
+      headers
+    })
+    return handleResponse(response)
+  },
+
   // ---- Comments ----
   async getComments(postId, page = 1) {
     const headers = await getAuthHeaders()


### PR DESCRIPTION
 ## Description

  Implements scheduled publishing for community posts, resolving #615.

  Users can pick a future date/time when creating a post. The post is
  saved with `status: "scheduled"` and published automatically at the
  chosen time via a BullMQ delayed job. Until then it is hidden from
  the public feed and only visible to the author in a dedicated
  "Scheduled Posts" section.

  ## Type of Change
  - [x] New feature

  ## Related Issue
  Closes #615

  ## What Changed

  **Backend**
  - `backend/src/services/postScheduler.js` — new BullMQ queue + worker;
    follows the same pattern as the existing `jobAlertQueue.js`;
    gracefully no-ops if `REDIS_URL` is absent
  - `communityFirebaseController.js` — `createPost` accepts optional
    `scheduledAt`; new `getScheduledPosts` and `cancelScheduledPost`
    controllers
  - `routes/community.js` — `GET /posts/scheduled/mine` and
    `DELETE /posts/:postId/schedule`
  - `index.js` — initializes post scheduler on startup

  **Frontend**
  - `SchedulePost.jsx` — new datetime picker modal with timezone display
    and 5-minute minimum guard
  - `PostEditor.jsx` — Schedule button alongside Publish; shows chosen
    time inline with a remove option; existing Publish flow unchanged
  - `PostCard.jsx` — scheduled time badge + cancel banner visible only
    to the post author
  - `PostsFeed.jsx` — collapsible "Scheduled Posts" section; fetches
    author's scheduled posts on mount
  - `api.js` — `getScheduledPosts()` and `cancelScheduledPost(postId)`

  ## Edge Cases Handled
  - `scheduledAt` in the past → 400 error at the API layer
  - Redis unavailable → falls back to immediate publish, no data loss
  - Cancel → job removed from queue, status reverts to `draft`
  - Worker guard: skips publish if status changed before job fires

  ## Testing
  - [x] Backend syntax checks pass (`node --check`)
  - [x] Frontend production build passes (`npm run build`)
  - [x] Scheduled post excluded from public feed
  - [x] `/posts/scheduled/mine` returns only author's scheduled posts
  - [x] Cancel endpoint reverts status to draft

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed my code
  - [x] No new warnings generated

  ---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post scheduling: Schedule community posts to publish at a future date and time with intuitive date/time selection.
  * Scheduled posts management: View all your scheduled posts in a dedicated section and cancel them anytime before publication.
  * Post status indicators: Scheduled and draft posts now display status badges showing their publication state and scheduled time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->