### PR TITLE
Add useClipboard hook

### DIFF
--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { useSocketEvent, useTypingIndicator } from './useSocket';
 export { usePresence } from './usePresence';
+export { useClipboard } from './useClipboard';

--- a/frontend/src/hooks/useClipboard.js
+++ b/frontend/src/hooks/useClipboard.js
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useClipboard(timeout = 2000) {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState(null);
+  const timeoutRef = useRef(null);
+
+  const clearCopiedTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const copy = useCallback(
+    async (text) => {
+      clearCopiedTimer();
+      setCopied(false);
+      setError(null);
+
+      if (!navigator?.clipboard?.writeText) {
+        const message = 'Clipboard API is not available in this browser.';
+        setError(message);
+        return false;
+      }
+
+      try {
+        await navigator.clipboard.writeText(String(text ?? ''));
+        setCopied(true);
+        timeoutRef.current = window.setTimeout(() => {
+          setCopied(false);
+          timeoutRef.current = null;
+        }, timeout);
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unable to copy to clipboard.';
+        setError(message);
+        return false;
+      }
+    },
+    [clearCopiedTimer, timeout]
+  );
+
+  useEffect(() => clearCopiedTimer, [clearCopiedTimer]);
+
+  return { copy, copied, error };
+}
+
+export default useClipboard;


### PR DESCRIPTION
## Summary
- add a reusable `useClipboard` hook that exposes `copy`, `copied`, and `error`
- reset copied feedback after the provided timeout
- export the hook from the hooks barrel file

## Validation
- Passed: `npx eslint src/hooks/useClipboard.js src/hooks/index.js`

Closes #756