### PR TITLE
security: add Content Security Policy headers via Helmet (#559)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -69,9 +69,51 @@ app.use(cors({
 // Helmet security headers - configured to not interfere with CORS
 app.use(helmet({
   crossOriginResourcePolicy: { policy: 'cross-origin' },
-  crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' }
+  crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: [
+        "'self'",
+        "'unsafe-inline'",       // Required for React inline scripts
+        "https://apis.google.com",
+        "https://accounts.google.com",
+        "https://www.gstatic.com",
+      ],
+      styleSrc: [
+        "'self'",
+        "'unsafe-inline'",       // Required for Tailwind/inline styles
+        "https://fonts.googleapis.com",
+      ],
+      fontSrc: [
+        "'self'",
+        "https://fonts.gstatic.com",
+      ],
+      imgSrc: [
+        "'self'",
+        "data:",
+        "blob:",
+        "https:",                // Allow all HTTPS images (company logos etc)
+      ],
+      connectSrc: [
+        "'self'",
+        process.env.FRONTEND_URL || "http://localhost:5173",
+        "https://firebaseapp.com",
+        "https://*.googleapis.com",
+        "https://*.firebaseio.com",
+        "https://identitytoolkit.googleapis.com",
+        "wss:",                  // WebSocket for Socket.IO
+        "ws:",                   // WebSocket local dev
+      ],
+      frameSrc: [
+        "'self'",
+        "https://accounts.google.com",
+      ],
+      objectSrc: ["'none'"],
+      upgradeInsecureRequests: [],
+    },
+  },
 }));
-
 const limiter = rateLimit({
   windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes
   max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000, // increased for development


### PR DESCRIPTION
Fixes #559

Changes:
- Configured strict CSP headers in backend/src/index.js via Helmet

Allowlisted sources:
- Google APIs and Firebase for auth
- Google Fonts for typography  
- WebSocket (wss/ws) for Socket.IO
- HTTPS images for company logos
- unsafe-inline for React and Tailwind

Security improvements:
- defaultSrc: 'self' blocks unknown sources
- objectSrc: 'none' blocks Flash/plugins
- upgradeInsecureRequests enforces HTTPS

Tested: CSP header confirmed present via curl -I http://localhost:5000/health

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced security header policies to strengthen protection against web vulnerabilities and improve secure communication with external services and WebSocket connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->