### PR TITLE
feat: add pagination to job alerts endpoint

### DIFF
--- a/backend/src/routes/jobAlerts.js
+++ b/backend/src/routes/jobAlerts.js
@@ -53,20 +53,32 @@ router.get('/stats/summary', verifyToken, asyncHandler(async (req, res) => {
 
 router.get('/', verifyToken, asyncHandler(async (req, res) => {
     const userId = req.user.uid;
+    const limit = Math.min(Math.max(parseInt(req.query.limit) || 10, 1), 50);
+    const skip = Math.max(parseInt(req.query.skip) || 0, 0);
 
-    const alerts = await JobAlert.find({ userId })
-        .sort({ createdAt: -1 })
-        .lean();
+    const [alerts, total] = await Promise.all([
+        JobAlert.find({ userId })
+            .sort({ createdAt: -1 })
+            .limit(limit)
+            .skip(skip)
+            .lean(),
+        JobAlert.countDocuments({ userId })
+    ]);
 
     const alertsWithIndex = alerts.map((alert, index) => ({
         ...alert,
-        position: index + 1 
+        position: skip + index + 1
     }));
 
     res.json({
         success: true,
         count: alerts.length,
-        alerts: alertsWithIndex
+        alerts: alertsWithIndex,
+        pagination: {
+            total,
+            limit,
+            skip
+        }
     });
 }));
 


### PR DESCRIPTION
## Description

Added query-based pagination to the GET `/api/job-alerts` endpoint to improve performance and scalability.

Enhancements:
- Introduced `limit` and `skip` query parameters for controlled data fetching
- Applied `.limit()` and `.skip()` to the database query
- Added total count using `countDocuments` for frontend pagination support
- Maintained existing sorting and response structure
- Included safe bounds for `limit` and `skip` to prevent excessive queries
- Updated position indexing to account for pagination offset

This ensures efficient handling of large datasets while keeping backward compatibility intact.

---

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other (describe)

---

## Related Issue
Fixes #18

---

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

---

## Screenshots
N/A

---

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No unrelated changes included
- [x] No new warnings generated