### PR TITLE
fix: implement defensive array verification and empty-state fallback UI

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -203,24 +203,40 @@ export default function Dashboard() {
                 ) : (
                   <div className="rounded-[2rem] bg-card border border-border overflow-hidden shadow-sm">
                     <div className="divide-y divide-border">
-                      {trackedJobs.slice(0, 5).map((job, index) => {
-                        const statusConfig = STATUS_CONFIG[job.status] || STATUS_CONFIG.saved
-                        const StatusIcon = statusConfig.icon
-                        return (
-                          <div key={job.id || index} className="p-5 hover:bg-muted/50 transition-all group">
-                            <div className="flex justify-between items-center">
-                              <div className="flex-1">
-                                <h4 className="text-lg font-bold text-foreground group-hover:text-primary transition-colors">{job.title}</h4>
-                                <p className="text-sm text-muted-foreground font-semibold">{job.company}</p>
+                     {/** * GSSoC Optimization: Defensive structural evaluation on the active data view slice.
+                        * Prevents layout container voids if the array slice metrics index is altered.
+                        */}
+                      {(() => {
+                        const displayedJobs = trackedJobs.slice(0, 5);
+                        
+                        if (displayedJobs.length > 0) {
+                          return displayedJobs.map((job, index) => {
+                            const statusConfig = STATUS_CONFIG[job.status] || STATUS_CONFIG.saved;
+                            const StatusIcon = statusConfig.icon;
+                            return (
+                              <div key={job.id || index} className="p-5 hover:bg-muted/50 transition-all group">
+                                <div className="flex justify-between items-center">
+                                  <div className="flex-1">
+                                    <h4 className="text-lg font-bold text-foreground group-hover:text-primary transition-colors">{job.title}</h4>
+                                    <p className="text-sm text-muted-foreground font-semibold">{job.company}</p>
+                                  </div>
+                                  <span className={`px-3 py-1.5 rounded-xl text-xs font-bold flex items-center gap-2 ${statusConfig.color}`}>
+                                    <StatusIcon className="w-3.5 h-3.5" />
+                                    {statusConfig.label}
+                                  </span>
+                                </div>
                               </div>
-                              <span className={`px-3 py-1.5 rounded-xl text-xs font-bold flex items-center gap-2 ${statusConfig.color}`}>
-                                <StatusIcon className="w-3.5 h-3.5" />
-                                {statusConfig.label}
-                              </span>
+                            );
+                          });
+                        } else {
+                          return (
+                            /* Graceful fallback UI layout state when view density evaluation yields zero records */
+                            <div className="p-10 text-center text-sm font-medium text-muted-foreground bg-muted/10 rounded-2xl border border-dashed border-border/60 mx-5 my-4">
+                              No active application records available in this view index.
                             </div>
-                          </div>
-                        )
-                      })}
+                          );
+                        }
+                      })()}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## **User description**
## Description
Implemented defensive structural validation checks on the main dashboard tracking arrays. If the user's data metrics map down to a zero-length index sequence during evaluation, the UI layout template will short-circuit gracefully to render a dashed-border empty-state placeholder instead of collapsing into a blank container void.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #922

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
N/A (This is a structural defensive rendering fix for logical array loops under dynamic filter sets)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Recent Applications section on the Dashboard to properly handle cases when no applications are being tracked, providing clearer messaging and improved fallback UI when the list is empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show an empty state when no tracked applications match the dashboard view**

### What Changed
- The Recent Applications section now checks for available tracked jobs before trying to list them
- When no applications match the current view, it shows a dashed empty-state message instead of leaving a blank area
- The existing list still shows up to five tracked applications when data is available

### Impact
`✅ Clearer dashboard empty states`
`✅ Fewer blank sections on filtered views`
`✅ Easier to understand when no applications match`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
