### PR TITLE
Add sitemap.xml generation for public portfolios

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -1,11 +1,39 @@
 import express from 'express';
+import fs from 'fs/promises';
 import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import { enhanceSection } from '../services/ai/portfolioContentEnhancer.js';
+import { generateRobotsTxt, generateSitemapXml } from '../utils/sitemapGenerator.js';
 
 const router = express.Router();
 
 const VALID_SECTIONS = ['hero', 'projects', 'about', 'skills'];
+const VALID_SLUG_PATTERN = /^[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?$/i;
+
+const getPublicPortfolioBaseUrl = (req) => {
+  const configuredBaseUrl = process.env.PORTFOLIO_BASE_URL || process.env.FRONTEND_URL;
+  const fallbackBaseUrl = `${req.protocol}://${req.get('host')}`;
+
+  return String(configuredBaseUrl || fallbackBaseUrl).replace(/\/$/, '');
+};
+
+const getApiBaseUrl = (req) => {
+  return `${req.protocol}://${req.get('host')}`.replace(/\/$/, '');
+};
+
+const getPublicPortfolioPageUrl = (req, slug) => {
+  return `${getPublicPortfolioBaseUrl(req)}/portfolio/public/${encodeURIComponent(slug)}`;
+};
+
+const getPortfolioTemplatePath = (slug) => {
+  return new URL(`../templates/portfolio/${slug}/index.html`, import.meta.url);
+};
+
+const assertValidPortfolioSlug = (slug) => {
+  if (!VALID_SLUG_PATTERN.test(slug)) {
+    throw new ApiError(400, 'Invalid portfolio slug.');
+  }
+};
 
 /**
  * POST /api/ai/enhance-portfolio-content
@@ -40,6 +68,49 @@ router.post('/enhance-portfolio-content', verifyToken, asyncHandler(async (req, 
       improvements: result.improvements,
     },
   });
+}));
+
+router.get('/public/:slug/sitemap.xml', asyncHandler(async (req, res) => {
+  const { slug } = req.params;
+  assertValidPortfolioSlug(slug);
+
+  let templateStat;
+
+  try {
+    templateStat = await fs.stat(getPortfolioTemplatePath(slug));
+  } catch {
+    throw new ApiError(404, 'Portfolio template not found.');
+  }
+
+  const sitemapXml = generateSitemapXml({
+    baseUrl: getPublicPortfolioBaseUrl(req),
+    slug,
+    portfolioPath: '/portfolio/public',
+    portfolioUpdatedAt: templateStat.mtime,
+  });
+
+  res
+    .status(200)
+    .type('application/xml')
+    .send(sitemapXml);
+}));
+
+router.get('/public/:slug/robots.txt', asyncHandler(async (req, res) => {
+  const { slug } = req.params;
+  assertValidPortfolioSlug(slug);
+
+  try {
+    await fs.stat(getPortfolioTemplatePath(slug));
+  } catch {
+    throw new ApiError(404, 'Portfolio template not found.');
+  }
+
+  const sitemapUrl = `${getApiBaseUrl(req)}/api/portfolio/public/${encodeURIComponent(slug)}/sitemap.xml`;
+
+  res
+    .status(200)
+    .type('text/plain')
+    .send(generateRobotsTxt({ sitemapUrl }));
 }));
 
 export default router;

--- a/backend/src/utils/sitemapGenerator.js
+++ b/backend/src/utils/sitemapGenerator.js
@@ -1,0 +1,134 @@
+/**
+ * Utility to generate XML sitemaps for portfolio pages.
+ * Filters out draft/unpublished project and blog entries when supplied.
+ */
+
+const escapeXml = (value = '') => {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/'/g, '&apos;')
+    .replace(/"/g, '&quot;')
+    .replace(/>/g, '&gt;')
+    .replace(/</g, '&lt;');
+};
+
+const formatDate = (date) => {
+  const parsedDate = new Date(date);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return new Date().toISOString().split('T')[0];
+  }
+
+  return parsedDate.toISOString().split('T')[0];
+};
+
+const normalizePath = (value = '') => {
+  const trimmed = String(value).trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  return `/${trimmed.replace(/^\/+|\/+$/g, '')}`;
+};
+
+const isPublishedContent = (item) => {
+  if (!item || typeof item !== 'object') {
+    return false;
+  }
+
+  if (item.isPublished === false || item.isDraft === true) {
+    return false;
+  }
+
+  if (typeof item.status === 'string') {
+    const status = item.status.trim().toLowerCase();
+
+    if (['draft', 'unpublished', 'private', 'hidden'].includes(status)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const buildUrlEntry = ({
+  loc,
+  lastmod,
+  changefreq = 'monthly',
+  priority = '0.5',
+}) => {
+  return `  <url>
+    <loc>${escapeXml(loc)}</loc>
+    <lastmod>${formatDate(lastmod)}</lastmod>
+    <changefreq>${escapeXml(changefreq)}</changefreq>
+    <priority>${escapeXml(priority)}</priority>
+  </url>`;
+};
+
+const generateSitemapXml = ({
+  baseUrl,
+  slug,
+  portfolioPath = '/portfolio/public',
+  portfolioUpdatedAt,
+  projects = [],
+  blogs = [],
+}) => {
+  const cleanBaseUrl = String(baseUrl || '').replace(/\/$/, '');
+  const cleanPortfolioPath = normalizePath(portfolioPath);
+  const encodedSlug = encodeURIComponent(slug);
+  const portfolioBase = `${cleanBaseUrl}${cleanPortfolioPath}/${encodedSlug}`;
+
+  const entries = [
+    buildUrlEntry({
+      loc: portfolioBase,
+      lastmod: portfolioUpdatedAt,
+      changefreq: 'weekly',
+      priority: '1.0',
+    }),
+  ];
+
+  projects.filter(isPublishedContent).forEach((project) => {
+    if (!project?.slug) {
+      return;
+    }
+
+    entries.push(
+      buildUrlEntry({
+        loc: `${portfolioBase}/projects/${encodeURIComponent(project.slug)}`,
+        lastmod: project.updatedAt || portfolioUpdatedAt,
+        changefreq: 'monthly',
+        priority: '0.8',
+      })
+    );
+  });
+
+  blogs.filter(isPublishedContent).forEach((blog) => {
+    if (!blog?.slug) {
+      return;
+    }
+
+    entries.push(
+      buildUrlEntry({
+        loc: `${portfolioBase}/blog/${encodeURIComponent(blog.slug)}`,
+        lastmod: blog.updatedAt || portfolioUpdatedAt,
+        changefreq: 'monthly',
+        priority: '0.7',
+      })
+    );
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries.join('\n')}
+</urlset>`;
+};
+
+const generateRobotsTxt = ({ sitemapUrl }) => {
+  return `User-agent: *
+Allow: /
+
+Sitemap: ${String(sitemapUrl || '').trim()}`;
+};
+
+export { generateSitemapXml, generateRobotsTxt, formatDate, escapeXml };

--- a/backend/src/utils/sitemapGenerator.js
+++ b/backend/src/utils/sitemapGenerator.js
@@ -1,6 +1,5 @@
 /**
  * Utility to generate XML sitemaps for portfolio pages.
- * Filters out draft/unpublished project and blog entries when supplied.
  */
 
 const escapeXml = (value = '') => {
@@ -16,7 +15,7 @@ const formatDate = (date) => {
   const parsedDate = new Date(date);
 
   if (Number.isNaN(parsedDate.getTime())) {
-    return new Date().toISOString().split('T')[0];
+    return null;
   }
 
   return parsedDate.toISOString().split('T')[0];
@@ -32,35 +31,17 @@ const normalizePath = (value = '') => {
   return `/${trimmed.replace(/^\/+|\/+$/g, '')}`;
 };
 
-const isPublishedContent = (item) => {
-  if (!item || typeof item !== 'object') {
-    return false;
-  }
-
-  if (item.isPublished === false || item.isDraft === true) {
-    return false;
-  }
-
-  if (typeof item.status === 'string') {
-    const status = item.status.trim().toLowerCase();
-
-    if (['draft', 'unpublished', 'private', 'hidden'].includes(status)) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
 const buildUrlEntry = ({
   loc,
   lastmod,
   changefreq = 'monthly',
   priority = '0.5',
 }) => {
+  const formattedLastmod = formatDate(lastmod);
+
   return `  <url>
     <loc>${escapeXml(loc)}</loc>
-    <lastmod>${formatDate(lastmod)}</lastmod>
+    ${formattedLastmod ? `<lastmod>${formattedLastmod}</lastmod>` : ''}
     <changefreq>${escapeXml(changefreq)}</changefreq>
     <priority>${escapeXml(priority)}</priority>
   </url>`;
@@ -88,7 +69,7 @@ const generateSitemapXml = ({
     }),
   ];
 
-  projects.filter(isPublishedContent).forEach((project) => {
+  projects.forEach((project) => {
     if (!project?.slug) {
       return;
     }
@@ -103,7 +84,7 @@ const generateSitemapXml = ({
     );
   });
 
-  blogs.filter(isPublishedContent).forEach((blog) => {
+  blogs.forEach((blog) => {
     if (!blog?.slug) {
       return;
     }


### PR DESCRIPTION
## Description

Implemented sitemap.xml and robots.txt generation for public portfolio pages to improve search engine indexing and SEO support.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Other (describe)

## Related Issue

Fixes #846 

## Testing

* [ ] Unit tests pass
* [x] Tested Locally
* [ ] New tests added

Tested:

* `/api/portfolio/public/retro-pixel/sitemap.xml`
* `/api/portfolio/public/retro-pixel/robots.txt`

## Screenshots (MANDATORY for UI/UX changes)

N/A

## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio sites now include auto-generated sitemap.xml and robots.txt endpoints to improve search engine discoverability and indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->