### PR TITLE
docs(env): harden environment-setup guide against key leaks

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -40,23 +40,26 @@ NODE_ENV=development
 FRONTEND_URL=http://localhost:5173
 MONGODB_URI=mongodb://localhost:27017/career-pilot
 REDIS_URL=redis://localhost:6379
-GEMINI_API_KEY=AIzaSy-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-RAPIDAPI_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GEMINI_API_KEY=<your-gemini-api-key>
+GROQ_API_KEY=<your-groq-api-key>
+RAPIDAPI_KEY=<your-rapidapi-key>
 RAPIDAPI_HOST=jsearch.p.rapidapi.com
-FIREBASE_PROJECT_ID=xxxxxxxxxxxxxxxx
-FIREBASE_STORAGE_BUCKET=xxxxxxxxxxxxxxxx.appspot.com
+FIREBASE_PROJECT_ID=<your-firebase-project-id>
+FIREBASE_STORAGE_BUCKET=<your-firebase-project-id>.appspot.com
 FIREBASE_SERVICE_ACCOUNT_PATH=./path/to/service-account-key.json
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587
-SMTP_USER=your-email@example.com
-SMTP_PASS=your-app-password
-RAZORPAY_KEY_ID=rzp_test_xxxxxxxxxxxxxxxxxxxx
-RAZORPAY_KEY_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-LINKEDIN_CLIENT_ID=xxxxxxxxxxxxxxxx
-LINKEDIN_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+EMAIL_USER=<your-email-address>
+EMAIL_PASS=<your-gmail-app-password>
+EMAIL_SERVICE_URL=https://email-service.example.com
+EMAIL_API_KEY=<your-email-api-key>
+RAZORPAY_KEY_ID=rzp_test_<your-key-id>
+RAZORPAY_KEY_SECRET=<your-razorpay-key-secret>
+LINKEDIN_CLIENT_ID=<your-linkedin-client-id>
+LINKEDIN_CLIENT_SECRET=<your-linkedin-client-secret>
 LINKEDIN_REDIRECT_URI=http://localhost:5000/api/auth/linkedin/callback
-TOTP_ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+PROXYCURL_API_KEY=<your-proxycurl-api-key>
+TOTP_ENCRYPTION_KEY=<64-char-hex-string>
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 ALERT_CRON_SCHEDULE="0 */6 * * *"
@@ -72,13 +75,13 @@ DEV_USER_EMAIL=dev@example.com
 ```env
 VITE_API_URL=http://localhost:5000
 VITE_API_BASE=http://localhost:5000/api
-VITE_FIREBASE_API_KEY=AIzaSy-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-VITE_FIREBASE_AUTH_DOMAIN=xxxxxxxxxxxxxxxx.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=xxxxxxxxxxxxxxxx
-VITE_FIREBASE_STORAGE_BUCKET=xxxxxxxxxxxxxxxx.appspot.com
-VITE_FIREBASE_MESSAGING_SENDER_ID=000000000000
-VITE_FIREBASE_APP_ID=1:000000000000:web:xxxxxxxxxxxxxxxx
-VITE_FIREBASE_MEASUREMENT_ID=G-XXXXXXXXXX
+VITE_FIREBASE_API_KEY=<your-firebase-web-api-key>
+VITE_FIREBASE_AUTH_DOMAIN=<your-firebase-project-id>.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=<your-firebase-project-id>
+VITE_FIREBASE_STORAGE_BUCKET=<your-firebase-project-id>.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=<your-sender-id>
+VITE_FIREBASE_APP_ID=<your-firebase-app-id>
+VITE_FIREBASE_MEASUREMENT_ID=G-<your-measurement-id>
 VITE_MAX_SIZE_MB=5
 ```
 
@@ -86,6 +89,7 @@ VITE_MAX_SIZE_MB=5
 - `DEV_BYPASS_AUTH=false` — set to `true` only to skip Firebase login during local testing
 - `ALERT_TEST_INTERVAL` — set a value in milliseconds (e.g. `10000` for 10 seconds) to test job alerts faster locally
 - `ENABLE_DB_PROFILING=false` — set to `true` to log slow MongoDB queries while debugging
+- `PROXYCURL_API_KEY` — required only for the LinkedIn profile import feature; leave blank to disable that feature without affecting anything else. Free tier: 10 credits, no credit card required ([proxycurl.com](https://proxycurl.com))
 
 ---
 
@@ -147,6 +151,7 @@ The live environment. All values must be real, secure, and set as environment va
 | **RapidAPI / JSearch** | [RapidAPI](https://rapidapi.com/letscrape-6bRBa3QguO5/api/jsearch) |
 | **Razorpay** | [Razorpay Dashboard](https://dashboard.razorpay.com/app/keys) |
 | **LinkedIn OAuth** | [LinkedIn Developers](https://www.linkedin.com/developers/apps) |
+| **Proxycurl** | [proxycurl.com](https://proxycurl.com) — free tier: 10 credits, no credit card required |
 | **Gmail App Password** | [Google Account](https://myaccount.google.com/apppasswords) |
 | **TOTP Key** | Run: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
 
@@ -157,9 +162,12 @@ The live environment. All values must be real, secure, and set as environment va
 Before deploying, make sure:
 
 - [ ] `.env` files are in `.gitignore` and never committed
+- [ ] All placeholders in `.env.example` use `<angle-bracket>` format — not realistic-looking values that could be flagged by secret scanners
 - [ ] `DEV_BYPASS_AUTH=false` in staging and production
 - [ ] `ENABLE_DB_PROFILING=false` in production
 - [ ] Razorpay live keys are only used in production
 - [ ] `TOTP_ENCRYPTION_KEY` is a unique 64-char hex string
 - [ ] `RAZORPAY_KEY_SECRET` is never exposed to the frontend
 - [ ] `ALERT_TEST_INTERVAL` is empty in staging and production
+- [ ] `PROXYCURL_API_KEY` is kept server-side only and rotated if exposed
+- [ ] No API keys appear in client-side code, logs, or error responses


### PR DESCRIPTION
 ## What changed

  `docs/environment-setup.md` had several issues that could cause real problems:
  
  | Problem | Fix |
  |---|---|
  | `GEMINI_API_KEY=AIzaSy-xxx` — matches real Google API key format, triggers secret scanners | Replaced with `<your-gemini-api-key>` |
  | `VITE_FIREBASE_API_KEY=AIzaSy-xxx` — same issue in frontend section | Replaced with `<your-firebase-web-api-key>` |
  | `GROQ_API_KEY=gsk_xxx` — matches real Groq key format | Replaced with `<your-groq-api-key>` |
  | All `xxxxxxxx` tokens — ambiguous, could be misread as real values | Replaced with `<angle-bracket>` tokens throughout |
  | `PROXYCURL_API_KEY` missing entirely | Added to backend dev example, notes, credentials table, and security checklist |
  | `EMAIL_USER` / `EMAIL_PASS` missing from dev example | Added with correct variable names |
  | Security checklist incomplete | Added: placeholder format standard, client-side key exposure, PROXYCURL rotation |
 
  ## Why this matters
  Secret scanners (GitHub, truffleHog, gitleaks) pattern-match on realistic-looking values. Using `AIzaSy-xxx` in docs can generate false-positive
  alerts or — worse — train contributors to think that format is acceptable in committed files.