### PR TITLE
feat: add Netlify deployment service for portfolio publishing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -197,6 +197,18 @@ TOTP_ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 # -----------------------------------------------------------------------------
+# PORTFOLIO DEPLOYMENT - NETLIFY
+# -----------------------------------------------------------------------------
+
+# Personal access token for the Netlify API
+# Type: string
+# Generate at: https://app.netlify.com/user/applications#personal-access-tokens
+# Note: Each user can supply their own token per request; this value is the
+#       server-owned fallback used when no per-request token is provided.
+NETLIFY_ACCESS_TOKEN=your_netlify_personal_access_token_here
+
+
+# -----------------------------------------------------------------------------
 # LOCAL DEVELOPMENT ONLY - never set these to true in production
 # -----------------------------------------------------------------------------
 

--- a/backend/src/services/deploy/netlifyDeployer.js
+++ b/backend/src/services/deploy/netlifyDeployer.js
@@ -1,0 +1,162 @@
+import crypto from 'crypto';
+
+const NETLIFY_API = 'https://api.netlify.com/api/v1';
+
+function getToken(token) {
+  const resolved = token || process.env.NETLIFY_ACCESS_TOKEN;
+  if (!resolved) {
+    throw new Error('A Netlify access token is required. Pass it as a parameter or set NETLIFY_ACCESS_TOKEN in your environment.');
+  }
+  return resolved;
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function netlifyRequest(method, path, body, token) {
+  const res = await fetch(`${NETLIFY_API}${path}`, {
+    method,
+    headers: authHeaders(token),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await res.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = { message: text };
+  }
+
+  if (!res.ok) {
+    throw new Error(`Netlify API error ${res.status}: ${data.message || text}`);
+  }
+
+  return data;
+}
+
+function sha1(content) {
+  return crypto.createHash('sha1').update(content).digest('hex');
+}
+
+/**
+ * Deploy an HTML portfolio to Netlify using the file-digest method.
+ *
+ * @param {string} portfolioId  - Stable identifier used to find an existing site
+ * @param {string} htmlContent  - Full HTML string for index.html
+ * @param {Object} assets       - Map of relative path → string/Buffer content, e.g. { 'style.css': '...' }
+ * @param {string} [siteName]   - Desired Netlify subdomain (auto-generated if omitted)
+ * @param {string} [token]      - Netlify personal access token (falls back to NETLIFY_ACCESS_TOKEN)
+ * @returns {Promise<{ url: string, siteId: string, deployId: string }>}
+ */
+export async function deploy(portfolioId, htmlContent, assets = {}, siteName, token) {
+  const resolvedToken = getToken(token);
+
+  // Build file map: path → Buffer
+  const files = {
+    '/index.html': Buffer.isBuffer(htmlContent) ? htmlContent : Buffer.from(htmlContent, 'utf8'),
+  };
+  for (const [path, content] of Object.entries(assets)) {
+    const normalised = path.startsWith('/') ? path : `/${path}`;
+    files[normalised] = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+  }
+
+  // Compute SHA1 digest for every file
+  const digestMap = {};
+  for (const [path, buf] of Object.entries(files)) {
+    digestMap[path] = sha1(buf);
+  }
+
+  // Find or create the Netlify site for this portfolioId
+  let siteId;
+  const allSites = await netlifyRequest('GET', '/sites?per_page=100', undefined, resolvedToken);
+  const existing = allSites.find((s) => s.name && s.name.startsWith(`career-pilot-${portfolioId}`));
+
+  if (existing) {
+    siteId = existing.id;
+  } else {
+    const nameSlug = siteName
+      ? siteName.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+      : `career-pilot-${portfolioId.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+
+    const newSite = await netlifyRequest('POST', '/sites', { name: nameSlug }, resolvedToken);
+    siteId = newSite.id;
+  }
+
+  // Create a deploy with file digests; Netlify responds with which files are missing
+  const deployPayload = { files: digestMap, async: false };
+  const deployResult = await netlifyRequest('POST', `/sites/${siteId}/deploys`, deployPayload, resolvedToken);
+  const deployId = deployResult.id;
+
+  // Upload only the files Netlify says are missing
+  const required = deployResult.required || [];
+  for (const hash of required) {
+    const entry = Object.entries(digestMap).find(([, h]) => h === hash);
+    if (!entry) continue;
+
+    const [filePath, fileHash] = entry;
+    const fileBuffer = files[filePath];
+
+    const uploadRes = await fetch(`${NETLIFY_API}/deploys/${deployId}/files${filePath}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${resolvedToken}`,
+        'Content-Type': 'application/octet-stream',
+      },
+      body: fileBuffer,
+    });
+
+    if (!uploadRes.ok) {
+      const errText = await uploadRes.text();
+      throw new Error(`Failed to upload ${filePath} (${fileHash}): ${errText}`);
+    }
+  }
+
+  // Poll until the deploy is ready (max 60 s)
+  const url = await waitForDeploy(deployId, resolvedToken);
+
+  return { url, siteId, deployId };
+}
+
+async function waitForDeploy(deployId, token, maxWaitMs = 60_000, intervalMs = 3_000) {
+  const deadline = Date.now() + maxWaitMs;
+
+  while (Date.now() < deadline) {
+    const status = await netlifyRequest('GET', `/deploys/${deployId}`, undefined, token);
+
+    if (status.state === 'ready') {
+      return `https://${status.ssl_url ? status.ssl_url.replace(/^https?:\/\//, '') : status.url.replace(/^https?:\/\//, '')}`;
+    }
+
+    if (status.state === 'error') {
+      throw new Error(`Deploy ${deployId} failed: ${status.error_message || 'unknown error'}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`Deploy ${deployId} did not become ready within ${maxWaitMs / 1000}s`);
+}
+
+/**
+ * Get the current deployment status for a Netlify site.
+ *
+ * @param {string} siteId  - Netlify site ID
+ * @param {string} [token] - Netlify personal access token (falls back to NETLIFY_ACCESS_TOKEN)
+ * @returns {Promise<{ state: string, url: string, sslUrl: string, publishedAt: string|null }>}
+ */
+export async function getDeploymentStatus(siteId, token) {
+  const resolvedToken = getToken(token);
+  const site = await netlifyRequest('GET', `/sites/${siteId}`, undefined, resolvedToken);
+
+  return {
+    state: site.published_deploy?.state ?? 'unknown',
+    url: site.url ?? null,
+    sslUrl: site.ssl_url ?? null,
+    publishedAt: site.published_deploy?.published_at ?? null,
+  };
+}

--- a/backend/src/services/deploy/netlifyDeployer.js
+++ b/backend/src/services/deploy/netlifyDeployer.js
@@ -2,12 +2,27 @@ import crypto from 'crypto';
 
 const NETLIFY_API = 'https://api.netlify.com/api/v1';
 
+// Netlify enforces a 63-character limit on site name slugs (DNS label rules).
+const MAX_SITE_NAME_LENGTH = 63;
+
 function getToken(token) {
   const resolved = token || process.env.NETLIFY_ACCESS_TOKEN;
   if (!resolved) {
-    throw new Error('A Netlify access token is required. Pass it as a parameter or set NETLIFY_ACCESS_TOKEN in your environment.');
+    throw new Error(
+      'A Netlify access token is required. Pass it as a parameter or set NETLIFY_ACCESS_TOKEN in your environment.'
+    );
   }
   return resolved;
+}
+
+function assertSafeId(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  // Only allow alphanumeric, hyphens, and underscores — prevents path traversal in URL segments.
+  if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+    throw new Error(`${label} contains invalid characters. Use only letters, numbers, hyphens, and underscores.`);
+  }
 }
 
 function authHeaders(token) {
@@ -43,6 +58,13 @@ function sha1(content) {
   return crypto.createHash('sha1').update(content).digest('hex');
 }
 
+function toSiteNameSlug(raw) {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .slice(0, MAX_SITE_NAME_LENGTH);
+}
+
 /**
  * Deploy an HTML portfolio to Netlify using the file-digest method.
  *
@@ -54,6 +76,7 @@ function sha1(content) {
  * @returns {Promise<{ url: string, siteId: string, deployId: string }>}
  */
 export async function deploy(portfolioId, htmlContent, assets = {}, siteName, token) {
+  assertSafeId(portfolioId, 'portfolioId');
   const resolvedToken = getToken(token);
 
   // Build file map: path → Buffer
@@ -74,49 +97,64 @@ export async function deploy(portfolioId, htmlContent, assets = {}, siteName, to
   // Find or create the Netlify site for this portfolioId
   let siteId;
   const allSites = await netlifyRequest('GET', '/sites?per_page=100', undefined, resolvedToken);
-  const existing = allSites.find((s) => s.name && s.name.startsWith(`career-pilot-${portfolioId}`));
+
+  if (!Array.isArray(allSites)) {
+    throw new Error('Unexpected response from Netlify when listing sites. Check your access token and try again.');
+  }
+
+  const prefix = `career-pilot-${portfolioId}`;
+  const existing = allSites.find((s) => s.name && s.name.startsWith(prefix));
 
   if (existing) {
     siteId = existing.id;
   } else {
     const nameSlug = siteName
-      ? siteName.toLowerCase().replace(/[^a-z0-9-]/g, '-')
-      : `career-pilot-${portfolioId.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+      ? toSiteNameSlug(siteName)
+      : toSiteNameSlug(`career-pilot-${portfolioId}`);
 
     const newSite = await netlifyRequest('POST', '/sites', { name: nameSlug }, resolvedToken);
     siteId = newSite.id;
   }
 
   // Create a deploy with file digests; Netlify responds with which files are missing
-  const deployPayload = { files: digestMap, async: false };
-  const deployResult = await netlifyRequest('POST', `/sites/${siteId}/deploys`, deployPayload, resolvedToken);
+  const deployResult = await netlifyRequest(
+    'POST',
+    `/sites/${siteId}/deploys`,
+    { files: digestMap },
+    resolvedToken
+  );
   const deployId = deployResult.id;
 
-  // Upload only the files Netlify says are missing
-  const required = deployResult.required || [];
-  for (const hash of required) {
-    const entry = Object.entries(digestMap).find(([, h]) => h === hash);
-    if (!entry) continue;
-
-    const [filePath, fileHash] = entry;
-    const fileBuffer = files[filePath];
-
-    const uploadRes = await fetch(`${NETLIFY_API}/deploys/${deployId}/files${filePath}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${resolvedToken}`,
-        'Content-Type': 'application/octet-stream',
-      },
-      body: fileBuffer,
-    });
-
-    if (!uploadRes.ok) {
-      const errText = await uploadRes.text();
-      throw new Error(`Failed to upload ${filePath} (${fileHash}): ${errText}`);
-    }
+  // Build a reverse map: hash → filePath for O(1) lookup during upload
+  const hashToPath = {};
+  for (const [path, hash] of Object.entries(digestMap)) {
+    hashToPath[hash] = path;
   }
 
-  // Poll until the deploy is ready (max 60 s)
+  // Upload all missing files in parallel
+  const required = deployResult.required || [];
+  await Promise.all(
+    required.map(async (hash) => {
+      const filePath = hashToPath[hash];
+      if (!filePath) return;
+
+      const fileBuffer = files[filePath];
+      const uploadRes = await fetch(`${NETLIFY_API}/deploys/${deployId}/files${filePath}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${resolvedToken}`,
+          'Content-Type': 'application/octet-stream',
+        },
+        body: fileBuffer,
+      });
+
+      if (!uploadRes.ok) {
+        const errText = await uploadRes.text();
+        throw new Error(`Failed to upload ${filePath}: ${errText}`);
+      }
+    })
+  );
+
   const url = await waitForDeploy(deployId, resolvedToken);
 
   return { url, siteId, deployId };
@@ -129,7 +167,12 @@ async function waitForDeploy(deployId, token, maxWaitMs = 60_000, intervalMs = 3
     const status = await netlifyRequest('GET', `/deploys/${deployId}`, undefined, token);
 
     if (status.state === 'ready') {
-      return `https://${status.ssl_url ? status.ssl_url.replace(/^https?:\/\//, '') : status.url.replace(/^https?:\/\//, '')}`;
+      // ssl_url and url both include the protocol; prefer HTTPS.
+      const rawUrl = status.ssl_url || status.url;
+      if (!rawUrl) {
+        throw new Error(`Deploy ${deployId} is ready but no URL was returned by Netlify.`);
+      }
+      return rawUrl.startsWith('https://') ? rawUrl : `https://${rawUrl.replace(/^https?:\/\//, '')}`;
     }
 
     if (status.state === 'error') {
@@ -147,9 +190,10 @@ async function waitForDeploy(deployId, token, maxWaitMs = 60_000, intervalMs = 3
  *
  * @param {string} siteId  - Netlify site ID
  * @param {string} [token] - Netlify personal access token (falls back to NETLIFY_ACCESS_TOKEN)
- * @returns {Promise<{ state: string, url: string, sslUrl: string, publishedAt: string|null }>}
+ * @returns {Promise<{ state: string, url: string|null, sslUrl: string|null, publishedAt: string|null }>}
  */
 export async function getDeploymentStatus(siteId, token) {
+  assertSafeId(siteId, 'siteId');
   const resolvedToken = getToken(token);
   const site = await netlifyRequest('GET', `/sites/${siteId}`, undefined, resolvedToken);
 


### PR DESCRIPTION
 Closes #687

  ## What's changed   

  - `backend/src/services/deploy/netlifyDeployer.js` — new service using native `fetch` + Node's built-in `crypto` (zero new dependencies)
  - `backend/.env.example` — added `NETLIFY_ACCESS_TOKEN` section with usage notes

  ## Implementation details

  ### `deploy(portfolioId, htmlContent, assets, siteName?, token?)`
  1. Validates `portfolioId` — rejects path-traversal characters before it touches any URL
  2. Looks up existing Netlify site by `career-pilot-<portfolioId>` prefix; creates one if none found
  3. Builds a SHA-1 digest map for every file (`/index.html` + any extra assets)
  4. Opens a deploy via `POST /api/v1/sites/:siteId/deploys` — Netlify responds with only the hashes it needs
  5. Uploads only missing files in **parallel** via `Promise.all`
  6. Polls until `state === 'ready'` (60 s timeout, 3 s interval), returns `{ url, siteId, deployId }`

  ### `getDeploymentStatus(siteId, token?)`
  Calls `GET /api/v1/sites/:siteId` and returns `{ state, url, sslUrl, publishedAt }`.

  ### Token handling  
  Token is always caller-supplied — no Netlify team is hardcoded. `NETLIFY_ACCESS_TOKEN` in `.env` is the server-owned fallback only, so every user
   deploys to their own account.
  
  ## Test plan
  - [ ] `deploy()` with a valid token creates a new site and returns a live HTTPS URL
  - [ ] Second call with the same `portfolioId` updates the existing site instead of creating a new one
  - [ ] Re-deploying with unchanged files results in 0 uploads (verify via Netlify deploy log)
  - [ ] `getDeploymentStatus()` returns correct `state` and `sslUrl` for a known site
  - [ ] Calling either function with no token and no `NETLIFY_ACCESS_TOKEN` env var throws a clear error
  - [ ] Passing a `portfolioId` with path-traversal characters (e.g. `../../etc`) throws immediately