### PR TITLE
feat: GitHub Pages deployment service for portfolio publishing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -197,6 +197,22 @@ TOTP_ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 # -----------------------------------------------------------------------------
+# PORTFOLIO DEPLOYMENT - GITHUB PAGES
+# -----------------------------------------------------------------------------
+
+# GitHub OAuth App Client ID — used to initiate the OAuth flow so users can
+# grant Career Pilot permission to create and manage their portfolio repos.
+# Type: string
+# Register at: https://github.com/settings/applications/new
+#   - Authorization callback URL: http://localhost:5000/api/auth/github/callback
+GITHUB_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxx
+
+# GitHub OAuth App Client Secret
+# Type: string
+GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+# -----------------------------------------------------------------------------
 # PORTFOLIO DEPLOYMENT - NETLIFY
 # -----------------------------------------------------------------------------
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -197,6 +197,18 @@ TOTP_ENCRYPTION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 # -----------------------------------------------------------------------------
+# PORTFOLIO DEPLOYMENT - NETLIFY
+# -----------------------------------------------------------------------------
+
+# Personal access token for the Netlify API
+# Type: string
+# Generate at: https://app.netlify.com/user/applications#personal-access-tokens
+# Note: Each user can supply their own token per request; this value is the
+#       server-owned fallback used when no per-request token is provided.
+NETLIFY_ACCESS_TOKEN=your_netlify_personal_access_token_here
+
+
+# -----------------------------------------------------------------------------
 # LOCAL DEVELOPMENT ONLY - never set these to true in production
 # -----------------------------------------------------------------------------
 

--- a/backend/src/services/deploy/githubPagesDeployer.js
+++ b/backend/src/services/deploy/githubPagesDeployer.js
@@ -1,0 +1,284 @@
+const GITHUB_API = 'https://api.github.com';
+
+// Topic used as a safety marker so deleteDeployment never touches non-portfolio repos.
+const PORTFOLIO_TOPIC = 'career-pilot-portfolio';
+
+const MAX_REPO_NAME_LENGTH = 100;
+
+// GitHub names allow alphanumeric, hyphens, underscores, and dots.
+// Must start with alphanumeric to prevent hidden-file-style path segments.
+function assertSafeSegment(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(value)) {
+    throw new Error(
+      `${label} contains invalid characters or starts with a non-alphanumeric character. ` +
+      `Use only letters, numbers, hyphens, underscores, and dots.`
+    );
+  }
+}
+
+function githubHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+async function githubRequest(method, path, body, token) {
+  const res = await fetch(`${GITHUB_API}${path}`, {
+    method,
+    headers: githubHeaders(token),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  // 204 No Content (e.g. DELETE, some PATCHes)
+  if (res.status === 204) return null;
+
+  const text = await res.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = { message: text };
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status} on ${method} ${path}: ${data.message || text}`);
+  }
+
+  return data;
+}
+
+function toRepoSlug(raw) {
+  return (
+    raw
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, MAX_REPO_NAME_LENGTH) || 'portfolio'
+  );
+}
+
+/**
+ * Deploy an HTML portfolio to GitHub Pages using the Git Tree API.
+ * All files are committed in a single batch — no per-file API calls.
+ *
+ * @param {string} portfolioId  - Stable identifier used to name/find the deployment repo
+ * @param {string} htmlContent  - Full HTML string for index.html
+ * @param {Object} assets       - Map of relative path → string/Buffer content, e.g. { 'style.css': '...' }
+ * @param {string} [repoName]   - Desired repo name slug (auto-generated if omitted)
+ * @param {string} token        - GitHub OAuth token (user must supply their own — never stored)
+ * @returns {Promise<{ url: string, owner: string, repo: string, commitSha: string }>}
+ */
+export async function deploy(portfolioId, htmlContent, assets = {}, repoName, token) {
+  if (!token) throw new Error('A GitHub OAuth token is required.');
+  assertSafeSegment(portfolioId, 'portfolioId');
+
+  // Resolve the authenticated user's login — token is used only for GitHub API calls.
+  const user = await githubRequest('GET', '/user', undefined, token);
+  if (!user?.login) {
+    throw new Error('Could not resolve GitHub username from the provided token.');
+  }
+  const owner = user.login;
+
+  const slug = repoName
+    ? toRepoSlug(repoName)
+    : toRepoSlug(`portfolio-${portfolioId}`);
+
+  // Determine whether the portfolio repo already exists
+  let repoExists = false;
+  try {
+    await githubRequest('GET', `/repos/${owner}/${slug}`, undefined, token);
+    repoExists = true;
+  } catch (err) {
+    if (!err.message.includes('404')) throw err;
+  }
+
+  if (!repoExists) {
+    await githubRequest('POST', '/user/repos', {
+      name: slug,
+      description: 'Portfolio deployed via Career Pilot',
+      private: false,
+      auto_init: false, // We create the first commit ourselves via the Tree API
+    }, token);
+
+    // GitHub's create-repo endpoint does not accept topics — set them separately.
+    // This topic is the safety guard that allows deleteDeployment to identify our repos.
+    try {
+      await githubRequest('PUT', `/repos/${owner}/${slug}/topics`, {
+        names: [PORTFOLIO_TOPIC],
+      }, token);
+    } catch {
+      console.warn(
+        `[githubPagesDeployer] Could not tag ${owner}/${slug} with topic "${PORTFOLIO_TOPIC}". ` +
+        `deleteDeployment will refuse to remove this repo until the topic is set manually.`
+      );
+    }
+  }
+
+  // Build normalised file map — Git tree paths must NOT start with /
+  const fileMap = {
+    'index.html': Buffer.isBuffer(htmlContent) ? htmlContent : Buffer.from(htmlContent, 'utf8'),
+  };
+  for (const [path, content] of Object.entries(assets)) {
+    const normalised = path.startsWith('/') ? path.slice(1) : path;
+    fileMap[normalised] = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+  }
+
+  // Create all blobs in parallel; base64 encoding handles both text and binary files.
+  const treeEntries = await Promise.all(
+    Object.entries(fileMap).map(async ([filePath, buf]) => {
+      const blob = await githubRequest(
+        'POST',
+        `/repos/${owner}/${slug}/git/blobs`,
+        { content: buf.toString('base64'), encoding: 'base64' },
+        token
+      );
+      return { path: filePath, sha: blob.sha, mode: '100644', type: 'blob' };
+    })
+  );
+
+  // Resolve the current HEAD so we can build on top of existing history
+  let baseTreeSha;
+  let parentShas = [];
+
+  if (repoExists) {
+    try {
+      const ref = await githubRequest(
+        'GET',
+        `/repos/${owner}/${slug}/git/ref/heads/main`,
+        undefined,
+        token
+      );
+      const parentCommit = await githubRequest(
+        'GET',
+        `/repos/${owner}/${slug}/git/commits/${ref.object.sha}`,
+        undefined,
+        token
+      );
+      parentShas = [ref.object.sha];
+      baseTreeSha = parentCommit.tree.sha;
+    } catch {
+      // Repo exists but main branch has no commits yet (edge case: interrupted prior deploy)
+    }
+  }
+
+  // Single-batch tree commit
+  const tree = await githubRequest(
+    'POST',
+    `/repos/${owner}/${slug}/git/trees`,
+    {
+      tree: treeEntries,
+      ...(baseTreeSha && { base_tree: baseTreeSha }),
+    },
+    token
+  );
+
+  const commit = await githubRequest(
+    'POST',
+    `/repos/${owner}/${slug}/git/commits`,
+    {
+      message: 'Deploy portfolio via Career Pilot',
+      tree: tree.sha,
+      ...(parentShas.length > 0 && { parents: parentShas }),
+    },
+    token
+  );
+
+  if (parentShas.length === 0) {
+    // New repo: main branch ref doesn't exist yet — create it
+    await githubRequest('POST', `/repos/${owner}/${slug}/git/refs`, {
+      ref: 'refs/heads/main',
+      sha: commit.sha,
+    }, token);
+  } else {
+    // force: true so the branch always reflects the latest deployed state
+    await githubRequest('PATCH', `/repos/${owner}/${slug}/git/refs/heads/main`, {
+      sha: commit.sha,
+      force: true,
+    }, token);
+  }
+
+  // Enable Pages (409 = already enabled — not an error)
+  await enablePages(owner, slug, token);
+
+  // Standard Pages URL; the special <owner>.github.io repo has no subpath.
+  const pagesUrl =
+    slug === `${owner}.github.io`
+      ? `https://${owner}.github.io`
+      : `https://${owner}.github.io/${slug}`;
+
+  return { url: pagesUrl, owner, repo: slug, commitSha: commit.sha };
+}
+
+async function enablePages(owner, repo, token) {
+  const res = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/pages`, {
+    method: 'POST',
+    headers: githubHeaders(token),
+    body: JSON.stringify({ source: { branch: 'main', path: '/' } }),
+  });
+
+  // 201 = created, 409 = already enabled — both are acceptable outcomes
+  if (res.status === 201 || res.status === 204 || res.status === 409) return;
+
+  const text = await res.text();
+  let data;
+  try { data = JSON.parse(text); } catch { data = { message: text }; }
+  throw new Error(`Failed to enable GitHub Pages ${res.status}: ${data.message || text}`);
+}
+
+/**
+ * Get the GitHub Pages deployment status for a repository.
+ *
+ * @param {string} owner - GitHub username or organisation
+ * @param {string} repo  - Repository name
+ * @param {string} token - GitHub OAuth token
+ * @returns {Promise<{ status: string, url: string|null, custom_domain: string|null }>}
+ */
+export async function getDeploymentStatus(owner, repo, token) {
+  assertSafeSegment(owner, 'owner');
+  assertSafeSegment(repo, 'repo');
+  if (!token) throw new Error('A GitHub OAuth token is required.');
+
+  const pages = await githubRequest('GET', `/repos/${owner}/${repo}/pages`, undefined, token);
+
+  return {
+    status: pages.status ?? 'unknown',
+    url: pages.html_url ?? null,
+    custom_domain: pages.custom_domain ?? null,
+  };
+}
+
+/**
+ * Delete a portfolio repository.
+ *
+ * Safety: only deletes repos tagged with the "career-pilot-portfolio" topic —
+ * prevents accidental deletion of any repo the user didn't create through this service.
+ *
+ * @param {string} owner - GitHub username or organisation
+ * @param {string} repo  - Repository name
+ * @param {string} token - GitHub OAuth token
+ * @returns {Promise<void>}
+ */
+export async function deleteDeployment(owner, repo, token) {
+  assertSafeSegment(owner, 'owner');
+  assertSafeSegment(repo, 'repo');
+  if (!token) throw new Error('A GitHub OAuth token is required.');
+
+  const repoData = await githubRequest('GET', `/repos/${owner}/${repo}`, undefined, token);
+  const topics = repoData.topics ?? [];
+
+  if (!topics.includes(PORTFOLIO_TOPIC)) {
+    throw new Error(
+      `Repository "${owner}/${repo}" is not tagged as a Career Pilot portfolio and will not be deleted. ` +
+      `Only repositories with the topic "${PORTFOLIO_TOPIC}" can be removed via this service.`
+    );
+  }
+
+  await githubRequest('DELETE', `/repos/${owner}/${repo}`, undefined, token);
+}

--- a/backend/src/services/deploy/githubPagesDeployer.js
+++ b/backend/src/services/deploy/githubPagesDeployer.js
@@ -163,8 +163,11 @@ export async function deploy(portfolioId, htmlContent, assets = {}, repoName, to
       );
       parentShas = [ref.object.sha];
       baseTreeSha = parentCommit.tree.sha;
-    } catch {
-      // Repo exists but main branch has no commits yet (edge case: interrupted prior deploy)
+    } catch (err) {
+      // Only swallow 404 — main branch doesn't exist yet on this repo.
+      // Any other failure (rate limit, network error) must propagate so
+      // we don't incorrectly fall through to POST /git/refs on an existing branch.
+      if (!err.message.includes('404')) throw err;
     }
   }
 

--- a/backend/src/services/deploy/netlifyDeployer.js
+++ b/backend/src/services/deploy/netlifyDeployer.js
@@ -1,0 +1,162 @@
+import crypto from 'crypto';
+
+const NETLIFY_API = 'https://api.netlify.com/api/v1';
+
+function getToken(token) {
+  const resolved = token || process.env.NETLIFY_ACCESS_TOKEN;
+  if (!resolved) {
+    throw new Error('A Netlify access token is required. Pass it as a parameter or set NETLIFY_ACCESS_TOKEN in your environment.');
+  }
+  return resolved;
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function netlifyRequest(method, path, body, token) {
+  const res = await fetch(`${NETLIFY_API}${path}`, {
+    method,
+    headers: authHeaders(token),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await res.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = { message: text };
+  }
+
+  if (!res.ok) {
+    throw new Error(`Netlify API error ${res.status}: ${data.message || text}`);
+  }
+
+  return data;
+}
+
+function sha1(content) {
+  return crypto.createHash('sha1').update(content).digest('hex');
+}
+
+/**
+ * Deploy an HTML portfolio to Netlify using the file-digest method.
+ *
+ * @param {string} portfolioId  - Stable identifier used to find an existing site
+ * @param {string} htmlContent  - Full HTML string for index.html
+ * @param {Object} assets       - Map of relative path → string/Buffer content, e.g. { 'style.css': '...' }
+ * @param {string} [siteName]   - Desired Netlify subdomain (auto-generated if omitted)
+ * @param {string} [token]      - Netlify personal access token (falls back to NETLIFY_ACCESS_TOKEN)
+ * @returns {Promise<{ url: string, siteId: string, deployId: string }>}
+ */
+export async function deploy(portfolioId, htmlContent, assets = {}, siteName, token) {
+  const resolvedToken = getToken(token);
+
+  // Build file map: path → Buffer
+  const files = {
+    '/index.html': Buffer.isBuffer(htmlContent) ? htmlContent : Buffer.from(htmlContent, 'utf8'),
+  };
+  for (const [path, content] of Object.entries(assets)) {
+    const normalised = path.startsWith('/') ? path : `/${path}`;
+    files[normalised] = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+  }
+
+  // Compute SHA1 digest for every file
+  const digestMap = {};
+  for (const [path, buf] of Object.entries(files)) {
+    digestMap[path] = sha1(buf);
+  }
+
+  // Find or create the Netlify site for this portfolioId
+  let siteId;
+  const allSites = await netlifyRequest('GET', '/sites?per_page=100', undefined, resolvedToken);
+  const existing = allSites.find((s) => s.name && s.name.startsWith(`career-pilot-${portfolioId}`));
+
+  if (existing) {
+    siteId = existing.id;
+  } else {
+    const nameSlug = siteName
+      ? siteName.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+      : `career-pilot-${portfolioId.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+
+    const newSite = await netlifyRequest('POST', '/sites', { name: nameSlug }, resolvedToken);
+    siteId = newSite.id;
+  }
+
+  // Create a deploy with file digests; Netlify responds with which files are missing
+  const deployPayload = { files: digestMap, async: false };
+  const deployResult = await netlifyRequest('POST', `/sites/${siteId}/deploys`, deployPayload, resolvedToken);
+  const deployId = deployResult.id;
+
+  // Upload only the files Netlify says are missing
+  const required = deployResult.required || [];
+  for (const hash of required) {
+    const entry = Object.entries(digestMap).find(([, h]) => h === hash);
+    if (!entry) continue;
+
+    const [filePath, fileHash] = entry;
+    const fileBuffer = files[filePath];
+
+    const uploadRes = await fetch(`${NETLIFY_API}/deploys/${deployId}/files${filePath}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${resolvedToken}`,
+        'Content-Type': 'application/octet-stream',
+      },
+      body: fileBuffer,
+    });
+
+    if (!uploadRes.ok) {
+      const errText = await uploadRes.text();
+      throw new Error(`Failed to upload ${filePath} (${fileHash}): ${errText}`);
+    }
+  }
+
+  // Poll until the deploy is ready (max 60 s)
+  const url = await waitForDeploy(deployId, resolvedToken);
+
+  return { url, siteId, deployId };
+}
+
+async function waitForDeploy(deployId, token, maxWaitMs = 60_000, intervalMs = 3_000) {
+  const deadline = Date.now() + maxWaitMs;
+
+  while (Date.now() < deadline) {
+    const status = await netlifyRequest('GET', `/deploys/${deployId}`, undefined, token);
+
+    if (status.state === 'ready') {
+      return `https://${status.ssl_url ? status.ssl_url.replace(/^https?:\/\//, '') : status.url.replace(/^https?:\/\//, '')}`;
+    }
+
+    if (status.state === 'error') {
+      throw new Error(`Deploy ${deployId} failed: ${status.error_message || 'unknown error'}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`Deploy ${deployId} did not become ready within ${maxWaitMs / 1000}s`);
+}
+
+/**
+ * Get the current deployment status for a Netlify site.
+ *
+ * @param {string} siteId  - Netlify site ID
+ * @param {string} [token] - Netlify personal access token (falls back to NETLIFY_ACCESS_TOKEN)
+ * @returns {Promise<{ state: string, url: string, sslUrl: string, publishedAt: string|null }>}
+ */
+export async function getDeploymentStatus(siteId, token) {
+  const resolvedToken = getToken(token);
+  const site = await netlifyRequest('GET', `/sites/${siteId}`, undefined, resolvedToken);
+
+  return {
+    state: site.published_deploy?.state ?? 'unknown',
+    url: site.url ?? null,
+    sslUrl: site.ssl_url ?? null,
+    publishedAt: site.published_deploy?.published_at ?? null,
+  };
+}

--- a/backend/src/services/deploy/netlifyDeployer.js
+++ b/backend/src/services/deploy/netlifyDeployer.js
@@ -2,12 +2,27 @@ import crypto from 'crypto';
 
 const NETLIFY_API = 'https://api.netlify.com/api/v1';
 
+// Netlify enforces a 63-character limit on site name slugs (DNS label rules).
+const MAX_SITE_NAME_LENGTH = 63;
+
 function getToken(token) {
   const resolved = token || process.env.NETLIFY_ACCESS_TOKEN;
   if (!resolved) {
-    throw new Error('A Netlify access token is required. Pass it as a parameter or set NETLIFY_ACCESS_TOKEN in your environment.');
+    throw new Error(
+      'A Netlify access token is required. Pass it as a parameter or set NETLIFY_ACCESS_TOKEN in your environment.'
+    );
   }
   return resolved;
+}
+
+function assertSafeId(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  // Only allow alphanumeric, hyphens, and underscores — prevents path traversal in URL segments.
+  if (!/^[a-zA-Z0-9_-]+$/.test(value)) {
+    throw new Error(`${label} contains invalid characters. Use only letters, numbers, hyphens, and underscores.`);
+  }
 }
 
 function authHeaders(token) {
@@ -43,6 +58,13 @@ function sha1(content) {
   return crypto.createHash('sha1').update(content).digest('hex');
 }
 
+function toSiteNameSlug(raw) {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .slice(0, MAX_SITE_NAME_LENGTH);
+}
+
 /**
  * Deploy an HTML portfolio to Netlify using the file-digest method.
  *
@@ -54,6 +76,7 @@ function sha1(content) {
  * @returns {Promise<{ url: string, siteId: string, deployId: string }>}
  */
 export async function deploy(portfolioId, htmlContent, assets = {}, siteName, token) {
+  assertSafeId(portfolioId, 'portfolioId');
   const resolvedToken = getToken(token);
 
   // Build file map: path → Buffer
@@ -74,49 +97,64 @@ export async function deploy(portfolioId, htmlContent, assets = {}, siteName, to
   // Find or create the Netlify site for this portfolioId
   let siteId;
   const allSites = await netlifyRequest('GET', '/sites?per_page=100', undefined, resolvedToken);
-  const existing = allSites.find((s) => s.name && s.name.startsWith(`career-pilot-${portfolioId}`));
+
+  if (!Array.isArray(allSites)) {
+    throw new Error('Unexpected response from Netlify when listing sites. Check your access token and try again.');
+  }
+
+  const prefix = `career-pilot-${portfolioId}`;
+  const existing = allSites.find((s) => s.name && s.name.startsWith(prefix));
 
   if (existing) {
     siteId = existing.id;
   } else {
     const nameSlug = siteName
-      ? siteName.toLowerCase().replace(/[^a-z0-9-]/g, '-')
-      : `career-pilot-${portfolioId.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+      ? toSiteNameSlug(siteName)
+      : toSiteNameSlug(`career-pilot-${portfolioId}`);
 
     const newSite = await netlifyRequest('POST', '/sites', { name: nameSlug }, resolvedToken);
     siteId = newSite.id;
   }
 
   // Create a deploy with file digests; Netlify responds with which files are missing
-  const deployPayload = { files: digestMap, async: false };
-  const deployResult = await netlifyRequest('POST', `/sites/${siteId}/deploys`, deployPayload, resolvedToken);
+  const deployResult = await netlifyRequest(
+    'POST',
+    `/sites/${siteId}/deploys`,
+    { files: digestMap },
+    resolvedToken
+  );
   const deployId = deployResult.id;
 
-  // Upload only the files Netlify says are missing
-  const required = deployResult.required || [];
-  for (const hash of required) {
-    const entry = Object.entries(digestMap).find(([, h]) => h === hash);
-    if (!entry) continue;
-
-    const [filePath, fileHash] = entry;
-    const fileBuffer = files[filePath];
-
-    const uploadRes = await fetch(`${NETLIFY_API}/deploys/${deployId}/files${filePath}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${resolvedToken}`,
-        'Content-Type': 'application/octet-stream',
-      },
-      body: fileBuffer,
-    });
-
-    if (!uploadRes.ok) {
-      const errText = await uploadRes.text();
-      throw new Error(`Failed to upload ${filePath} (${fileHash}): ${errText}`);
-    }
+  // Build a reverse map: hash → filePath for O(1) lookup during upload
+  const hashToPath = {};
+  for (const [path, hash] of Object.entries(digestMap)) {
+    hashToPath[hash] = path;
   }
 
-  // Poll until the deploy is ready (max 60 s)
+  // Upload all missing files in parallel
+  const required = deployResult.required || [];
+  await Promise.all(
+    required.map(async (hash) => {
+      const filePath = hashToPath[hash];
+      if (!filePath) return;
+
+      const fileBuffer = files[filePath];
+      const uploadRes = await fetch(`${NETLIFY_API}/deploys/${deployId}/files${filePath}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${resolvedToken}`,
+          'Content-Type': 'application/octet-stream',
+        },
+        body: fileBuffer,
+      });
+
+      if (!uploadRes.ok) {
+        const errText = await uploadRes.text();
+        throw new Error(`Failed to upload ${filePath}: ${errText}`);
+      }
+    })
+  );
+
   const url = await waitForDeploy(deployId, resolvedToken);
 
   return { url, siteId, deployId };
@@ -129,7 +167,12 @@ async function waitForDeploy(deployId, token, maxWaitMs = 60_000, intervalMs = 3
     const status = await netlifyRequest('GET', `/deploys/${deployId}`, undefined, token);
 
     if (status.state === 'ready') {
-      return `https://${status.ssl_url ? status.ssl_url.replace(/^https?:\/\//, '') : status.url.replace(/^https?:\/\//, '')}`;
+      // ssl_url and url both include the protocol; prefer HTTPS.
+      const rawUrl = status.ssl_url || status.url;
+      if (!rawUrl) {
+        throw new Error(`Deploy ${deployId} is ready but no URL was returned by Netlify.`);
+      }
+      return rawUrl.startsWith('https://') ? rawUrl : `https://${rawUrl.replace(/^https?:\/\//, '')}`;
     }
 
     if (status.state === 'error') {
@@ -147,9 +190,10 @@ async function waitForDeploy(deployId, token, maxWaitMs = 60_000, intervalMs = 3
  *
  * @param {string} siteId  - Netlify site ID
  * @param {string} [token] - Netlify personal access token (falls back to NETLIFY_ACCESS_TOKEN)
- * @returns {Promise<{ state: string, url: string, sslUrl: string, publishedAt: string|null }>}
+ * @returns {Promise<{ state: string, url: string|null, sslUrl: string|null, publishedAt: string|null }>}
  */
 export async function getDeploymentStatus(siteId, token) {
+  assertSafeId(siteId, 'siteId');
   const resolvedToken = getToken(token);
   const site = await netlifyRequest('GET', `/sites/${siteId}`, undefined, resolvedToken);
 


### PR DESCRIPTION
Closes #686

  ## What's changed

  - `backend/src/services/deploy/githubPagesDeployer.js` — new service using
    native `fetch` (zero new dependencies)
  - `backend/.env.example` — added `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`
    for the OAuth app that issues user tokens

  ## Implementation details

  ### `deploy(portfolioId, htmlContent, assets, repoName?, token)`
  1. Validates `portfolioId` — rejects path-traversal characters before touching any URL
  2. Resolves caller's GitHub username via `GET /user`
  3. Checks if portfolio repo already exists (`GET /repos/:owner/:repo`)
  4. Creates repo with `POST /user/repos` if absent (`auto_init: false`)
  5. Sets `career-pilot-portfolio` topic via separate `PUT /repos/:owner/:repo/topics`
     (GitHub's create-repo endpoint does not accept topics)
  6. Creates all file blobs in **parallel** via `Promise.all` with base64 encoding
     (handles text and binary assets identically)
  7. Resolves current HEAD to build on top of existing history
  8. Commits all files in a **single batch** via the Git Tree API — no per-file calls
  9. Creates `refs/heads/main` for new repos; force-updates it for re-deploys
  10. Enables GitHub Pages via `POST /repos/:owner/:repo/pages`
      (409 = already enabled — treated as success, not an error)
  11. Returns `{ url, owner, repo, commitSha }`

  ### `getDeploymentStatus(owner, repo, token)`
  Calls `GET /repos/:owner/:repo/pages` and returns
  `{ status, url, custom_domain }`.

  ### `deleteDeployment(owner, repo, token)`
  Fetches repo topics first. Refuses to delete any repo that does not carry the
  accidentally removed.
  
  ### Token handling
  Token is always caller-supplied and used **only** for GitHub API calls.
  Never stored, logged, or forwarded anywhere else.
 
  ## Test plan
  - [ ] `deploy()` with a valid token creates a new repo and returns
        `https://<owner>.github.io/<repo>`
  - [ ] Re-deploying with the same `portfolioId` updates the existing repo
        (new commit on main — no duplicate repo created)
  - [ ] Re-deploying with unchanged files still succeeds (idempotent)
  - [ ] `getDeploymentStatus()` returns correct `status` and `url`
  - [ ] `deleteDeployment()` removes a correctly tagged repo
  - [ ] `deleteDeployment()` throws when the `career-pilot-portfolio` topic is absent
  - [ ] Passing a `portfolioId` with path-traversal characters throws immediately
  - [ ] Calling any function without a token throws a clear error message