### PR TITLE
Remove redundant keyboard handlers from FAB buttons

### DIFF
--- a/frontend/src/components/FAB.jsx
+++ b/frontend/src/components/FAB.jsx
@@ -85,11 +85,6 @@ export default function FAB({ scrollContainerRef }) {
               animate={{ scale: 1 }}
               exit={{ scale: 0 }}
               onClick={() => setIsOpen(!isOpen)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  setIsOpen(!isOpen);
-                }
-              }}
               aria-label={
                 isOpen ? "Close quick actions" : "Open quick actions"
               }
@@ -117,11 +112,6 @@ export default function FAB({ scrollContainerRef }) {
                     tabIndex={0}
                     aria-label={action.label}
                     onClick={() => action.onClick?.()}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        action.onClick?.();
-                      }
-                    }}
                     className="flex items-center gap-3 px-4 py-2 bg-background border border-border rounded-full shadow-md hover:bg-muted transition-colors whitespace-nowrap"
                   >
                     {action.icon}


### PR DESCRIPTION
fixed as per coderabbit recommendation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified keyboard interaction handling in the FAB component's menu toggle and action items. The component now relies on standard button semantics for keyboard support instead of custom key handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->