### PR TITLE
feat: add portfolio performance scorer Lighthouse-lite (#823)

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -4,6 +4,8 @@ import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import { enhanceSection } from '../services/ai/portfolioContentEnhancer.js';
 import { generateRobotsTxt, generateSitemapXml } from '../utils/sitemapGenerator.js';
+import { scorePortfolioPerformance } from '../services/portfolioPerformanceScorer.js';
+
 
 const router = express.Router();
 
@@ -111,6 +113,32 @@ router.get('/public/:slug/robots.txt', asyncHandler(async (req, res) => {
     .status(200)
     .type('text/plain')
     .send(generateRobotsTxt({ sitemapUrl }));
+}));
+
+/**
+ * GET /api/portfolio/:id/performance
+ * Lighthouse-lite performance scorer for portfolio
+ */
+router.get('/:id/performance', verifyToken, asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  if (!id || id.trim() === '') {
+    throw new ApiError(400, 'Portfolio ID is required.');
+  }
+
+  const portfolioData = req.body;
+
+  if (!portfolioData || Object.keys(portfolioData).length === 0) {
+    throw new ApiError(400, 'Portfolio performance metrics are required in request body.');
+  }
+
+  const result = scorePortfolioPerformance({ id, ...portfolioData });
+
+  return res.status(200).json({
+    success: true,
+    message: 'Portfolio performance analysis complete.',
+    data: result,
+  });
 }));
 
 export default router;

--- a/backend/src/services/portfolioPerformanceScorer.js
+++ b/backend/src/services/portfolioPerformanceScorer.js
@@ -1,0 +1,198 @@
+/**
+ * Portfolio Performance Scorer (Lighthouse-lite)
+ * Analyzes portfolio content for performance metrics without using actual Lighthouse
+ */
+
+// Scoring weights (must sum to 100)
+const WEIGHTS = {
+  htmlSize: 20,
+  cssSize: 20,
+  imageSize: 20,
+  externalRequests: 15,
+  cssComplexity: 15,
+  fontStrategy: 10,
+};
+
+// Targets
+const TARGETS = {
+  htmlSizeKB: 50,       // < 50KB
+  cssSizeKB: 20,        // < 20KB
+  imageSizeMB: 1,       // < 1MB total
+  externalRequests: 10, // < 10 external requests
+  cssSelectors: 500,    // < 500 selectors
+};
+
+/**
+ * Score HTML size (0-100)
+ * Target: < 50KB
+ */
+const scoreHtmlSize = (htmlSizeKB) => {
+  if (htmlSizeKB <= TARGETS.htmlSizeKB) return 100;
+  if (htmlSizeKB <= 100) return Math.round(100 - ((htmlSizeKB - 50) / 50) * 50);
+  if (htmlSizeKB <= 200) return Math.round(50 - ((htmlSizeKB - 100) / 100) * 40);
+  return 10;
+};
+
+/**
+ * Score CSS size (0-100)
+ * Target: < 20KB
+ */
+const scoreCssSize = (cssSizeKB) => {
+  if (cssSizeKB <= TARGETS.cssSizeKB) return 100;
+  if (cssSizeKB <= 50) return Math.round(100 - ((cssSizeKB - 20) / 30) * 50);
+  if (cssSizeKB <= 100) return Math.round(50 - ((cssSizeKB - 50) / 50) * 40);
+  return 10;
+};
+
+/**
+ * Score total image size (0-100)
+ * Target: < 1MB
+ */
+const scoreImageSize = (imageSizeMB) => {
+  if (imageSizeMB <= TARGETS.imageSizeMB) return 100;
+  if (imageSizeMB <= 3) return Math.round(100 - ((imageSizeMB - 1) / 2) * 60);
+  if (imageSizeMB <= 5) return Math.round(40 - ((imageSizeMB - 3) / 2) * 30);
+  return 10;
+};
+
+/**
+ * Score external requests (0-100)
+ * Target: < 10 requests
+ */
+const scoreExternalRequests = (count) => {
+  if (count <= TARGETS.externalRequests) return 100;
+  if (count <= 20) return Math.round(100 - ((count - 10) / 10) * 50);
+  if (count <= 40) return Math.round(50 - ((count - 20) / 20) * 40);
+  return 10;
+};
+
+/**
+ * Score CSS complexity (0-100)
+ * Target: < 500 selectors
+ */
+const scoreCssComplexity = (selectorCount) => {
+  if (selectorCount <= TARGETS.cssSelectors) return 100;
+  if (selectorCount <= 1000) return Math.round(100 - ((selectorCount - 500) / 500) * 50);
+  if (selectorCount <= 2000) return Math.round(50 - ((selectorCount - 1000) / 1000) * 40);
+  return 10;
+};
+
+/**
+ * Score font loading strategy (0-100)
+ * Based on strategy type
+ */
+const scoreFontStrategy = (strategy) => {
+  const strategies = {
+    'preload': 100,
+    'swap': 85,
+    'system': 100,
+    'variable': 95,
+    'none': 60,
+    'blocking': 20,
+    'unknown': 50,
+  };
+  return strategies[strategy?.toLowerCase()] ?? 50;
+};
+
+/**
+ * Calculate weighted overall score
+ */
+const calculateOverallScore = (scores) => {
+  return Math.round(
+    (scores.htmlSize * WEIGHTS.htmlSize +
+    scores.cssSize * WEIGHTS.cssSize +
+    scores.imageSize * WEIGHTS.imageSize +
+    scores.externalRequests * WEIGHTS.externalRequests +
+    scores.cssComplexity * WEIGHTS.cssComplexity +
+    scores.fontStrategy * WEIGHTS.fontStrategy) / 100
+  );
+};
+
+/**
+ * Generate actionable suggestions based on scores
+ */
+const generateSuggestions = (scores, metrics) => {
+  const suggestions = [];
+
+  if (scores.htmlSize < 80) {
+    suggestions.push(`HTML size is ${metrics.htmlSizeKB}KB — minify HTML and remove unused markup to get under ${TARGETS.htmlSizeKB}KB.`);
+  }
+  if (scores.cssSize < 80) {
+    suggestions.push(`CSS size is ${metrics.cssSizeKB}KB — use PurgeCSS or remove unused styles to get under ${TARGETS.cssSizeKB}KB.`);
+  }
+  if (scores.imageSize < 80) {
+    suggestions.push(`Total image size is ${metrics.imageSizeMB.toFixed(2)}MB — compress images using WebP format and lazy loading.`);
+  }
+  if (scores.externalRequests < 80) {
+    suggestions.push(`${metrics.externalRequests} external requests detected — bundle dependencies and reduce third-party scripts.`);
+  }
+  if (scores.cssComplexity < 80) {
+    suggestions.push(`${metrics.cssSelectors} CSS selectors found — simplify selectors and remove redundant rules.`);
+  }
+  if (scores.fontStrategy < 80) {
+    suggestions.push(`Font loading strategy "${metrics.fontStrategy}" is suboptimal — use font-display: swap or preload key fonts.`);
+  }
+  if (suggestions.length === 0) {
+    suggestions.push('Great job! Your portfolio is well optimized. Consider adding resource hints (preconnect, prefetch) for further gains.');
+  }
+
+  return suggestions;
+};
+
+/**
+ * Get performance grade from score
+ */
+const getGrade = (score) => {
+  if (score >= 90) return 'A+';
+  if (score >= 80) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 60) return 'C';
+  if (score >= 50) return 'D';
+  return 'F';
+};
+
+/**
+ * Main scorer function
+ * @param {object} portfolioData - Portfolio performance metrics
+ * @returns {object} - Scores, grade, suggestions
+ */
+export const scorePortfolioPerformance = (portfolioData) => {
+  if (!portfolioData || typeof portfolioData !== 'object' || Array.isArray(portfolioData)) {
+    throw new Error('portfolioData must be a non-null object');
+  }
+
+  // Extract metrics with safe defaults
+  const metrics = {
+    htmlSizeKB: Number(portfolioData.htmlSizeKB) || 0,
+    cssSizeKB: Number(portfolioData.cssSizeKB) || 0,
+    imageSizeMB: Number(portfolioData.imageSizeMB) || 0,
+    externalRequests: Number(portfolioData.externalRequests) || 0,
+    cssSelectors: Number(portfolioData.cssSelectors) || 0,
+    fontStrategy: portfolioData.fontStrategy || 'unknown',
+  };
+
+  // Calculate individual scores
+  const scores = {
+    htmlSize: scoreHtmlSize(metrics.htmlSizeKB),
+    cssSize: scoreCssSize(metrics.cssSizeKB),
+    imageSize: scoreImageSize(metrics.imageSizeMB),
+    externalRequests: scoreExternalRequests(metrics.externalRequests),
+    cssComplexity: scoreCssComplexity(metrics.cssSelectors),
+    fontStrategy: scoreFontStrategy(metrics.fontStrategy),
+  };
+
+  const overall = calculateOverallScore(scores);
+  const grade = getGrade(overall);
+  const suggestions = generateSuggestions(scores, metrics);
+
+  return {
+    portfolioId: portfolioData.id || null,
+    analyzedAt: new Date().toISOString(),
+    overall,
+    grade,
+    scores,
+    metrics,
+    targets: TARGETS,
+    suggestions,
+  };
+};


### PR DESCRIPTION
Fixes #823

Changes:
- Created backend/src/services/portfolioPerformanceScorer.js
- Added GET /api/portfolio/:id/performance endpoint

Metrics scored (0-100 each):
- HTML size (target: < 50KB) — weight 20%
- CSS size (target: < 20KB) — weight 20%
- Total image size (target: < 1MB) — weight 20%
- External requests (target: < 10) — weight 15%
- CSS complexity/selectors (target: < 500) — weight 15%
- Font loading strategy — weight 10%

Features:
- Weighted overall score (0-100) + letter grade (A+ to F)
- Actionable suggestions per failing metric
- Does NOT use actual Lighthouse as required
- Pure JavaScript scorer — lightweight and fast

Tested: Route confirmed working via curl.
Screenshots: N/A - Backend service, no UI changes.