### PR TITLE
feat: add portfolio showcase section to landing page

### DIFF
--- a/frontend/src/components/ui/PortfolioShowcaseSection.jsx
+++ b/frontend/src/components/ui/PortfolioShowcaseSection.jsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+
+export default function PortfolioShowcaseSection() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const carouselItems = [
+    {
+      id: 1,
+      name: "Developer Theme",
+      description: "Showcase your projects, repositories, and technical skills in a clean portfolio layout.",
+      skills: ["React", "TypeScript", "Node.js"]
+    },
+    {
+      id: 2,
+      name: "Creative Theme",
+      description: "Display your design work, case studies, and creative projects with a minimalist aesthetic.",
+      skills: ["Figma", "UI/UX", "Design Systems"]
+    },
+    {
+      id: 3,
+      name: "Professional Theme",
+      description: "Highlight your career milestones, industry experience, and professional achievements.",
+      skills: ["Product", "Strategy", "Growth"]
+    }
+  ];
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentIndex((prevIndex) => (prevIndex + 1) % carouselItems.length);
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [carouselItems.length]);
+
+  return (
+    <section className="py-20 bg-zinc-950 relative overflow-hidden">
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <motion.div 
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+          className="text-center max-w-3xl mx-auto mb-16"
+        >
+          {/* Feature Pills */}
+          <div className="flex flex-wrap justify-center gap-3 mb-8">
+            <span className="px-3 py-1 bg-sky-500/10 text-sky-400 text-xs rounded-full border border-sky-500/20 font-medium">
+              One-Click Deploy
+            </span>
+            <span className="px-3 py-1 bg-emerald-500/10 text-emerald-400 text-xs rounded-full border border-emerald-500/20 font-medium">
+              AI Content
+            </span>
+            <span className="px-3 py-1 bg-amber-500/10 text-amber-400 text-xs rounded-full border border-amber-500/20 font-medium">
+              10+ Themes
+            </span>
+          </div>
+
+          <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+            Build Stunning Portfolios in Minutes
+          </h2>
+
+          <p className="text-zinc-400 max-w-xl mx-auto">
+            From Resume, GitHub, or LinkedIn — deployed instantly
+          </p>
+        </motion.div>
+
+        {/* Carousel */}
+        <div className="max-w-xl mx-auto mb-12 relative">
+          <div className="relative w-full h-[220px] overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900/50 p-6 flex flex-col justify-between">
+            {carouselItems.map((item, index) => {
+              const isActive = index === currentIndex;
+              return (
+                <div
+                  key={item.id}
+                  className={`absolute inset-0 p-6 flex flex-col justify-between transition-opacity duration-500 ease-in-out ${
+                    isActive ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+                  }`}
+                >
+                  <div>
+                    <h3 className="text-xl font-semibold text-white mb-2">{item.name}</h3>
+                    <p className="text-zinc-400 text-sm leading-relaxed">
+                      {item.description}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    {item.skills.map((skill) => (
+                      <span
+                        key={skill}
+                        className="px-2.5 py-1 text-xs rounded-full border border-zinc-800 bg-zinc-900 text-zinc-400 font-medium"
+                      >
+                        {skill}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Dot Indicators */}
+          <div className="flex justify-center gap-2 mt-4">
+            {carouselItems.map((_, index) => (
+              <button
+                key={index}
+                onClick={() => setCurrentIndex(index)}
+                aria-label={`Go to slide ${index + 1}`}
+                className={`w-2 h-2 rounded-full transition-all duration-300 ${
+                  index === currentIndex ? "bg-white" : "bg-zinc-800 hover:bg-zinc-700"
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* CTA Button */}
+        <div className="text-center">
+          <Link
+            to="/register"
+            className="group inline-flex items-center justify-center gap-2 px-8 py-4 bg-white text-black font-medium rounded-lg hover:bg-zinc-200 transition-all duration-200"
+          >
+            Build Your Portfolio
+            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import Navbar from '../components/Navbar'
 import HeroSection from '../components/ui/HeroSection'
 import FeaturesSection, { AdditionalFeatures } from '../components/ui/FeaturesSection'
+import PortfolioShowcaseSection from '../components/ui/PortfolioShowcaseSection'
 import HowItWorksSection from '../components/ui/HowItWorksSection'
 import TestimonialsSection from '../components/ui/TestimonialsSection'
 import CTASection from '../components/ui/CTASection'
@@ -27,6 +28,9 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      {/* Portfolio Showcase Section */}
+      <PortfolioShowcaseSection />
 
       {/* How It Works Section */}
       <HowItWorksSection />


### PR DESCRIPTION
## Description

Added a Portfolio Showcase section to the landing page highlighting the portfolio generation feature.

* Includes a simple auto-rotating carousel with theme previews
* Displays key features (One-Click Deploy, AI Content, 10+ Themes)
* Integrated a clear CTA for portfolio creation
* Uses Tailwind and framer-motion consistent with existing UI patterns

The implementation focuses on keeping the design clean, responsive, and aligned with the current codebase.

---

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update

---

## Related Issue

Fixes #752

---

## Testing

* [x] Tested locally

---

## Screenshots

<img width="1311" height="609" alt="image" src="https://github.com/user-attachments/assets/5e4edd0e-7860-45ed-a341-c161deab29d0" />




---

## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [x] No unrelated changes included
