### PR TITLE
Feature: Two-Factor Authentication Backup Codes for Account Recovery

### DIFF
--- a/backend/src/routes/twoFactor.js
+++ b/backend/src/routes/twoFactor.js
@@ -95,4 +95,17 @@ router.post('/backup-codes/regenerate', verifyToken, asyncHandler(async (req, re
   res.json({ success: true, backupCodes: codes });
 }));
 
+// POST /api/auth/2fa/disable-with-backup
+// Allows disabling 2FA using a backup code when authenticator is unavailable.
+router.post('/disable-with-backup', verifyToken, verifyLimiter, asyncHandler(async (req, res) => {
+  const { code } = req.body;
+  if (!code) throw new ApiError(400, 'code is required');
+
+  const ok = await twoFactor.disableTwoFactorWithBackup(req.user.uid, code);
+  if (!ok) throw new ApiError(401, 'Invalid backup code');
+
+  console.log('2FA disabled using backup code for a user');
+  res.json({ success: true });
+}));
+
 export default router;

--- a/backend/src/services/twoFactorService.js
+++ b/backend/src/services/twoFactorService.js
@@ -125,7 +125,7 @@ export const disableTwoFactorWithBackup = async (uid, code) => {
 
   const updated = await TwoFactor.findOneAndUpdate(
     { uid, enabled: true, backupCodes: matchedHash },
-    { $set: { secret: null, enabled: false }, $set: { backupCodes: [] } }
+    { $set: { secret: null, enabled: false, backupCodes: [] } }
   );
   if (!updated) return false;
 

--- a/backend/src/services/twoFactorService.js
+++ b/backend/src/services/twoFactorService.js
@@ -5,7 +5,7 @@ import bcrypt from 'bcryptjs';
 import TwoFactor from '../models/TwoFactor.model.js';
 
 const ALGORITHM = 'aes-256-gcm';
-const BACKUP_CODE_COUNT = 8;
+const BACKUP_CODE_COUNT = 10;
 
 const getKey = () => {
   const key = process.env.TOTP_ENCRYPTION_KEY;
@@ -101,6 +101,34 @@ export const disableTwoFactor = async (uid, token) => {
   record.enabled = false;
   record.backupCodes = [];
   await record.save();
+  return true;
+};
+
+/**
+ * Disable 2FA using a backup code. This is useful when user loses access
+ * to their authenticator app and needs to recover their account.
+ * Returns true on success, false if no matching backup code found.
+ */
+export const disableTwoFactorWithBackup = async (uid, code) => {
+  const record = await TwoFactor.findOne({ uid, enabled: true }).select('+backupCodes');
+  if (!record?.backupCodes?.length) return false;
+
+  const normalised = normaliseCode(code);
+  let matchedHash = null;
+  for (const hash of record.backupCodes) {
+    if (await bcrypt.compare(normalised, hash)) {
+      matchedHash = hash;
+      break;
+    }
+  }
+  if (!matchedHash) return false;
+
+  const updated = await TwoFactor.findOneAndUpdate(
+    { uid, enabled: true, backupCodes: matchedHash },
+    { $set: { secret: null, enabled: false }, $set: { backupCodes: [] } }
+  );
+  if (!updated) return false;
+
   return true;
 };
 

--- a/frontend/src/pages/SecuritySettings.jsx
+++ b/frontend/src/pages/SecuritySettings.jsx
@@ -108,6 +108,9 @@ export default function SecuritySettings() {
   const [disableOpen, setDisableOpen] = useState(false)
   const [disableToken, setDisableToken] = useState('')
   const [disableLoading, setDisableLoading] = useState(false)
+  const [useBackupToDisable, setUseBackupToDisable] = useState(false)
+  const [disableBackupCode, setDisableBackupCode] = useState('')
+  const [disableBackupLoading, setDisableBackupLoading] = useState(false)
 
   // Regenerate confirmation
   const [regenOpen, setRegenOpen] = useState(false)
@@ -184,6 +187,26 @@ export default function SecuritySettings() {
       toast.error(error.message || 'Invalid code — please try again')
     } finally {
       setDisableLoading(false)
+    }
+  }
+
+  const handleDisableWithBackup = async (e) => {
+    e.preventDefault()
+    if (!disableBackupCode.trim()) return
+
+    setDisableBackupLoading(true)
+    try {
+      await twoFactorApi.disableWithBackup(disableBackupCode.trim().toUpperCase())
+      setView('disabled')
+      setDisableOpen(false)
+      setDisableBackupCode('')
+      setNewCodes([])
+      setShowCodesFor(null)
+      toast.success('Two-factor authentication disabled')
+    } catch (error) {
+      toast.error(error.message || 'Invalid backup code')
+    } finally {
+      setDisableBackupLoading(false)
     }
   }
 
@@ -407,7 +430,7 @@ export default function SecuritySettings() {
                   <div>
                     <p className="text-sm text-white font-medium">Backup codes</p>
                     <p className="text-xs text-neutral-500">
-                      {backupCodesRemaining} of 8 codes remaining
+                      {backupCodesRemaining} of 10 codes remaining
                     </p>
                   </div>
                 </div>
@@ -483,33 +506,84 @@ export default function SecuritySettings() {
                 }
               </button>
               {disableOpen && (
-                <form
-                  onSubmit={handleDisable}
-                  className="px-4 pb-4 pt-3 border-t border-red-500/20 bg-red-500/5 space-y-3"
-                >
-                  <p className="text-xs text-red-400/80">
-                    This will remove 2FA protection from your account. Enter your current authenticator code to confirm.
-                  </p>
-                  <Input
-                    type="text"
-                    name="disableToken"
-                    value={disableToken}
-                    onChange={(e) => setDisableToken(e.target.value.replace(/\D/g, '').slice(0, 6))}
-                    placeholder="6-digit code"
-                    className="font-mono tracking-widest text-center"
-                    maxLength={6}
-                  />
-                  <Button
-                    type="submit"
-                    variant="danger"
-                    size="sm"
-                    loading={disableLoading}
-                    disabled={disableToken.length !== 6}
-                  >
-                    <ShieldOff className="w-4 h-4" />
-                    Disable 2FA
-                  </Button>
-                </form>
+                <div className="px-4 pb-4 pt-3 border-t border-red-500/20 bg-red-500/5 space-y-3">
+                  <div className="flex gap-2 mb-3">
+                    <button
+                      type="button"
+                      onClick={() => { setUseBackupToDisable(false); setDisableToken(''); setDisableBackupCode('') }}
+                      className={`flex-1 py-1.5 px-3 rounded-lg text-xs font-medium transition-colors ${
+                        !useBackupToDisable
+                          ? 'bg-red-500/20 text-red-400 border border-red-500/30'
+                          : 'bg-neutral-800 text-neutral-400 border border-neutral-700 hover:bg-neutral-700'
+                      }`}
+                    >
+                      Use Authenticator
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setUseBackupToDisable(true); setDisableToken(''); setDisableBackupCode('') }}
+                      className={`flex-1 py-1.5 px-3 rounded-lg text-xs font-medium transition-colors ${
+                        useBackupToDisable
+                          ? 'bg-red-500/20 text-red-400 border border-red-500/30'
+                          : 'bg-neutral-800 text-neutral-400 border border-neutral-700 hover:bg-neutral-700'
+                      }`}
+                    >
+                      Use Backup Code
+                    </button>
+                  </div>
+
+                  {!useBackupToDisable ? (
+                    <form onSubmit={handleDisable} className="space-y-3">
+                      <p className="text-xs text-red-400/80">
+                        This will remove 2FA protection from your account. Enter your current authenticator code to confirm.
+                      </p>
+                      <Input
+                        type="text"
+                        name="disableToken"
+                        value={disableToken}
+                        onChange={(e) => setDisableToken(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                        placeholder="6-digit code"
+                        className="font-mono tracking-widest text-center"
+                        maxLength={6}
+                      />
+                      <Button
+                        type="submit"
+                        variant="danger"
+                        size="sm"
+                        loading={disableLoading}
+                        disabled={disableToken.length !== 6}
+                      >
+                        <ShieldOff className="w-4 h-4" />
+                        Disable 2FA
+                      </Button>
+                    </form>
+                  ) : (
+                    <form onSubmit={handleDisableWithBackup} className="space-y-3">
+                      <p className="text-xs text-red-400/80">
+                        Lost access to your authenticator? Use a backup code to disable 2FA. This will consume one backup code.
+                      </p>
+                      <Input
+                        type="text"
+                        name="disableBackupCode"
+                        value={disableBackupCode}
+                        onChange={(e) => setDisableBackupCode(e.target.value.toUpperCase().replace(/[^A-F0-9]/g, '').slice(0, 9))}
+                        placeholder="XXXX-XXXX"
+                        className="font-mono tracking-widest text-center"
+                        maxLength={9}
+                      />
+                      <Button
+                        type="submit"
+                        variant="danger"
+                        size="sm"
+                        loading={disableBackupLoading}
+                        disabled={disableBackupCode.replace(/[^A-F0-9]/g, '').length !== 8}
+                      >
+                        <ShieldOff className="w-4 h-4" />
+                        Disable 2FA with Backup Code
+                      </Button>
+                    </form>
+                  )}
+                </div>
               )}
             </div>
           </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1059,6 +1059,16 @@ export const twoFactorApi = {
       body: JSON.stringify({ token })
     })
     return handleResponse(response)
+  },
+
+  async disableWithBackup(code) {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/auth/2fa/disable-with-backup`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ code })
+    })
+    return handleResponse(response)
   }
 }
 


### PR DESCRIPTION
## **User description**
This PR implements two-factor authentication backup codes for account recovery as described in issue #948.

## Changes Made:

### Backend:
- Updated backup code count from 8 to 10
- Added disableTwoFactorWithBackup function for account recovery when user loses authenticator
- Added new endpoint /api/auth/2fa/disable-with-backup with rate limiting

### Frontend:
- Updated SecuritySettings to display 10 codes remaining
- Added option to disable 2FA using a backup code for account recovery
- Added disableWithBackup API method

## Features:
- 10 single-use backup codes generated during 2FA enablement
- Backup codes stored as hashed (never plaintext)
- Generate new backup codes via regenerate endpoint
- Verify backup code during login
- Disable 2FA with backup code for account recovery

Closes #948


___

## **CodeAnt-AI Description**
**Add backup-code recovery for turning off two-factor authentication**

### What Changed
- Two-factor authentication now generates 10 backup codes instead of 8.
- In Security Settings, users can now disable 2FA either with their authenticator code or with a backup code if they lost access to their authenticator app.
- The backup-code flow uses a one-time code and removes 2FA from the account after a successful match.
- The disable-with-backup path was tightened so the account is updated safely when the code is used.

### Impact
`✅ Account recovery without authenticator access`
`✅ Fewer lockouts after losing a phone or authenticator app`
`✅ More backup codes available for 2FA recovery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
