### PR TITLE
Add bandwidth usage estimation endpoint for portfolio templates

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -113,4 +113,40 @@ router.get('/public/:slug/robots.txt', asyncHandler(async (req, res) => {
     .send(generateRobotsTxt({ sitemapUrl }));
 }));
 
+router.get('/:slug/bandwidth', asyncHandler(async (req, res) => {
+  const { slug } = req.params;
+
+  assertValidPortfolioSlug(slug);
+
+  try {
+    await fs.stat(getPortfolioTemplatePath(slug));
+  } catch {
+    throw new ApiError(404, 'Portfolio template not found.');
+  }
+
+  // Placeholder analytics estimation until real tracking is implemented
+  const estimatedPageSizeKB = 500;
+  const monthlyViews = 1200;
+
+  const bandwidthUsageMB =
+    (estimatedPageSizeKB * monthlyViews) / 1024;
+
+  const FREE_TIER_LIMIT_MB = 102400;
+
+  const usagePercentage =
+    (bandwidthUsageMB / FREE_TIER_LIMIT_MB) * 100;
+
+  res.status(200).json({
+    success: true,
+    data: {
+      slug,
+      estimatedPageSizeKB,
+      monthlyViews,
+      bandwidthUsageMB: bandwidthUsageMB.toFixed(2),
+      freeTierLimitMB: FREE_TIER_LIMIT_MB,
+      usagePercentage: usagePercentage.toFixed(2),
+      warning: usagePercentage >= 80,
+    },
+  });
+}));
 export default router;


### PR DESCRIPTION
## Description

Added a lightweight bandwidth usage estimation endpoint for portfolio templates.

### New Endpoint

`GET /api/portfolio/:slug/bandwidth`

### Features

* Estimates bandwidth usage based on page size and monthly views
* Returns usage percentage against free-tier limit
* Includes warning flag for high usage

### Notes

* Uses placeholder estimation values for now
* Designed to support future analytics integration without invasive schema changes

### Example Response

```json id="wn6hql"
{
  "success": true,
  "data": {
    "slug": "vercel-mono",
    "estimatedPageSizeKB": 500,
    "monthlyViews": 1200,
    "bandwidthUsageMB": "585.94",
    "freeTierLimitMB": 102400,
    "usagePercentage": "0.57",
    "warning": false
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio bandwidth monitoring now available. Check estimated bandwidth consumption, including page size metrics, monthly view projections, free tier allocation, and usage alerts when thresholds are exceeded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->