### PR TITLE
feat: add keyboard shortcut badges component

### DIFF
--- a/frontend/src/components/KeyboardShortcut.jsx
+++ b/frontend/src/components/KeyboardShortcut.jsx
@@ -1,0 +1,26 @@
+export default function KeyboardShortcut({ keys = [] }) {
+  const isMac =
+    typeof window !== 'undefined' &&
+    /Mac|iPhone|iPad/.test(navigator.platform)
+
+  return (
+    <div className="hidden md:flex items-center gap-1">
+      {keys.map((key, index) => {
+        let displayKey = key
+
+        if (key === 'Ctrl') {
+          displayKey = isMac ? '⌘' : 'Ctrl'
+        }
+
+        return (
+          <kbd
+            key={index}
+            className="px-2 py-1 text-xs font-medium rounded bg-gray-800 text-gray-200 border border-gray-700"
+          >
+            {displayKey}
+          </kbd>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Added reusable KeyboardShortcut component for displaying keyboard shortcut badges.

## Changes Made

* added reusable KeyboardShortcut component
* supports dynamic shortcut keys via props
* detects macOS for ⌘ key display
* desktop-only visibility
* clean badge UI for shortcuts

fixes #834
