### PR TITLE
security: sanitize portfolio HTML output to prevent XSS (#778)

### DIFF
--- a/backend/src/services/portfolioTemplateEngine.js
+++ b/backend/src/services/portfolioTemplateEngine.js
@@ -1,0 +1,25 @@
+import { sanitizePortfolioHtml, detectThreats } from '../utils/htmlSanitizer.js';
+
+/**
+ * Render and sanitize a portfolio template before serving
+ * @param {string} rawHtml - Raw HTML from template
+ * @param {object} data - Portfolio data to inject
+ * @returns {object} - { html, threats, wasSanitized }
+ */
+export const renderPortfolioTemplate = (rawHtml, data = {}) => {
+  if (typeof rawHtml !== 'string') {
+    throw new TypeError('rawHtml must be a string');
+  }
+
+  // Detect threats before sanitizing
+  const { safe, threats } = detectThreats(rawHtml);
+
+  // Always sanitize regardless
+  const sanitizedHtml = sanitizePortfolioHtml(rawHtml);
+
+  return {
+    html: sanitizedHtml,
+    threats,
+    wasSanitized: !safe,
+  };
+};

--- a/backend/src/utils/htmlSanitizer.js
+++ b/backend/src/utils/htmlSanitizer.js
@@ -1,0 +1,184 @@
+import sanitizeHtml from 'sanitize-html';
+
+/**
+ * Whitelisted HTML tags — no script, no iframe
+ */
+const ALLOWED_TAGS = [
+  // Structure
+  'html', 'head', 'body', 'main', 'section', 'article',
+  'header', 'footer', 'nav', 'aside', 'div', 'span',
+  // Text
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'p', 'br', 'hr', 'strong', 'em', 'b', 'i', 'u',
+  'small', 'mark', 'del', 'ins', 'sub', 'sup', 'blockquote',
+  'pre', 'code',
+  // Lists
+  'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+  // Links & Media
+  'a', 'img',
+  // Tables
+  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption',
+  // Forms (display only — no action)
+  'label',
+  // Meta (safe ones)
+  'meta', 'title',
+];
+
+/**
+ * Whitelisted attributes per tag
+ */
+const ALLOWED_ATTRIBUTES = {
+  '*': [
+    'class', 'id', 'style',
+    'aria-label', 'aria-hidden', 'aria-describedby',
+    'role', 'tabindex',
+    // data-* attributes allowed
+    'data-*',
+  ],
+  'a': ['href', 'target', 'rel'],
+  'img': ['src', 'alt', 'width', 'height', 'loading'],
+  'meta': ['name', 'content', 'charset', 'viewport'],
+  'link': ['rel', 'href', 'type'],
+  'td': ['colspan', 'rowspan'],
+  'th': ['colspan', 'rowspan', 'scope'],
+};
+
+/**
+ * Whitelisted CSS properties for inline styles
+ */
+const ALLOWED_CSS_PROPERTIES = [
+  'color', 'background-color', 'background',
+  'font-size', 'font-family', 'font-weight', 'font-style',
+  'text-align', 'text-decoration', 'text-transform',
+  'line-height', 'letter-spacing',
+  'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+  'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+  'width', 'height', 'max-width', 'max-height', 'min-width', 'min-height',
+  'display', 'flex', 'flex-direction', 'flex-wrap', 'justify-content', 'align-items',
+  'grid', 'grid-template-columns', 'grid-template-rows', 'gap',
+  'border', 'border-radius', 'border-color', 'border-width', 'border-style',
+  'box-shadow', 'opacity', 'overflow', 'position',
+  'top', 'right', 'bottom', 'left', 'z-index',
+  'list-style', 'cursor',
+];
+
+/**
+ * Sanitize options
+ */
+const SANITIZE_OPTIONS = {
+  allowedTags: ALLOWED_TAGS,
+  allowedAttributes: ALLOWED_ATTRIBUTES,
+  allowVulnerableTags: false, 
+
+  // Allow data-* attributes globally
+  allowedAttributesGlob: { '*': ['data-*'] },
+
+  // Validate and sanitize inline styles
+  allowedStyles: {
+    '*': ALLOWED_CSS_PROPERTIES.reduce((acc, prop) => {
+      acc[prop] = [/.*/]; // allow any value for whitelisted props
+      return acc;
+    }, {}),
+  },
+
+  // Block javascript: and data: URLs in href/src
+  allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+  allowedSchemesByTag: {
+    img: ['http', 'https', 'data'], // data URIs OK for images
+    link: ['http', 'https'],
+  },
+
+  // Force rel="noopener noreferrer" on external links
+  transformTags: {
+    a: (tagName, attribs) => {
+      const href = attribs.href || '';
+
+      // Block javascript: URLs
+      if (/^javascript:/i.test(href.trim())) {
+        return { tagName: 'span', attribs: {} };
+      }
+
+      return {
+        tagName,
+        attribs: {
+          ...attribs,
+          // Force safe rel on all links
+          rel: 'noopener noreferrer',
+          // Force external links to open in new tab
+          target: href.startsWith('http') ? '_blank' : attribs.target,
+        },
+      };
+    },
+
+    img: (tagName, attribs) => {
+      const src = attribs.src || '';
+
+      // Block external resources that aren't images
+      if (/^javascript:/i.test(src.trim())) {
+        return { tagName: 'span', attribs: {} };
+      }
+
+      return {
+        tagName,
+        attribs: {
+          ...attribs,
+          // Add lazy loading by default
+          loading: attribs.loading || 'lazy',
+        },
+      };
+    },
+  },
+
+  // Remove all event handlers (onclick, onerror, onload, etc.)
+  disallowedTagsMode: 'discard',
+};
+
+/**
+ * Sanitize HTML string to prevent XSS and code injection
+ * @param {string} html - Raw HTML to sanitize
+ * @returns {string} - Sanitized HTML safe for serving
+ */
+export const sanitizePortfolioHtml = (html) => {
+  if (typeof html !== 'string') {
+    throw new TypeError('html must be a string');
+  }
+
+  if (!html.trim()) return '';
+
+  return sanitizeHtml(html, SANITIZE_OPTIONS);
+};
+
+/**
+ * Sanitize a plain text string (strip all HTML)
+ * @param {string} text - Raw text that may contain HTML
+ * @returns {string} - Plain text with all HTML removed
+ */
+export const sanitizePlainText = (text) => {
+  if (typeof text !== 'string') return '';
+  return sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
+};
+
+/**
+ * Check if HTML contains dangerous patterns before sanitizing
+ * @param {string} html - HTML to check
+ * @returns {object} - { safe: boolean, threats: string[] }
+ */
+export const detectThreats = (html) => {
+  if (typeof html !== 'string') return { safe: false, threats: ['Input is not a string'] };
+
+  const threats = [];
+
+  if (/<script/i.test(html)) threats.push('script tag detected');
+  if (/javascript:/i.test(html)) threats.push('javascript: URL detected');
+  if (/on\w+\s*=/i.test(html)) threats.push('event handler attribute detected');
+  if (/<iframe/i.test(html)) threats.push('iframe tag detected');
+  if (/<object/i.test(html)) threats.push('object tag detected');
+  if (/<embed/i.test(html)) threats.push('embed tag detected');
+  if (/data:text\/html/i.test(html)) threats.push('data:text/html URL detected');
+  if (/<link[^>]*rel=["']?import/i.test(html)) threats.push('HTML import detected');
+
+  return {
+    safe: threats.length === 0,
+    threats,
+  };
+};


### PR DESCRIPTION
## **User description**
Fixes #778

Changes:
- Created backend/src/utils/htmlSanitizer.js
- Created backend/src/services/portfolioTemplateEngine.js

Security features:
- Blocks: script tags, iframe, object, embed
- Blocks: event handlers (onclick, onerror, onload etc)
- Blocks: javascript: URLs, data:text/html URLs
- Whitelists: standard HTML tags, safe CSS properties, data-* attributes
- Forces rel="noopener noreferrer" on all links
- Forces lazy loading on images
- detectThreats() pre-scan before sanitizing
- sanitizePlainText() strips all HTML for plain text fields
- NO JavaScript allowed in output as required
- NO iframe tags whitelisted as required

Tested:
Input:  <p>Hello</p><script>alert(1)</script><a href="javascript:void">click</a>
Output: <p>Hello</p><span>click</span>
Threats detected: script tag, javascript: URL ✅

Screenshots: N/A - Backend security utility, no UI changes.


___

## **CodeAnt-AI Description**
**Sanitize portfolio HTML before it is shown to users**

### What Changed
- Portfolio HTML is now cleaned before rendering, removing dangerous content such as scripts, iframes, embeds, and event handlers
- Unsafe links and image sources are blocked, and safe links now get protection against tabnabbing
- Images are loaded with lazy loading by default, and plain-text fields now strip all HTML
- The service now reports detected threats and rejects non-text input with a clear error

### Impact
`✅ Fewer XSS attacks in portfolio pages`
`✅ Safer link clicks in rendered content`
`✅ Faster portfolio pages with lazy-loaded images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio templates now include automatic threat detection and comprehensive HTML sanitization to filter unsafe content
  * Prevents execution of malicious scripts and removes unsafe markup patterns
  * External links automatically include security attributes to protect users
  * Plain text inputs are stripped of any HTML markup for added safety

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->