### PR TITLE
feat: add AI career trajectory prediction service

### DIFF
--- a/backend/src/routes/enhance.js
+++ b/backend/src/routes/enhance.js
@@ -379,11 +379,29 @@ router.post('/career-trajectory', verifyToken, extractAIProvider, aiRateLimiter,
   }
 
   // Sanitise inputs — never forward raw resumeText to the AI (token cost)
+  // Validate and sanitise each field to enforce strict token/cost bounds
   const sanitisedData = {
-    currentRole: hasRole ? currentRole.trim() : 'Software Engineer',
-    skills: hasSkills ? skills.slice(0, 10) : [],
-    yearsOfExperience: typeof yearsOfExperience === 'number' ? yearsOfExperience : 0,
-    industry: typeof industry === 'string' ? industry.trim() : 'Technology',
+    // Cap role to 100 chars to prevent prompt injection / token bloat
+    currentRole: hasRole ? currentRole.trim().slice(0, 100) : 'Software Engineer',
+
+    // Filter to valid non-empty strings only, cap each skill at 50 chars, limit to 10 skills
+    skills: hasSkills
+      ? skills
+          .filter((s) => typeof s === 'string' && s.trim().length > 0)
+          .map((s) => s.trim().slice(0, 50))
+          .slice(0, 10)
+      : [],
+
+    // Reject NaN, Infinity, and negative values — clamp to safe range [0, 50]
+    yearsOfExperience:
+      typeof yearsOfExperience === 'number' &&
+      Number.isFinite(yearsOfExperience) &&
+      yearsOfExperience >= 0
+        ? Math.min(Math.floor(yearsOfExperience), 50)
+        : 0,
+
+    // Cap industry to 100 chars
+    industry: typeof industry === 'string' ? industry.trim().slice(0, 100) : 'Technology',
   };
 
   try {

--- a/backend/src/routes/enhance.js
+++ b/backend/src/routes/enhance.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { enhanceResume, generateSummary, suggestImprovements, analyzeATSScore, analyzeResumeComprehensive, analyzeBulletPoints, generateBeforeAfter, getVerbLists, getSystemPrompt } from '../config/langchain.js';
 import { generateEmails } from '../services/emailGeneratorService.js';
+import { predictTrajectory } from '../services/ai/careerTrajectory.js';
 import { optimizeLinkedInProfile } from '../services/linkedinOptimizerService.js';
 import { verifyToken } from '../middleware/auth.js';
 import { extractAIProvider } from '../middleware/aiKey.js';
@@ -355,6 +356,53 @@ router.post('/stream', verifyToken, extractAIProvider, aiRateLimiter, asyncHandl
     console.error('Streaming enhancement error:', error);
     stream.sendError(error.message || 'Failed to enhance resume');
     stream.endStream();
+  }
+}));
+
+// Predict career trajectories based on resume data
+// POST /api/enhance/career-trajectory
+router.post('/career-trajectory', verifyToken, extractAIProvider, aiRateLimiter, asyncHandler(async (req, res) => {
+  const { resumeData } = req.body;
+
+  if (!resumeData || typeof resumeData !== 'object') {
+    throw new ApiError(400, 'resumeData object is required');
+  }
+
+  const { currentRole, skills, yearsOfExperience, industry } = resumeData;
+
+  // At least one meaningful field must be present
+  const hasRole = currentRole && typeof currentRole === 'string' && currentRole.trim();
+  const hasSkills = Array.isArray(skills) && skills.length > 0;
+
+  if (!hasRole && !hasSkills) {
+    throw new ApiError(400, 'resumeData must include at least currentRole or skills');
+  }
+
+  // Sanitise inputs — never forward raw resumeText to the AI (token cost)
+  const sanitisedData = {
+    currentRole: hasRole ? currentRole.trim() : 'Software Engineer',
+    skills: hasSkills ? skills.slice(0, 10) : [],
+    yearsOfExperience: typeof yearsOfExperience === 'number' ? yearsOfExperience : 0,
+    industry: typeof industry === 'string' ? industry.trim() : 'Technology',
+  };
+
+  try {
+    const result = await predictTrajectory(sanitisedData, req.aiProvider);
+
+    res.json({
+      success: true,
+      data: {
+        ...result,
+        provider: req.aiProvider?.providerName || 'gemini',
+        providerSource: req.aiProviderSource,
+      },
+    });
+  } catch (error) {
+    console.error('Career trajectory prediction error:', error);
+    if (error.statusCode === 502) {
+      throw new ApiError(502, 'AI returned an unexpected response. Please try again.');
+    }
+    throw new ApiError(500, 'Failed to predict career trajectory. Please try again.');
   }
 }));
 

--- a/backend/src/services/ai/careerTrajectory.js
+++ b/backend/src/services/ai/careerTrajectory.js
@@ -96,10 +96,15 @@ export const predictTrajectory = async (resumeData, aiProvider = null) => {
 
   // --- Use injected aiProvider (user's key / DB config) if available ---
   if (aiProvider && typeof aiProvider.generateContent === 'function') {
-    const providerName = aiProvider.providerName || 'custom';
-    aiCallsCounter.inc({ provider: providerName });
-
+    // Note: aiCallsCounter is NOT incremented here — built-in provider adapters
+    // already track this metric internally to avoid double-counting.
     const result = await aiProvider.generateContent(prompt);
+
+    // Guard against nullish adapter response before dereferencing
+    if (!result) {
+      throw new Error('AI provider returned a null or undefined response.');
+    }
+
     // Normalise across provider adapters — some return .text directly, some wrap it
     responseText = typeof result.text === 'function'
       ? result.text()
@@ -132,7 +137,26 @@ export const predictTrajectory = async (resumeData, aiProvider = null) => {
     throw err;
   }
 
-  const trajectories = parsed.typicalPaths || parsed.paths || [];
+  // Hard-cap parsed output to enforce API contract regardless of model compliance.
+  // This prevents oversized payloads and keeps token/cost bounds stable.
+  const rawPaths = Array.isArray(parsed.typicalPaths)
+    ? parsed.typicalPaths
+    : Array.isArray(parsed.paths)
+    ? parsed.paths
+    : [];
+
+  const trajectories = rawPaths.slice(0, 3).map((path) => ({
+    pathName: path.pathName || '',
+    roles: Array.isArray(path.roles)
+      ? path.roles.slice(0, 4).map((role) => ({
+          title: role.title || '',
+          level: role.level || '',
+          timeToReach: role.timeToReach || '',
+          skills: Array.isArray(role.skills) ? role.skills.slice(0, 3) : [],
+          estimatedSalary: role.estimatedSalary || '',
+        }))
+      : [],
+  }));
 
   return {
     trajectories,

--- a/backend/src/services/ai/careerTrajectory.js
+++ b/backend/src/services/ai/careerTrajectory.js
@@ -1,0 +1,150 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import dotenv from 'dotenv';
+import { aiCallsCounter } from '../../middleware/metrics.js';
+
+dotenv.config();
+
+const geminiApiKey = process.env.GEMINI_API_KEY;
+if (!geminiApiKey) {
+  console.warn('GEMINI_API_KEY is missing. Career trajectory service will only work with a user-supplied AI provider.');
+}
+
+// Lazily initialised — avoids crashing on startup if key is absent
+let defaultModel;
+if (geminiApiKey) {
+  const genAI = new GoogleGenerativeAI(geminiApiKey);
+  // gemini-2.0-flash: fastest & cheapest Gemini variant — minimises token cost
+  defaultModel = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+}
+
+/**
+ * Build a compact, token-efficient prompt.
+ * Raw resumeText is intentionally excluded — structured fields only.
+ * Output is capped at 3 paths × 4 roles × 3 skills to limit response tokens.
+ *
+ * @param {object} profile - Extracted structured fields from resumeData
+ */
+const buildPrompt = ({ currentRole, skills, yearsOfExperience, industry }) => {
+  // Trim skills list to avoid ballooning the input token count
+  const topSkills = (skills || []).slice(0, 10).join(', ') || 'not specified';
+  const exp = yearsOfExperience ?? 'unknown';
+  const ind = industry || 'Technology';
+
+  return `You are a career advisor AI. Given the profile below, return ONLY a valid JSON object — no markdown, no extra text.
+
+Profile:
+- Role: ${currentRole || 'Software Engineer'}
+- Skills: ${topSkills}
+- Experience: ${exp} years
+- Industry: ${ind}
+
+Return exactly this JSON structure (3 paths, max 4 roles each, max 3 skills each):
+{
+  "typicalPaths": [
+    {
+      "pathName": "short label e.g. Senior Engineer → Engineering Manager",
+      "roles": [
+        {
+          "title": "job title",
+          "level": "Junior|Mid|Senior|Lead|Director",
+          "timeToReach": "e.g. 1-2 yrs",
+          "skills": ["skill1", "skill2", "skill3"],
+          "estimatedSalary": "e.g. $80k-$110k"
+        }
+      ]
+    }
+  ]
+}
+
+Rules:
+- Exactly 3 paths. Each path max 4 roles. Each role max 3 skills.
+- Use hedging language in pathName: "typical", "estimated" where suitable.
+- Salaries as short strings like "$90k-$120k". Vary by industry.
+- No descriptions, no extra fields, no markdown fences.`;
+};
+
+/**
+ * Predict 3 typical career trajectories from structured resume data.
+ *
+ * Token optimisations applied:
+ *  - Raw resumeText is never sent to the AI
+ *  - Skills list is capped at 10 inputs
+ *  - Output is constrained to 3 paths × 4 roles × 3 skills
+ *  - Salary returned as a compact string (not an object)
+ *  - No prose description fields
+ *  - Uses gemini-2.0-flash (cheapest Gemini model)
+ *
+ * @param {object} resumeData
+ * @param {string}   resumeData.currentRole
+ * @param {string[]} resumeData.skills
+ * @param {number}   resumeData.yearsOfExperience
+ * @param {string}   [resumeData.industry]
+ * @param {object}   [aiProvider] - Provider instance from extractAIProvider middleware
+ * @returns {Promise<object>} Parsed trajectory result
+ */
+export const predictTrajectory = async (resumeData, aiProvider = null) => {
+  const profile = {
+    currentRole: resumeData.currentRole,
+    skills: resumeData.skills,
+    yearsOfExperience: resumeData.yearsOfExperience,
+    industry: resumeData.industry,
+  };
+
+  const prompt = buildPrompt(profile);
+
+  let responseText;
+
+  // --- Use injected aiProvider (user's key / DB config) if available ---
+  if (aiProvider && typeof aiProvider.generateContent === 'function') {
+    const providerName = aiProvider.providerName || 'custom';
+    aiCallsCounter.inc({ provider: providerName });
+
+    const result = await aiProvider.generateContent(prompt);
+    // Normalise across provider adapters — some return .text directly, some wrap it
+    responseText = typeof result.text === 'function'
+      ? result.text()
+      : result.text ?? result?.response?.text?.() ?? '';
+  } else {
+    // --- Fall back to server Gemini key ---
+    if (!defaultModel) {
+      throw new Error('No AI provider available. Please configure GEMINI_API_KEY or supply a provider.');
+    }
+
+    aiCallsCounter.inc({ provider: 'gemini' });
+    const result = await defaultModel.generateContent(prompt);
+    responseText = result.response.text();
+  }
+
+  // Strip markdown code fences if the model adds them despite instructions
+  const cleaned = responseText
+    .replace(/```json\s*/gi, '')
+    .replace(/```\s*/g, '')
+    .trim();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (parseError) {
+    const err = new Error('AI returned invalid JSON for career trajectory');
+    err.statusCode = 502;
+    err.cause = parseError;
+    err.rawResponse = responseText;
+    throw err;
+  }
+
+  const trajectories = parsed.typicalPaths || parsed.paths || [];
+
+  return {
+    trajectories,
+    analyzedProfile: {
+      currentRole: profile.currentRole || 'Not specified',
+      yearsOfExperience: profile.yearsOfExperience ?? 'Not specified',
+      skillCount: (profile.skills || []).length,
+      industry: profile.industry || 'Technology',
+    },
+    disclaimer:
+      'These are estimated typical career paths based on industry trends and are not guarantees. ' +
+      'Actual timelines and salaries may vary based on location, company, and individual performance.',
+    generatedAt: new Date().toISOString(),
+  };
+};


### PR DESCRIPTION
## **User description**
## Description

Implements an AI-powered career trajectory prediction service that analyses a user's current role, skills, experience level, and industry — then returns 3 estimated career paths, each with role progressions (Junior → Mid → Senior → Lead → Director), time estimates per transition, required skill additions, and estimated salary ranges at each level.

All predictions use hedging language ("typical", "estimated", "potential") and include a disclaimer so they are never presented as guarantees.

**Token optimisation** (per maintainer's guidance):
- Raw `resumeText` is never sent to the AI — only structured fields are used
- Output is capped at 3 paths × 4 roles × 3 skills per role
- Salary returned as a compact string (`"$90k–$120k"`) instead of an object
- Uses `gemini-2.0-flash` (fastest, cheapest Gemini model)
- No free-form prose/description fields in the output



Ai has been used for coding based on implementation in my accordance; stated as per rules of GSSOC'26


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #728 

## Changes Made

### New File: `backend/src/services/ai/careerTrajectory.js`
- Exports `predictTrajectory(resumeData, aiProvider)` function
- Uses `gemini-2.0-flash` via `@google/generative-ai`
- Supports the existing multi-provider system (`extractAIProvider` middleware) — works with user's own key, DB-saved key, or server's `GEMINI_API_KEY` fallback
- Graceful startup — warns on missing API key without crashing the server
- Increments `aiCallsCounter` metric (consistent with existing AI services)
- Returns `trajectories`, `analyzedProfile`, `disclaimer`, and `generatedAt`

### Modified File: `backend/src/routes/enhance.js`
- Added `import { predictTrajectory }` at the top
- Added `POST /api/enhance/career-trajectory` endpoint
- Full middleware chain: `verifyToken → extractAIProvider → aiRateLimiter → asyncHandler`
- Input validation: requires at least `currentRole` or `skills` in `resumeData`
- Sanitises input before passing to service (strips `resumeText`, caps skills at 10)
- Distinguishes 502 (bad AI response) from 500 (server error)

## API Usage

**Endpoint:** `POST /api/enhance/career-trajectory`

**Request:**
```json
{
  "resumeData": {
    "currentRole": "Frontend Developer",
    "skills": ["React", "TypeScript", "Node.js"],
    "yearsOfExperience": 2,
    "industry": "Technology"
  }
}


___

## **CodeAnt-AI Description**
**Add AI career trajectory predictions from resume details**

### What Changed
- Added a new career trajectory request that returns 3 estimated career paths based on a user’s role, skills, experience, and industry
- The service now rejects requests without usable career information and only uses structured resume data, not raw resume text
- Results include a short disclaimer, analyzed profile summary, and generation time
- If the usual AI provider is unavailable, the request can still use the server’s Gemini key; if the AI response is not valid JSON, the request returns a clear error

### Impact
`✅ Career path estimates from resume data`
`✅ Fewer failed predictions from missing AI keys`
`✅ Clearer errors when the AI response is unusable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered career trajectory predictions. Users can submit resume information including current role and skills to receive personalized career path recommendations with detailed trajectory analysis and guidance for professional development planning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->