### PR TITLE
Feature/search input

### DIFF
--- a/frontend/src/components/SearchInput.jsx
+++ b/frontend/src/components/SearchInput.jsx
@@ -16,10 +16,19 @@ export default function SearchInput({
   debounceMs = 300,
   isLoading = false,
   wrapperClassName = "",
-  inputClassName = ""
+  inputClassName = "",
 }) {
-  // Internal query state which is decoupled from the parent's onChange so we can debounce without the parent re-rendering on every keystroke
+  // Internal input state used for debouncing.
+  // Starts with the external value prop if provided.
   const [query, setQuery] = useState(value || "");
+
+  /**
+   * Keep internal query state synced with external value changes.
+   * Useful when parent components reset or update the search value.
+   */
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
 
   /**
    * Store the latest onChange in a ref so the debounce effect doesn't need onChange in its dependency array.
@@ -37,26 +46,36 @@ export default function SearchInput({
    * The cleanup function cancels the pending timer if query changes again
    * before the delay completes, ensuring onChange is never called mid-typing.
    */
+
+  // Used to skip the debounce effect during the initial render
+  // so onChange is not triggered immediately on mount.
+  const isFirstRender = useRef(true);
+
   useEffect(() => {
+    // Skip debounce on first render to avoid firing
+    // an unnecessary initial onChange call.
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
     const timer = setTimeout(() => {
       onChangeRef.current(query);
     }, debounceMs);
 
-    // Cleanup function
     return () => clearTimeout(timer);
   }, [query, debounceMs]);
 
+  // Update local query state immediately for responsive typing.
+  // The parent onChange will still be debounced separately.
   const handleInputChange = (e) => {
     setQuery(e.target.value);
   };
 
+  // Clear the current search query.
+  // This will also trigger the debounced onChange effect.
   const handleInputClear = () => {
-    // Resetting query triggers the debounce effect above,
-    // which will call onChange("") after debounceMs.
     setQuery("");
-
-    // Uncomment to trigger onChange immediately on clear, bypassing debounce
-    // onChangeRef.current("");
   };
 
   return (
@@ -89,9 +108,11 @@ export default function SearchInput({
           id={name}
           name={name}
           value={query}
+          aria-label={label || placeholder || "Search"}
           onChange={handleInputChange}
           placeholder={placeholder}
           disabled={disabled}
+          required={required}
           className={cn(
             "w-full px-5 py-3.5 rounded-2xl transition-all duration-300",
             "bg-muted/30 border border-border",
@@ -100,7 +121,7 @@ export default function SearchInput({
             "disabled:bg-muted disabled:cursor-not-allowed disabled:opacity-50",
             "pl-10 pr-10", // room for icons on both sides
             error ? "border-destructive/50 focus:ring-destructive/20" : "",
-            inputClassName, 
+            inputClassName,
           )}
         />
 
@@ -142,7 +163,7 @@ SearchInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   error: PropTypes.string,
   debounceMs: PropTypes.number,
-  isLoading: PropTypes.bool, 
+  isLoading: PropTypes.bool,
   wrapperClassName: PropTypes.string,
   inputClassName: PropTypes.string,
 };

--- a/frontend/src/components/SearchInput.jsx
+++ b/frontend/src/components/SearchInput.jsx
@@ -60,7 +60,7 @@ export default function SearchInput({
   };
 
   return (
-    <div className={cn("mb-6", wrapperClassName)}>
+    <div className={cn(wrapperClassName)}>
       {/* Label only rendered when the label prop is provided */}
       {label && (
         <label
@@ -100,7 +100,7 @@ export default function SearchInput({
             "disabled:bg-muted disabled:cursor-not-allowed disabled:opacity-50",
             "pl-10 pr-10", // room for icons on both sides
             error ? "border-destructive/50 focus:ring-destructive/20" : "",
-            inputClassName,
+            inputClassName, 
           )}
         />
 

--- a/frontend/src/components/SearchInput.jsx
+++ b/frontend/src/components/SearchInput.jsx
@@ -1,0 +1,148 @@
+import { useState, useEffect, useRef } from "react";
+import { Search, X, Loader2 } from "lucide-react";
+import PropTypes from "prop-types";
+import { cn } from "@/lib/utils";
+
+export default function SearchInput({
+  label,
+  required = false,
+  disabled = false,
+  type = "text",
+  name,
+  value,
+  placeholder,
+  onChange,
+  error,
+  debounceMs = 300,
+  isLoading = false,
+  wrapperClassName = "",
+  inputClassName = ""
+}) {
+  // Internal query state which is decoupled from the parent's onChange so we can debounce without the parent re-rendering on every keystroke
+  const [query, setQuery] = useState(value || "");
+
+  /**
+   * Store the latest onChange in a ref so the debounce effect doesn't need onChange in its dependency array.
+   * This prevents the timer from resetting when the parent passes a new function reference on re-render
+   * (e.g. an inline arrow function), which would break the debounce.
+   */
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  /**
+   * Fire onChange after the user stops typing for `debounceMs` milliseconds.
+   * The cleanup function cancels the pending timer if query changes again
+   * before the delay completes, ensuring onChange is never called mid-typing.
+   */
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onChangeRef.current(query);
+    }, debounceMs);
+
+    // Cleanup function
+    return () => clearTimeout(timer);
+  }, [query, debounceMs]);
+
+  const handleInputChange = (e) => {
+    setQuery(e.target.value);
+  };
+
+  const handleInputClear = () => {
+    // Resetting query triggers the debounce effect above,
+    // which will call onChange("") after debounceMs.
+    setQuery("");
+
+    // Uncomment to trigger onChange immediately on clear, bypassing debounce
+    // onChangeRef.current("");
+  };
+
+  return (
+    <div className={cn("mb-6", wrapperClassName)}>
+      {/* Label only rendered when the label prop is provided */}
+      {label && (
+        <label
+          htmlFor={name}
+          className="block text-sm font-bold text-foreground mb-2 uppercase tracking-widest opacity-70"
+        >
+          {label}
+          {required && <span className="text-destructive ml-1">*</span>}
+        </label>
+      )}
+
+      {/* Relative wrapper so the icons can be absolutely positioned over the input without affecting its width or layout */}
+      <div className="relative flex items-center">
+        {/* Search icon turns destructive color when there's an error */}
+        <span
+          className={cn(
+            "absolute left-4 pointer-events-none z-10",
+            error ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          <Search size={16} />
+        </span>
+
+        <input
+          type={type}
+          id={name}
+          name={name}
+          value={query}
+          onChange={handleInputChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={cn(
+            "w-full px-5 py-3.5 rounded-2xl transition-all duration-300",
+            "bg-muted/30 border border-border",
+            "text-foreground placeholder:text-muted-foreground",
+            "focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary",
+            "disabled:bg-muted disabled:cursor-not-allowed disabled:opacity-50",
+            "pl-10 pr-10", // room for icons on both sides
+            error ? "border-destructive/50 focus:ring-destructive/20" : "",
+            inputClassName,
+          )}
+        />
+
+        {/* Right slot which shows spinner while loading, clear button when there's a query, and nothing when the input is empty */}
+        <span className="absolute right-4 z-10 flex items-center">
+          {isLoading ? (
+            <Loader2 size={16} className="animate-spin text-muted-foreground" />
+          ) : query ? (
+            <button
+              type="button"
+              onClick={handleInputClear}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Clear search"
+            >
+              <X size={16} />
+            </button>
+          ) : null}
+        </span>
+      </div>
+
+      {/* Error message which mirrors Input component's error block */}
+      {error && (
+        <p className="mt-2 text-sm font-bold text-destructive uppercase tracking-wide">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+SearchInput.propTypes = {
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  disabled: PropTypes.bool,
+  type: PropTypes.string,
+  name: PropTypes.string,
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  error: PropTypes.string,
+  debounceMs: PropTypes.number,
+  isLoading: PropTypes.bool, 
+  wrapperClassName: PropTypes.string,
+  inputClassName: PropTypes.string,
+};


### PR DESCRIPTION
## **User description**
## Description
Added a reusable `SearchInput` component with:
- Debounced `onChange`
- Search icon
- Clear button
- Optional loading spinner

The component is styled consistently with the existing `Input` component.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #758

## Testing
- [ ] Unit tests pass
- [X] Tested Locally
- [ ] New tests added

### Screen Recording
https://github.com/user-attachments/assets/8ffb3afc-9f18-42dd-9a54-eda2c2c2bec7

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] Added comments where necessary
- [ ] Updated documentation
- [X] No new warnings generated


___

## **CodeAnt-AI Description**
**Add a reusable search field with debounced typing, clear action, and loading state**

### What Changed
- Added a searchable input that waits briefly before sending changes, so searches do not update on every keystroke
- Shows a search icon on the left, a clear button when text is present, and a loading spinner while results are being fetched
- Supports labels, validation messages, disabled state, and styling options so it matches the rest of the app

### Impact
`✅ Fewer search requests while typing`
`✅ Faster-feeling search input`
`✅ Clearer search state feedback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable input component with debounced input handling to reduce unnecessary updates.
  * Shows a loading indicator during async searches and a quick-clear button to reset the field.
  * Displays an accessible label (with required marker when applicable) and inline error messages when validation fails.
  * Component includes runtime prop validation to help catch incorrect usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->