### PR TITLE
feat: add inline AI ghost text suggestions in resume editor (#596)

### DIFF
--- a/backend/src/config/langchain.js
+++ b/backend/src/config/langchain.js
@@ -573,6 +573,35 @@ ${resumeText}`;
   }
 };
 
+// Generate inline text completion for ghost text suggestions
+export const generateInlineCompletion = async (text, cursorPosition, sectionContext, fieldType, aiProvider) => {
+  try {
+    const provider = resolveProvider(aiProvider);
+    const textBeforeCursor = text.slice(0, cursorPosition);
+    const textAfterCursor = text.slice(cursorPosition);
+
+    const prompt = `You are an expert resume writer providing inline text completions.
+
+The user is editing the "${fieldType}" field in the "${sectionContext}" section of their resume.
+
+Text before cursor: "${textBeforeCursor}"
+Text after cursor: "${textAfterCursor}"
+
+Provide a short, natural continuation (1-2 sentences max) that completes the current thought. Return ONLY the completion text, nothing else. No quotes, no explanations, no prefixes. If the text is empty, suggest a strong opening for this type of resume field.`;
+
+    const providerResult = await provider.generateContent(prompt);
+    return {
+      success: true,
+      completion: providerResult.text.trim(),
+      provider: provider.providerName
+    };
+  } catch (error) {
+    if (error.statusCode === 503) throw error;
+    console.error('Error generating inline completion:', error);
+    throw new Error(`Failed to generate inline completion: ${error.message}`);
+  }
+};
+
 // Export power/weak verbs for frontend use
 export const getVerbLists = () => ({
   powerVerbs: POWER_VERBS,

--- a/backend/src/routes/enhance.js
+++ b/backend/src/routes/enhance.js
@@ -284,7 +284,11 @@ router.post('/inline-completion', verifyToken, extractAIProvider, aiRateLimiter,
     throw new ApiError(400, 'Text is required');
   }
 
-  if (typeof cursorPosition !== 'number' || cursorPosition < 0) {
+  if (text.length > 5000) {
+    throw new ApiError(400, 'Text exceeds the allowed limit (max 5000 characters)');
+  }
+
+  if (!Number.isInteger(cursorPosition) || cursorPosition < 0 || cursorPosition > text.length) {
     throw new ApiError(400, 'Valid cursor position is required');
   }
 

--- a/backend/src/routes/enhance.js
+++ b/backend/src/routes/enhance.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { enhanceResume, generateSummary, suggestImprovements, analyzeATSScore, analyzeResumeComprehensive, analyzeBulletPoints, generateBeforeAfter, getVerbLists, getSystemPrompt } from '../config/langchain.js';
+import { enhanceResume, generateSummary, suggestImprovements, analyzeATSScore, analyzeResumeComprehensive, analyzeBulletPoints, generateBeforeAfter, getVerbLists, getSystemPrompt, generateInlineCompletion } from '../config/langchain.js';
 import { generateEmails } from '../services/emailGeneratorService.js';
 import { optimizeLinkedInProfile } from '../services/linkedinOptimizerService.js';
 import { verifyToken } from '../middleware/auth.js';
@@ -274,6 +274,36 @@ router.post('/optimize-linkedin', verifyToken, aiRateLimiter, validate(optimizeL
 
   const result = await optimizeLinkedInProfile(normalizedProfile, normalizedRole);
   res.json(result);
+}));
+
+// Inline AI completion for ghost text suggestions
+router.post('/inline-completion', verifyToken, extractAIProvider, aiRateLimiter, asyncHandler(async (req, res) => {
+  const { text, cursorPosition, sectionContext, fieldType } = req.body;
+
+  if (typeof text !== 'string') {
+    throw new ApiError(400, 'Text is required');
+  }
+
+  if (typeof cursorPosition !== 'number' || cursorPosition < 0) {
+    throw new ApiError(400, 'Valid cursor position is required');
+  }
+
+  const result = await generateInlineCompletion(
+    text,
+    cursorPosition,
+    sectionContext || 'General',
+    fieldType || 'description',
+    req.aiProvider
+  );
+
+  res.json({
+    success: true,
+    data: {
+      completion: result.completion,
+      provider: result.provider,
+      providerSource: req.aiProviderSource
+    }
+  });
 }));
 
 // Streaming endpoint for resume enhancement

--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -10,15 +10,10 @@ export default function AppLayout({ children, className }) {
         <div className={cn("flex h-screen bg-background overflow-hidden", className)}>
             <AppSidebar />
             {/* The main tag below is what the FAB component listens to for scrolling */}
-<<<<<<< notification-fix
-            <main className="flex-1 overflow-y-auto relative">
-                {/* Top bar with notification bell */}
+            <main ref={mainRef} className="flex-1 overflow-y-auto relative">
                 <div className="sticky top-0 z-40 flex justify-end items-center px-4 py-2 bg-background/80 backdrop-blur border-b border-border">
                     <NotificationCenter />
                 </div>
-=======
-            <main ref={mainRef} className="flex-1 overflow-y-auto relative">
->>>>>>> main
                 {children}
                 <FAB scrollContainerRef={mainRef} />
             </main>

--- a/frontend/src/components/CustomSection.jsx
+++ b/frontend/src/components/CustomSection.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from 'react'
 import { cn } from '@/lib/utils'
 import Button from './Button'
 import DragHandle from './DragHandle'
+import GhostTextArea from './GhostTextArea'
 
 // ─── Icons (inline SVG to keep zero extra deps) ────────────────────────────
 
@@ -62,7 +63,7 @@ const makeEntry = () => ({
 
 // ─── Entry editor ──────────────────────────────────────────────────────────
 
-function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst, isLast }) {
+function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst, isLast, sectionName }) {
   const [expanded, setExpanded] = useState(!entry.title)
 
   const update = (field) => (e) => onChange({ ...entry, [field]: e.target.value })
@@ -156,10 +157,12 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
           </div>
           <div className="sm:col-span-2">
             <label className="block text-xs font-medium text-muted-foreground mb-1">Description</label>
-            <textarea
+            <GhostTextArea
               rows={2}
               value={entry.description}
               onChange={update('description')}
+              sectionContext={sectionName || 'General'}
+              fieldType="description"
               placeholder="Brief description (optional)"
               className="w-full px-3 py-2 rounded-lg bg-background border border-border text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-colors resize-none"
             />
@@ -398,6 +401,7 @@ function SectionCard({
             <EntryEditor
               key={entry.id}
               entry={entry}
+              sectionName={section.name}
               onChange={(updated) => updateEntry(entry.id, updated)}
               onDelete={() => deleteEntry(entry.id)}
               onMoveUp={() => moveEntry(idx, -1)}

--- a/frontend/src/components/GhostTextArea.jsx
+++ b/frontend/src/components/GhostTextArea.jsx
@@ -2,10 +2,6 @@ import { useRef, useCallback, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { useAICompletion } from '../hooks/useAICompletion'
 
-/**
- * Textarea with inline AI ghost text suggestions.
- * Shows a faded completion after the cursor text. Tab accepts, Escape dismisses.
- */
 export default function GhostTextArea({
   value = '',
   onChange,
@@ -17,6 +13,7 @@ export default function GhostTextArea({
 }) {
   const textareaRef = useRef(null)
   const [isFocused, setIsFocused] = useState(false)
+  const [cursorPos, setCursorPos] = useState(0)
   const { suggestion, isLoading, fetchCompletion, dismiss } = useAICompletion({
     sectionContext,
     fieldType,
@@ -25,40 +22,47 @@ export default function GhostTextArea({
 
   const handleChange = useCallback((e) => {
     const newValue = e.target.value
+    const pos = e.target.selectionStart
     onChange(e)
     dismiss()
-    const cursorPos = e.target.selectionStart
-    fetchCompletion(newValue, cursorPos)
+    setCursorPos(pos)
+    fetchCompletion(newValue, pos)
   }, [onChange, fetchCompletion, dismiss])
 
   const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      dismiss()
+      return
+    }
+
     if (!suggestion) return
 
     if (e.key === 'Tab') {
       e.preventDefault()
       const textarea = textareaRef.current
       if (!textarea) return
-      const cursorPos = textarea.selectionStart
-      const before = value.slice(0, cursorPos)
-      const after = value.slice(cursorPos)
+      const pos = textarea.selectionStart
+      const currentValue = textarea.value
+      const before = currentValue.slice(0, pos)
+      const after = currentValue.slice(pos)
       const newValue = before + suggestion + after
 
       const syntheticEvent = { target: { value: newValue } }
       onChange(syntheticEvent)
       dismiss()
 
+      const newCursorPos = pos + suggestion.length
+      setCursorPos(newCursorPos)
       requestAnimationFrame(() => {
-        const newCursorPos = cursorPos + suggestion.length
         textarea.setSelectionRange(newCursorPos, newCursorPos)
       })
-      return
     }
+  }, [suggestion, onChange, dismiss])
 
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      dismiss()
-    }
-  }, [suggestion, value, onChange, dismiss])
+  const handleSelect = useCallback((e) => {
+    setCursorPos(e.target.selectionStart)
+  }, [])
 
   const showGhost = isFocused && suggestion && !isLoading
 
@@ -69,6 +73,7 @@ export default function GhostTextArea({
         value={value}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
+        onSelect={handleSelect}
         onFocus={() => setIsFocused(true)}
         onBlur={() => {
           setIsFocused(false)
@@ -89,8 +94,9 @@ export default function GhostTextArea({
             'px-3 py-2 text-sm leading-[1.5]',
           )}
         >
-          <span className="invisible">{value}</span>
+          <span className="invisible">{value.slice(0, cursorPos)}</span>
           <span className="text-muted-foreground/40 italic">{suggestion}</span>
+          <span className="invisible">{value.slice(cursorPos)}</span>
         </div>
       )}
 

--- a/frontend/src/components/GhostTextArea.jsx
+++ b/frontend/src/components/GhostTextArea.jsx
@@ -1,0 +1,113 @@
+import { useRef, useCallback, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { useAICompletion } from '../hooks/useAICompletion'
+
+/**
+ * Textarea with inline AI ghost text suggestions.
+ * Shows a faded completion after the cursor text. Tab accepts, Escape dismisses.
+ */
+export default function GhostTextArea({
+  value = '',
+  onChange,
+  sectionContext = '',
+  fieldType = 'description',
+  className = '',
+  ghostEnabled = true,
+  ...props
+}) {
+  const textareaRef = useRef(null)
+  const [isFocused, setIsFocused] = useState(false)
+  const { suggestion, isLoading, fetchCompletion, dismiss } = useAICompletion({
+    sectionContext,
+    fieldType,
+    enabled: ghostEnabled
+  })
+
+  const handleChange = useCallback((e) => {
+    const newValue = e.target.value
+    onChange(e)
+    dismiss()
+    const cursorPos = e.target.selectionStart
+    fetchCompletion(newValue, cursorPos)
+  }, [onChange, fetchCompletion, dismiss])
+
+  const handleKeyDown = useCallback((e) => {
+    if (!suggestion) return
+
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      const textarea = textareaRef.current
+      if (!textarea) return
+      const cursorPos = textarea.selectionStart
+      const before = value.slice(0, cursorPos)
+      const after = value.slice(cursorPos)
+      const newValue = before + suggestion + after
+
+      const syntheticEvent = { target: { value: newValue } }
+      onChange(syntheticEvent)
+      dismiss()
+
+      requestAnimationFrame(() => {
+        const newCursorPos = cursorPos + suggestion.length
+        textarea.setSelectionRange(newCursorPos, newCursorPos)
+      })
+      return
+    }
+
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      dismiss()
+    }
+  }, [suggestion, value, onChange, dismiss])
+
+  const showGhost = isFocused && suggestion && !isLoading
+
+  return (
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => {
+          setIsFocused(false)
+          dismiss()
+        }}
+        className={cn(
+          'relative z-10 bg-transparent',
+          className
+        )}
+        {...props}
+      />
+
+      {showGhost && (
+        <div
+          aria-hidden="true"
+          className={cn(
+            'absolute inset-0 pointer-events-none overflow-hidden whitespace-pre-wrap break-words',
+            'px-3 py-2 text-sm leading-[1.5]',
+          )}
+        >
+          <span className="invisible">{value}</span>
+          <span className="text-muted-foreground/40 italic">{suggestion}</span>
+        </div>
+      )}
+
+      {showGhost && (
+        <div className="absolute bottom-1 right-2 z-20 flex items-center gap-1.5 text-[10px] text-muted-foreground/50 pointer-events-none">
+          <kbd className="px-1 py-0.5 rounded border border-border/50 bg-muted/50 font-mono">Tab</kbd>
+          <span>accept</span>
+          <kbd className="px-1 py-0.5 rounded border border-border/50 bg-muted/50 font-mono">Esc</kbd>
+          <span>dismiss</span>
+        </div>
+      )}
+
+      {isLoading && isFocused && (
+        <div className="absolute top-2 right-2 z-20 pointer-events-none">
+          <div className="w-3 h-3 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAICompletion.js
+++ b/frontend/src/hooks/useAICompletion.js
@@ -1,0 +1,82 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { enhanceApi } from '../services/api'
+
+const DEBOUNCE_DELAY = 400
+const MIN_TEXT_LENGTH = 3
+
+/**
+ * Hook that fetches inline AI completions with debouncing and abort support.
+ * @param {Object} options
+ * @param {string} options.sectionContext - Resume section name (e.g. "Experience")
+ * @param {string} options.fieldType - Field being edited (e.g. "description", "title")
+ * @param {boolean} [options.enabled=true] - Whether completions are active
+ */
+export function useAICompletion({ sectionContext = '', fieldType = 'description', enabled = true } = {}) {
+  const [suggestion, setSuggestion] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const debounceTimer = useRef(null)
+  const abortController = useRef(null)
+
+  const clearPending = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current)
+      debounceTimer.current = null
+    }
+    if (abortController.current) {
+      abortController.current.abort()
+      abortController.current = null
+    }
+  }, [])
+
+  const fetchCompletion = useCallback((text, cursorPosition) => {
+    clearPending()
+    setSuggestion('')
+    setError(null)
+
+    if (!enabled || !text || text.trim().length < MIN_TEXT_LENGTH) {
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+
+    debounceTimer.current = setTimeout(async () => {
+      const controller = new AbortController()
+      abortController.current = controller
+
+      try {
+        const result = await enhanceApi.inlineCompletion(
+          text,
+          cursorPosition,
+          sectionContext,
+          fieldType,
+          controller.signal
+        )
+
+        if (!controller.signal.aborted && result?.data?.completion) {
+          setSuggestion(result.data.completion)
+        }
+      } catch (err) {
+        if (err.name !== 'AbortError') {
+          setError(err.message)
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false)
+        }
+      }
+    }, DEBOUNCE_DELAY)
+  }, [enabled, sectionContext, fieldType, clearPending])
+
+  const dismiss = useCallback(() => {
+    clearPending()
+    setSuggestion('')
+    setIsLoading(false)
+  }, [clearPending])
+
+  useEffect(() => clearPending, [clearPending])
+
+  return { suggestion, isLoading, error, fetchCompletion, dismiss }
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -291,6 +291,18 @@ export const enhanceApi = {
     return handleResponse(response)
   },
 
+  // Get inline AI completion for ghost text
+  async inlineCompletion(text, cursorPosition, sectionContext, fieldType, signal) {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/enhance/inline-completion`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ text, cursorPosition, sectionContext, fieldType }),
+      signal
+    })
+    return handleResponse(response)
+  },
+
   // Optimize LinkedIn profile with AI
   async optimizeLinkedIn(data) {
     const headers = await getAuthHeaders()


### PR DESCRIPTION
## **User description**
Closes #596

added inline AI ghost text suggestions in the resume editor. here's what's new:

**backend:**
- added `generateInlineCompletion()` in langchain config — lightweight prompt that returns 1-2 sentence continuations based on cursor context
- added `POST /api/enhance/inline-completion` endpoint with auth, AI provider selection, and rate limiting

**frontend:**
- created `useAICompletion` hook — debounced (400ms), fetches completions with AbortController support, handles loading/error/dismiss states, cleans up on unmount
- created `GhostTextArea` component — textarea wrapper with faded grey ghost text overlay after cursor, Tab to accept, Escape to dismiss, loading spinner
- integrated into `CustomSection.jsx` — replaced plain textarea in EntryEditor with GhostTextArea, passes section name ("Experience", "Awards" etc) for context-aware suggestions

**also fixed:** pre-existing upstream merge conflict in AppLayout.jsx that was blocking the build

happy to make changes if needed!


___

## **CodeAnt-AI Description**
**Add inline AI ghost text suggestions in the resume editor**

### What Changed
- Resume description fields now show inline AI suggestion text while you type, with Tab to accept and Escape to dismiss.
- Suggestions are tailored to the section and field being edited, and stop showing when the field is cleared, blurred, or the request is canceled.
- The resume editor build issue from the unresolved layout conflict was fixed.

### Impact
`✅ Faster resume writing`
`✅ Fewer context switches while editing`
`✅ Restored editor build and load reliability`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume entry descriptions now feature inline AI-powered completion suggestions displayed as ghost text while you type.
  * Accept suggestions by pressing Tab or dismiss using Escape key.
  * Suggestions appear only while the field is focused, with a visual loading indicator while fetching from the AI provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->