### PR TITLE
fix(auth): remove fail-open development auth bypass

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -23,7 +23,7 @@ export const verifyToken = async (req, res, next) => {
       };
       next();
     } catch (firebaseError) {
-      if (firebaseError.code === 'app/no-app') {
+       if (firebaseError?.code === 'app/no-app') {
         console.error('Firebase Admin not configured');
         throw new ApiError(
           500,

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -23,19 +23,12 @@ export const verifyToken = async (req, res, next) => {
       };
       next();
     } catch (firebaseError) {
-      // For development, allow bypass if Firebase Admin is not fully configured
       if (process.env.NODE_ENV === 'development' && firebaseError.code === 'app/no-app') {
-        console.warn('Firebase Admin not configured, allowing request in development mode');
-        // Use DEV_USER_EMAIL from .env for testing, or default
-        const devEmail = process.env.DEV_USER_EMAIL || 'dev@example.com';
-        req.user = {
-          uid: 'dev-user',
-          email: devEmail,
-          name: 'Developer',
-          emailVerified: true
-        };
-        console.log(`   Dev user email: ${devEmail}`);
-        next();
+        console.error('Firebase Admin not configured');
+        throw new ApiError(
+          500,
+          'Firebase Admin not configured'
+        );
       } else {
         throw new ApiError(401, 'Invalid or expired token');
       }

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -23,7 +23,7 @@ export const verifyToken = async (req, res, next) => {
       };
       next();
     } catch (firebaseError) {
-      if (process.env.NODE_ENV === 'development' && firebaseError.code === 'app/no-app') {
+      if (firebaseError.code === 'app/no-app') {
         console.error('Firebase Admin not configured');
         throw new ApiError(
           500,

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -14,6 +14,7 @@ export const verifyToken = async (req, res, next) => {
 
     try {
       const decodedToken = await admin.auth().verifyIdToken(token);
+
       req.user = {
         uid: decodedToken.uid,
         email: decodedToken.email,
@@ -21,17 +22,19 @@ export const verifyToken = async (req, res, next) => {
         picture: decodedToken.picture || null,
         emailVerified: decodedToken.email_verified
       };
+
       next();
     } catch (firebaseError) {
-       if (firebaseError?.code === 'app/no-app') {
+      if (firebaseError?.code === 'app/no-app') {
         console.error('Firebase Admin not configured');
+
         throw new ApiError(
           500,
           'Firebase Admin not configured'
         );
-      } else {
-        throw new ApiError(401, 'Invalid or expired token');
       }
+
+      throw new ApiError(401, 'Invalid or expired token');
     }
   } catch (error) {
     next(error);
@@ -52,6 +55,7 @@ export const optionalAuth = async (req, res, next) => {
 
     try {
       const decodedToken = await admin.auth().verifyIdToken(token);
+
       req.user = {
         uid: decodedToken.uid,
         email: decodedToken.email,
@@ -59,12 +63,22 @@ export const optionalAuth = async (req, res, next) => {
         picture: decodedToken.picture || null,
         emailVerified: decodedToken.email_verified
       };
+
+      next();
     } catch (error) {
+      if (error?.code === 'app/no-app') {
+        console.error('Firebase Admin not configured');
+
+        throw new ApiError(
+          500,
+          'Firebase Admin not configured'
+        );
+      }
+
       req.user = null;
+      next();
     }
-    next();
   } catch (error) {
-    req.user = null;
-    next();
+    next(error);
   }
 };


### PR DESCRIPTION
## Description

Removed the fail-open authentication bypass from the Firebase authentication middleware.

Previously, if Firebase Admin was not configured and the application was running in development mode, requests were automatically authenticated using a fake developer user.

This change ensures authentication now fails securely instead of silently bypassing authentication.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #961 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a development-only authentication bypass. When the backend lacks required Firebase Admin configuration, requests are now logged and fail with a server error instead of proceeding with a synthetic user. Authentication consistently requires proper configuration across environments, improving security and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->