### PR TITLE
feat: add portfolio stats card to dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -20,9 +20,10 @@ import {
   Sparkles,
   GraduationCap,
   Bell,
-  Mic
+  Mic,
+  Globe
 } from 'lucide-react'
-import { resumeApi, jobTrackerApi } from '../services/api'
+import { resumeApi, jobTrackerApi, portfolioApi } from '../services/api'
 import Button from '../components/Button'
 
 const STATUS_CONFIG = {
@@ -44,6 +45,7 @@ export default function Dashboard() {
     interviewing: 0,
     offered: 0
   })
+  const [portfolioCount, setPortfolioCount] = useState(0)
 
   useEffect(() => {
     fetchData()
@@ -51,14 +53,23 @@ export default function Dashboard() {
 
   const fetchData = async () => {
     try {
-      const [resumeRes, jobsRes] = await Promise.all([
+      const [resumeRes, jobsRes, portfolioRes] = await Promise.all([
         resumeApi.getAll().catch(() => ({ resumes: [] })),
-        jobTrackerApi.getAll().catch(() => ({ trackedJobs: [] }))
+        jobTrackerApi.getAll().catch(() => ({ trackedJobs: [] })),
+        portfolioApi.getAll().catch(() => ({ portfolioItems: [] }))
       ])
 
       setResumes(resumeRes.resumes || resumeRes.data?.resumes || [])
       const jobs = jobsRes.trackedJobs || []
       setTrackedJobs(jobs)
+
+      const portfolios =
+        portfolioRes.portfolios ||
+        portfolioRes.data?.portfolios ||
+        portfolioRes.data ||
+        [];
+
+      setPortfolioCount(portfolios.length)
 
       const stats = {
         total: jobs.length,
@@ -130,7 +141,7 @@ export default function Dashboard() {
                 </button>
               </div>
             )}
-            
+
             {/* Quick Actions */}
             <motion.div variants={itemVariants} className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4 mb-10">
               {[
@@ -158,22 +169,76 @@ export default function Dashboard() {
             </motion.div>
 
             {/* Stats Row */}
-            <motion.div variants={itemVariants} className="grid grid-cols-2 md:grid-cols-5 gap-5 mb-10">
+            <motion.div variants={itemVariants} className="grid grid-cols-2 md:grid-cols-6 gap-5 mb-10">
               {[
-                { icon: Star, value: jobStats.saved, label: 'Saved', color: 'text-muted-foreground', bg: 'bg-muted' },
-                { icon: Send, value: jobStats.applied, label: 'Applied', color: 'text-primary', bg: 'bg-primary/10' },
-                { icon: MessageSquare, value: jobStats.interviewing, label: 'Interviewing', color: 'text-secondary', bg: 'bg-secondary/10' },
-                { icon: CheckCircle2, value: jobStats.offered, label: 'Offers', color: 'text-emerald-500', bg: 'bg-emerald-500/10' },
-                { icon: FileText, value: resumes.length, label: 'Resumes', color: 'text-primary', bg: 'bg-primary/10' }
-              ].map((stat, idx) => (
-                <div key={idx} className="p-6 rounded-2xl bg-card border border-border text-center hover:border-primary/30 transition-all shadow-sm group">
-                  <div className={`w-12 h-12 ${stat.bg} rounded-xl flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-transform`}>
-                    <stat.icon className={`w-6 h-6 ${stat.color}`} />
+                {
+                  icon: Star,
+                  value: jobStats.saved,
+                  label: "Saved",
+                  color: "text-muted-foreground",
+                  bg: "bg-muted",
+                },
+                {
+                  icon: Send,
+                  value: jobStats.applied,
+                  label: "Applied",
+                  color: "text-primary",
+                  bg: "bg-primary/10",
+                },
+                {
+                  icon: MessageSquare,
+                  value: jobStats.interviewing,
+                  label: "Interviewing",
+                  color: "text-secondary",
+                  bg: "bg-secondary/10",
+                },
+                {
+                  icon: CheckCircle2,
+                  value: jobStats.offered,
+                  label: "Offers",
+                  color: "text-emerald-500",
+                  bg: "bg-emerald-500/10",
+                },
+                {
+                  icon: FileText,
+                  value: resumes.length,
+                  label: "Resumes",
+                  color: "text-primary",
+                  bg: "bg-primary/10",
+                },
+                {
+                  icon: Globe,
+                  value: portfolioCount,
+                  label: "Portfolios",
+                  color: "text-purple-500",
+                  bg: "bg-purple-500/10",
+                  link: "/portfolio",
+                },
+              ].map((stat, idx) => {
+                const content = (
+                  <div className="p-6 rounded-2xl bg-card border border-border text-center hover:border-primary/30 transition-all shadow-sm group">
+                    <div className={`w-12 h-12 ${stat.bg} rounded-xl flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-transform`}>
+                      <stat.icon className={`w-6 h-6 ${stat.color}`} />
+                    </div>
+
+                    <p className="text-3xl font-black text-foreground">
+                      {stat.value}
+                    </p>
+
+                    <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest mt-1">
+                      {stat.label}
+                    </p>
                   </div>
-                  <p className="text-3xl font-black text-foreground">{stat.value}</p>
-                  <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest mt-1">{stat.label}</p>
-                </div>
-              ))}
+                );
+
+                return stat.link ? (
+                  <Link key={idx} to={stat.link}>
+                    {content}
+                  </Link>
+                ) : (
+                  <div key={idx}>{content}</div>
+                );
+              })}
             </motion.div>
 
             <div className="grid lg:grid-cols-2 gap-10">
@@ -203,12 +268,12 @@ export default function Dashboard() {
                 ) : (
                   <div className="rounded-[2rem] bg-card border border-border overflow-hidden shadow-sm">
                     <div className="divide-y divide-border">
-                     {/** * GSSoC Optimization: Defensive structural evaluation on the active data view slice.
-                        * Prevents layout container voids if the array slice metrics index is altered.
-                        */}
+                      {/** * GSSoC Optimization: Defensive structural evaluation on the active data view slice.
+                       * Prevents layout container voids if the array slice metrics index is altered.
+                       */}
                       {(() => {
                         const displayedJobs = trackedJobs.slice(0, 5);
-                        
+
                         if (displayedJobs.length > 0) {
                           return displayedJobs.map((job, index) => {
                             const statusConfig = STATUS_CONFIG[job.status] || STATUS_CONFIG.saved;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -191,6 +191,21 @@ export const resumeApi = {
   }
 }
 
+// ============ PORTFOLIO API ============
+export const portfolioApi = {
+  // Get all portfolios
+  async getAll() {
+    const headers = await getAuthHeaders()
+
+    const response = await fetch(`${API_BASE}/portfolio`, {
+      method: 'GET',
+      headers
+    })
+
+    return handleResponse(response)
+  }
+}
+
 // ============ ENHANCE API ============
 export const enhanceApi = {
   // Enhance resume with AI


### PR DESCRIPTION
## Description

Added a new Portfolio stat card to the Dashboard page that displays the total portfolio count fetched from the portfolio API endpoint. The card is placed after the Resumes stat card and links to the portfolio page.

## Type of Change

* [x] New feature

## Related Issue

Fixes #701

## Testing

* [x] Tested Locally

## Screenshots 

* before
<img width="920" height="410" alt="image" src="https://github.com/user-attachments/assets/cb88b30c-930f-4725-bb47-b3cf81f2ddb1" />

* after
<img width="911" height="400" alt="Screenshot 2026-05-20 230117" src="https://github.com/user-attachments/assets/d15e6d93-e0f4-4323-83e0-921d5087cb01" />


## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new Portfolio stat tile is now displayed on the main dashboard, showing your total portfolio count and providing direct access to your portfolios section.
  * The dashboard now automatically loads and tracks your portfolio data in addition to your resumes and tracked job applications, keeping all your professional information current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->