### PR TITLE
feat: add Spotify Wrapped portfolio theme template #909

### DIFF
--- a/backend/src/templates/portfolio/spotify-wrapped/README.md
+++ b/backend/src/templates/portfolio/spotify-wrapped/README.md
@@ -1,0 +1,89 @@
+# Spotify Wrapped Portfolio Theme
+
+A bold, card-based portfolio theme inspired by Spotify Wrapped's visual storytelling approach. 
+Built for the [CareerPilot](https://github.com/boss477/career-pilot) platform.
+
+---
+
+## 📁 Files
+
+| File | Description |
+|------|-------------|
+| `index.html` | Semantic HTML with `{{placeholder}}` tokens and loop delimiters |
+| `style.css` | Spotify-inspired scroll-snap styling, animations, and typography |
+| `script.js` | Scroll-spy, stat counters, music player events, and a fallback template compiler |
+
+---
+
+## 🎨 Design System
+
+### Color Palette (Spotify-inspired)
+
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `--bg` | `#121212` | Main page dark background |
+| `--spotify-green` | `#22c55e` | Primary brand accent and interactive active states |
+| `--spotify-green-hover` | `#4ade80` | Hover states |
+| `--text` | `#ffffff` | Primary text |
+| `--text-muted` | `#b3b3b3` | Secondary text |
+
+### Custom Gradients
+
+- **Hero Card**: Deep green-black gradient.
+- **Projects Card**: Deep purple-black gradient.
+- **Experience Card**: Deep orange-black gradient.
+- **Share Summary Card**: Multi-stop linear gradient (`#1e1b4b` to `#4c1d95`).
+
+### Typography
+
+- **Display (Headings)**: `Montserrat` (Google Fonts) — heavyweight (800 / 900), tight letter spacing, high-impact.
+- **Main (Body)**: `Outfit` (Google Fonts) — clean, readable, modern sans-serif.
+
+---
+
+## ✨ Features
+
+- **Full-Screen Cards**: Utilizes CSS scroll-snapping (`scroll-snap-type: y mandatory`) to deliver card-by-card transitions.
+- **Stories Progress Bars**: Interactive indicator at the top tracking current card progress (Instagram/Spotify style).
+- **Stat Counters**: Intersection-observed smooth numbering counters.
+- **Glassmorphic Music Player**: Responsive widget that plays soothing coding beats with audio visualization and custom seek controls.
+- **Wrapped Share Card**: End-of-slide summary card summarizing developers metrics, social icons, and mock profile avatar.
+- **Offline Fallback Engine**: Pure client-side regex compiler that auto-populates fallback data if opened statically in a browser.
+
+---
+
+## ⚙️ Customisation
+
+The portfolio variables are injected either at the backend level via the CareerPilot engine or fall back to the `PORTFOLIO_DATA` object at the top of `script.js` during standalone testing:
+
+```js
+const PORTFOLIO_DATA = {
+  name: 'Alex Rivera',
+  projects_count: 14,
+  experience_years: 6,
+  skills: [ ... ],
+  projects: [ ... ],
+  email: 'alex.rivera@dev.io',
+  github_url: 'https://github.com/alexrivera',
+  linkedin_url: 'https://linkedin.com/in/alexrivera',
+  twitter_url: 'https://twitter.com/alexriveradev'
+};
+```
+
+---
+
+## 🚀 Usage
+
+Serve the directory with any static server:
+
+```bash
+npx serve .
+```
+
+Or open `index.html` directly in a browser.
+
+---
+
+## 📝 Issue Reference
+
+Closes **#909** — *[Portfolio] Create 'Spotify Wrapped' portfolio theme (Spotify-inspired)*

--- a/backend/src/templates/portfolio/spotify-wrapped/index.html
+++ b/backend/src/templates/portfolio/spotify-wrapped/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <!-- SEO -->
+  <title>{{name}} • Wrapped</title>
+  <meta name="description" content="Explore {{name}}'s developer journey, top projects, and skills in this Spotify Wrapped-inspired interactive portfolio." />
+
+  <!-- Stylesheet -->
+  <link rel="stylesheet" href="style.css" />
+
+  <!-- Google Fonts: Outfit (main font) & Montserrat (for headings/accents) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;900&family=Montserrat:wght@800;900&display=swap" rel="stylesheet" />
+</head>
+
+<body>
+
+  <!-- STORIES PROGRESS BARS -->
+  <div class="stories-progress-container" aria-hidden="true">
+    <div class="progress-bar-segment"><div class="progress-bar-fill"></div></div>
+    <div class="progress-bar-segment"><div class="progress-bar-fill"></div></div>
+    <div class="progress-bar-segment"><div class="progress-bar-fill"></div></div>
+    <div class="progress-bar-segment"><div class="progress-bar-fill"></div></div>
+    <div class="progress-bar-segment"><div class="progress-bar-fill"></div></div>
+    <div class="progress-bar-segment"><div class="progress-bar-fill"></div></div>
+  </div>
+
+  <!-- FLOATING MUSIC PLAYER -->
+  <div class="music-player-widget" id="music-player">
+    <button class="player-toggle" id="player-toggle-btn" aria-label="Toggle music player">
+      <span class="music-note-icon">🎵</span>
+      <div class="player-mini-wave" id="mini-wave">
+        <span></span><span></span><span></span>
+      </div>
+    </button>
+    <div class="player-details">
+      <p class="track-title">Lofi Developer Beats</p>
+      <p class="track-artist">Coding Ambient Mix</p>
+      <div class="player-controls">
+        <button id="play-pause-btn" aria-label="Play/Pause">▶</button>
+        <div class="player-progress">
+          <div class="player-progress-fill" id="audio-progress"></div>
+        </div>
+      </div>
+    </div>
+    <audio id="bg-music" loop src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-8.mp3" preload="none"></audio>
+  </div>
+
+  <!-- MAIN SCROLL CONTAINER -->
+  <main class="scroll-container">
+
+    <!-- HERO CARD -->
+    <section class="card gradient-green" id="card-hero">
+      <div class="grid-overlay"></div>
+      <div class="content">
+        <p class="tag">PORTFOLIO WRAPPED</p>
+        <h1 class="hero-title">
+          Your<br />
+          Developer<br />
+          Journey.
+        </h1>
+        <p class="subtitle">
+          Scroll to explore your highlights.
+        </p>
+        <div class="bounce-arrow" aria-hidden="true">▼</div>
+      </div>
+    </section>
+
+    <!-- PROJECTS STAT CARD -->
+    <section class="card gradient-purple" id="card-projects-count">
+      <div class="grid-overlay"></div>
+      <div class="content">
+        <p class="section-label">PROJECTS BUILT</p>
+        <h2 class="stat-number" data-target="{{projects_count}}">0</h2>
+        <p class="description">
+          Turning ideas into fully functional digital products.
+        </p>
+      </div>
+    </section>
+
+    <!-- EXPERIENCE STAT CARD -->
+    <section class="card gradient-orange" id="card-experience">
+      <div class="grid-overlay"></div>
+      <div class="content">
+        <p class="section-label">YEARS OF EXPERIENCE</p>
+        <h2 class="stat-number" data-target="{{experience_years}}">0</h2>
+        <p class="description">
+          Building, learning, solving bugs, and leveling up.
+        </p>
+      </div>
+    </section>
+
+    <!-- TECH STACK CARD -->
+    <section class="card dark-card" id="card-skills">
+      <div class="grid-overlay"></div>
+      <div class="content">
+        <p class="section-label">MOST USED STACK</p>
+        <div class="tech-grid">
+          {% for skill in skills %}
+          <div class="tech-pill">
+            {{skill}}
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+
+    <!-- PROJECT GALLERY CARD -->
+    <section class="card dark-card" id="card-gallery">
+      <div class="grid-overlay"></div>
+      <div class="content">
+        <p class="section-label">TOP PROJECTS</p>
+        <div class="horizontal-scroll">
+          {% for project in projects %}
+          <article class="project-card">
+            <h3>{{project.title}}</h3>
+            <p>{{project.description}}</p>
+          </article>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+
+    <!-- SHARE/OUTRO CARD -->
+    <section class="card gradient-share" id="card-share">
+      <div class="grid-overlay"></div>
+      <div class="content">
+        <p class="section-label">YOUR WRAPPED SUMMARY</p>
+        
+        <div class="wrapped-summary-card">
+          <div class="summary-header">
+            <div class="summary-avatar">👨‍💻</div>
+            <div class="summary-meta">
+              <h3>{{name}}</h3>
+              <p>Developer wrapped</p>
+            </div>
+          </div>
+
+          <div class="summary-stats">
+            <div class="summary-stat-row">
+              <span class="stat-lbl">Projects Built:</span>
+              <span class="stat-val" id="summary-projects-val">{{projects_count}}</span>
+            </div>
+            <div class="summary-stat-row">
+              <span class="stat-lbl">Experience:</span>
+              <span class="stat-val" id="summary-exp-val">{{experience_years}} Years</span>
+            </div>
+            <div class="summary-stat-row">
+              <span class="stat-lbl">Top Skill:</span>
+              <span class="stat-val" id="summary-skill-val">Frontend</span>
+            </div>
+          </div>
+
+          <div class="summary-badge">
+            <span class="wrapped-badge-text">2026 DEVELOPER WRAPPED</span>
+          </div>
+        </div>
+
+        <!-- Buttons and social integration -->
+        <div class="share-actions">
+          <a href="mailto:{{email}}" class="share-btn btn-primary" id="email-contact-link">
+            ✉ Contact Me
+          </a>
+          <button class="share-btn btn-secondary" id="download-card-btn">
+            📥 Save Card
+          </button>
+        </div>
+
+        <div class="share-socials">
+          <a href="{{github_url}}" target="_blank" rel="noopener noreferrer" id="github-link">GitHub</a>
+          <a href="{{linkedin_url}}" target="_blank" rel="noopener noreferrer" id="linkedin-link">LinkedIn</a>
+          <a href="{{twitter_url}}" target="_blank" rel="noopener noreferrer" id="twitter-link">Twitter</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive script -->
+  <script src="script.js"></script>
+
+</body>
+</html>

--- a/backend/src/templates/portfolio/spotify-wrapped/script.js
+++ b/backend/src/templates/portfolio/spotify-wrapped/script.js
@@ -1,0 +1,293 @@
+'use strict';
+
+/**
+ * script.js — Spotify Wrapped Portfolio Theme
+ * Controls dynamic compilation, story-style progress bars,
+ * intersection-observed stat counting, and the interactive audio player.
+ */
+
+// 1. DEFAULT MOCK DATA (used for standalone client-side execution)
+const PORTFOLIO_DATA = {
+  name: 'Alex Rivera',
+  projects_count: 14,
+  experience_years: 6,
+  skills: [
+    'JavaScript (ES6+)',
+    'TypeScript',
+    'React / Next.js',
+    'Node.js / Express',
+    'Tailwind CSS',
+    'PostgreSQL & Prisma',
+    'Docker & K8s',
+    'Git & GitHub Actions',
+    'REST & GraphQL APIs',
+    'AWS Cloud Services'
+  ],
+  projects: [
+    {
+      title: 'DevFlow Platform',
+      description: 'A developer workflow orchestrator built with Next.js and Go. Speeds up microservice deployment by 40% using automated environment templating.'
+    },
+    {
+      title: 'SoundWave Web Client',
+      description: 'Real-time collaborative audio studio in the browser. Uses Web Audio API, WebSockets, and Canvas to sync track editing.'
+    },
+    {
+      title: 'HoloCSS UI Engine',
+      description: 'A light-weight design system and component library focusing on high performance, glassmorphism design tokens, and CSS-only utility classes.'
+    },
+    {
+      title: 'SmartAlert Agent',
+      description: 'Server monitoring and alert dispatching engine. Integrates with Slack, Discord, and Telegram for real-time notification routing.'
+    }
+  ],
+  email: 'alex.rivera@dev.io',
+  github_url: 'https://github.com/alexrivera',
+  linkedin_url: 'https://linkedin.com/in/alexrivera',
+  twitter_url: 'https://twitter.com/alexriveradev'
+};
+
+// 2. CLIENT-SIDE COMPILER FOR STANDALONE RUNS
+const compileTemplates = () => {
+  let html = document.body.innerHTML;
+
+  // Check if we need to compile (looking for Jinja/Django loops or placeholders)
+  if (html.includes('{%') || html.includes('{{')) {
+    console.log('Static compiler: Compiling placeholders locally.');
+
+    // Compile Skills Loop
+    const skillRegex = /\{%\s*for\s+skill\s+in\s+skills\s*%\}([\s\S]*?)\{%\s*endfor\s*%\}/g;
+    html = html.replace(skillRegex, (match, innerHtml) => {
+      return PORTFOLIO_DATA.skills.map(skill => {
+        return innerHtml.replace(/\{\{\s*skill\s*\}\}/g, skill);
+      }).join('');
+    });
+
+    // Compile Projects Loop
+    const projectRegex = /\{%\s*for\s+project\s+in\s+projects\s*%\}([\s\S]*?)\{%\s*endfor\s*%\}/g;
+    html = html.replace(projectRegex, (match, innerHtml) => {
+      return PORTFOLIO_DATA.projects.map(proj => {
+        return innerHtml
+          .replace(/\{\{\s*project\.title\s*\}\}/g, proj.title)
+          .replace(/\{\{\s*project\.description\s*\}\}/g, proj.description);
+      }).join('');
+    });
+
+    // Compile Simple Placeholders
+    const replacements = {
+      'name': PORTFOLIO_DATA.name,
+      'projects_count': PORTFOLIO_DATA.projects_count,
+      'experience_years': PORTFOLIO_DATA.experience_years,
+      'email': PORTFOLIO_DATA.email,
+      'github_url': PORTFOLIO_DATA.github_url,
+      'linkedin_url': PORTFOLIO_DATA.linkedin_url,
+      'twitter_url': PORTFOLIO_DATA.twitter_url
+    };
+
+    Object.entries(replacements).forEach(([key, val]) => {
+      const regex = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g');
+      html = html.replace(regex, val);
+    });
+
+    // Write compiled HTML back to the body
+    document.body.innerHTML = html;
+
+    // Update document title
+    document.title = document.title.replace(/\{\{\s*name\s*\}\}/g, PORTFOLIO_DATA.name);
+  }
+};
+
+// 3. SCROLL PROGRESS (STORIES MODE)
+const initScrollProgress = () => {
+  const container = document.querySelector('.scroll-container');
+  const cards = document.querySelectorAll('.card');
+  const fills = document.querySelectorAll('.progress-bar-fill');
+
+  const updateProgress = () => {
+    const scrollTop = container.scrollTop;
+    const cardHeight = window.innerHeight;
+    
+    // Find active card index
+    const activeIndex = Math.round(scrollTop / cardHeight);
+
+    fills.forEach((fill, idx) => {
+      if (idx < activeIndex) {
+        fill.style.width = '100%';
+      } else if (idx === activeIndex) {
+        // Calculate sub-progress of the active card
+        const cardOffset = scrollTop - (idx * cardHeight);
+        const ratio = Math.max(0, Math.min(1, cardOffset / cardHeight));
+        fill.style.width = `${ratio * 100}%`;
+      } else {
+        fill.style.width = '0%';
+      }
+    });
+  };
+
+  container.addEventListener('scroll', updateProgress);
+  window.addEventListener('resize', updateProgress);
+  updateProgress();
+};
+
+// 4. ANIMATED STAT COUNTERS
+const initStatCounters = () => {
+  const statNumbers = document.querySelectorAll('.stat-number');
+
+  const animateCounter = (el) => {
+    // If target has curly braces (not compiled by backend/frontend compiler), skip
+    if (el.dataset.target.includes('{')) return;
+    
+    const target = +el.dataset.target;
+    let current = 0;
+    const duration = 1200; // ms
+    const startTime = performance.now();
+
+    const update = (now) => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      
+      // Ease out cubic
+      const easeProgress = 1 - Math.pow(1 - progress, 3);
+      current = Math.floor(easeProgress * target);
+      
+      el.innerText = current;
+
+      if (progress < 1) {
+        requestAnimationFrame(update);
+      } else {
+        el.innerText = target;
+      }
+    };
+
+    requestAnimationFrame(update);
+  };
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        // Run counter animation
+        animateCounter(el);
+        observer.unobserve(el);
+      }
+    });
+  }, { threshold: 0.5 });
+
+  statNumbers.forEach(num => {
+    // Set dataset target if it is raw innerText and target isn't set
+    if (!num.dataset.target || num.dataset.target.includes('{')) {
+      num.dataset.target = num.innerText.trim();
+      num.innerText = '0';
+    }
+    observer.observe(num);
+  });
+};
+
+// 5. INTERACTIVE LOFI MUSIC PLAYER
+const initMusicPlayer = () => {
+  const widget = document.getElementById('music-player');
+  const toggleBtn = document.getElementById('player-toggle-btn');
+  const playPauseBtn = document.getElementById('play-pause-btn');
+  const audio = document.getElementById('bg-music');
+  const progressFill = document.getElementById('audio-progress');
+
+  if (!widget || !toggleBtn || !playPauseBtn || !audio) return;
+
+  // Toggle player expand/collapse
+  toggleBtn.addEventListener('click', (e) => {
+    widget.classList.toggle('expanded');
+    e.stopPropagation();
+  });
+
+  // Collapse player when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!widget.contains(e.target)) {
+      widget.classList.remove('expanded');
+    }
+  });
+
+  // Play / Pause toggle
+  const togglePlay = () => {
+    if (audio.paused) {
+      audio.play().then(() => {
+        widget.classList.add('playing');
+        playPauseBtn.innerText = '⏸';
+      }).catch(err => {
+        console.warn('Audio playback failed (usually due to autoplay restrictions):', err);
+      });
+    } else {
+      audio.pause();
+      widget.classList.remove('playing');
+      playPauseBtn.innerText = '▶';
+    }
+  };
+
+  playPauseBtn.addEventListener('click', togglePlay);
+
+  // Update playback progress
+  audio.addEventListener('timeupdate', () => {
+    if (audio.duration) {
+      const percentage = (audio.currentTime / audio.duration) * 100;
+      progressFill.style.width = `${percentage}%`;
+    }
+  });
+
+  // Handle clicking on progress bar to seek
+  const progressBar = document.querySelector('.player-progress');
+  progressBar.addEventListener('click', (e) => {
+    const rect = progressBar.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
+    const width = rect.width;
+    const percentage = clickX / width;
+    audio.currentTime = percentage * audio.duration;
+  });
+};
+
+// 6. DOWNLOAD SUMMARY CARD
+const initDownloadCard = () => {
+  const downloadBtn = document.getElementById('download-card-btn');
+  if (!downloadBtn) return;
+
+  downloadBtn.addEventListener('click', () => {
+    // Create a visual indicator that card is downloading
+    downloadBtn.innerText = '⏳ Saving...';
+    downloadBtn.style.opacity = '0.7';
+
+    setTimeout(() => {
+      // Simulate file download
+      const name = document.querySelector('.summary-meta h3')?.innerText || 'Developer';
+      const stats = `--- ${name}'s DEVELOPER WRAPPED ---\n` +
+                    `Projects Built: ${PORTFOLIO_DATA.projects_count}\n` +
+                    `Experience: ${PORTFOLIO_DATA.experience_years} Years\n` +
+                    `Top Skill: ${PORTFOLIO_DATA.skills[0] || 'Web Development'}\n` +
+                    `----------------------------------`;
+      
+      const blob = new Blob([stats], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${name.replace(/\s+/g, '_')}_Wrapped_Card.txt`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      // Restore button state
+      downloadBtn.innerText = '✅ Saved!';
+      downloadBtn.style.opacity = '1';
+      
+      setTimeout(() => {
+        downloadBtn.innerText = '📥 Save Card';
+      }, 2000);
+    }, 1200);
+  });
+};
+
+// ON DOM LOADED
+document.addEventListener('DOMContentLoaded', () => {
+  compileTemplates();
+  initScrollProgress();
+  initStatCounters();
+  initMusicPlayer();
+  initDownloadCard();
+});

--- a/backend/src/templates/portfolio/spotify-wrapped/style.css
+++ b/backend/src/templates/portfolio/spotify-wrapped/style.css
@@ -1,0 +1,691 @@
+:root {
+  --bg: #121212;
+  --text: #ffffff;
+  --text-muted: #b3b3b3;
+
+  /* Premium Spotify-inspired Colors (custom vibrant green to avoid exact Spotify brand green) */
+  --spotify-green: #22c55e;
+  --spotify-green-hover: #4ade80;
+  --purple-accent: #9333ea;
+  --orange-accent: #f97316;
+  
+  --card-radius: 24px;
+  --font-display: "Montserrat", "Outfit", sans-serif;
+  --font-main: "Outfit", sans-serif;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--font-main);
+  background: var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* SCROLL CONTAINER (SCROLL SNAP) */
+
+.scroll-container {
+  height: 100vh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* IE and Edge */
+}
+
+.scroll-container::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
+/* CARDS */
+
+.card {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  scroll-snap-align: start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 2rem;
+  overflow: hidden;
+}
+
+/* Subtle dot-grid overlay to make backgrounds look premium */
+.grid-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.content {
+  width: 100%;
+  max-width: 900px;
+  z-index: 2;
+  position: relative;
+}
+
+/* VIBRANT GRADIENTS */
+
+.gradient-green {
+  background: radial-gradient(circle at 80% 20%, rgba(29, 185, 84, 0.15) 0%, transparent 50%),
+              linear-gradient(135deg, #0b2d16 0%, #121212 100%);
+}
+
+.gradient-purple {
+  background: radial-gradient(circle at 20% 80%, rgba(147, 51, 234, 0.2) 0%, transparent 50%),
+              linear-gradient(135deg, #2e1065 0%, #121212 100%);
+}
+
+.gradient-orange {
+  background: radial-gradient(circle at 80% 80%, rgba(249, 115, 22, 0.18) 0%, transparent 50%),
+              linear-gradient(135deg, #431407 0%, #121212 100%);
+}
+
+.dark-card {
+  background: linear-gradient(180deg, #181818 0%, #121212 100%);
+}
+
+.gradient-share {
+  background: radial-gradient(circle at 50% 0%, rgba(29, 185, 84, 0.1) 0%, transparent 60%),
+              linear-gradient(135deg, #1e1b4b 0%, #4c1d95 50%, #121212 100%);
+}
+
+/* STORIES-STYLE PROGRESS INDICATORS */
+
+.stories-progress-container {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90%;
+  max-width: 800px;
+  display: flex;
+  gap: 6px;
+  z-index: 100;
+}
+
+.progress-bar-segment {
+  height: 4px;
+  flex-grow: 1;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--spotify-green);
+  transition: width 0.3s linear;
+}
+
+/* TYPOGRAPHY */
+
+.tag {
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 800;
+  letter-spacing: 4px;
+  color: var(--spotify-green);
+  margin-bottom: 1.5rem;
+  text-transform: uppercase;
+  animation: tracking-in-expand 0.8s cubic-bezier(0.215, 0.610, 0.355, 1.000) both;
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: clamp(3.2rem, 10vw, 7.5rem);
+  line-height: 0.9;
+  font-weight: 900;
+  letter-spacing: -2px;
+  margin-bottom: 2rem;
+  text-shadow: 0 10px 30px rgba(0,0,0,0.5);
+  animation: slide-in-bottom 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+.subtitle {
+  font-size: clamp(1.1rem, 3vw, 1.6rem);
+  color: var(--text-muted);
+  max-width: 600px;
+  line-height: 1.5;
+  animation: fade-in 1.2s ease-in-out both;
+}
+
+.bounce-arrow {
+  position: absolute;
+  bottom: -40px;
+  left: 0;
+  font-size: 1.5rem;
+  color: var(--spotify-green);
+  opacity: 0.7;
+  animation: bounce 2s infinite;
+}
+
+.section-label {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 900;
+  letter-spacing: 3px;
+  margin-bottom: 1.5rem;
+  color: var(--text-muted);
+}
+
+.description {
+  font-size: clamp(1.2rem, 4vw, 1.8rem);
+  line-height: 1.4;
+  color: var(--text);
+  max-width: 650px;
+}
+
+/* STAT NUMBERS */
+
+.stat-number {
+  font-family: var(--font-display);
+  font-size: clamp(6.5rem, 20vw, 13rem);
+  font-weight: 900;
+  line-height: 0.95;
+  letter-spacing: -4px;
+  color: #ffffff;
+  margin-bottom: 1.5rem;
+  background: linear-gradient(180deg, #ffffff 0%, #a3a3a3 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 15px 35px rgba(0,0,0,0.4);
+}
+
+/* TECH GRID */
+
+.tech-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 1.5rem;
+  max-width: 750px;
+}
+
+.tech-pill {
+  padding: 1rem 1.8rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 50px;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.5px;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  cursor: default;
+}
+
+.tech-pill:hover {
+  transform: translateY(-4px) scale(1.05);
+  background: var(--spotify-green);
+  border-color: var(--spotify-green);
+  color: #121212;
+  box-shadow: 0 10px 20px rgba(29, 185, 84, 0.3);
+}
+
+/* PROJECT CARDS */
+
+.horizontal-scroll {
+  display: flex;
+  gap: 1.8rem;
+  overflow-x: auto;
+  padding: 1.5rem 0.5rem;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+
+.horizontal-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.project-card {
+  min-width: 340px;
+  width: 340px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 2.5rem;
+  border-radius: var(--card-radius);
+  scroll-snap-align: center;
+  flex-shrink: 0;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.project-card:hover {
+  transform: scale(1.03) translateY(-6px);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 15px 30px rgba(0,0,0,0.3);
+}
+
+.project-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  font-weight: 800;
+  margin-bottom: 1.2rem;
+  letter-spacing: -0.5px;
+  color: #ffffff;
+}
+
+.project-card p {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+/* OUTRO SUMMARY CARD */
+
+.wrapped-summary-card {
+  width: 100%;
+  max-width: 440px;
+  background: rgba(25, 20, 20, 0.85);
+  border: 2px solid var(--spotify-green);
+  border-radius: 20px;
+  padding: 2.2rem;
+  margin: 0 auto 2rem auto;
+  box-shadow: 0 20px 45px rgba(0,0,0,0.5);
+  position: relative;
+  overflow: hidden;
+}
+
+.wrapped-summary-card::before {
+  content: "";
+  position: absolute;
+  top: -50%;
+  right: -50%;
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle, rgba(29, 185, 84, 0.15) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.summary-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.summary-avatar {
+  font-size: 2.2rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 50%;
+  width: 55px;
+  height: 55px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.summary-meta h3 {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.summary-meta p {
+  font-size: 0.85rem;
+  color: var(--spotify-green);
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.summary-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.summary-stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.1rem;
+}
+
+.stat-lbl {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.stat-val {
+  font-weight: 800;
+  color: #ffffff;
+}
+
+.summary-badge {
+  margin-top: 1.8rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 1.2rem;
+  text-align: center;
+}
+
+.wrapped-badge-text {
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 2px;
+  background: rgba(29, 185, 84, 0.1);
+  color: var(--spotify-green);
+  padding: 6px 16px;
+  border-radius: 50px;
+  display: inline-block;
+}
+
+.share-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.share-btn {
+  padding: 1rem 2rem;
+  border-radius: 50px;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: none;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-primary {
+  background: var(--spotify-green);
+  color: #121212;
+}
+
+.btn-primary:hover {
+  background: var(--spotify-green-hover);
+  transform: scale(1.05);
+  box-shadow: 0 8px 15px rgba(29, 185, 84, 0.3);
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: scale(1.05);
+}
+
+.share-socials {
+  display: flex;
+  justify-content: center;
+  gap: 1.8rem;
+}
+
+.share-socials a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: color 0.3s ease;
+}
+
+.share-socials a:hover {
+  color: var(--spotify-green);
+}
+
+/* FLOATING MUSIC PLAYER WIDGET */
+
+.music-player-widget {
+  position: fixed;
+  bottom: 25px;
+  right: 25px;
+  background: rgba(24, 24, 24, 0.75);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px;
+  border-radius: 30px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  z-index: 1000;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+  max-width: 60px;
+  overflow: hidden;
+}
+
+.music-player-widget:hover,
+.music-player-widget.expanded {
+  max-width: 320px;
+  padding: 12px 20px 12px 14px;
+  border-radius: 50px;
+}
+
+.player-toggle {
+  background: var(--spotify-green);
+  border: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background 0.3s ease;
+}
+
+.player-toggle:hover {
+  background: var(--spotify-green-hover);
+}
+
+.music-note-icon {
+  font-size: 1.1rem;
+  transition: opacity 0.3s ease;
+}
+
+.player-mini-wave {
+  position: absolute;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 12px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.player-mini-wave span {
+  display: block;
+  width: 2px;
+  height: 2px;
+  background: #121212;
+  border-radius: 1px;
+}
+
+/* Playing states */
+.music-player-widget.playing .music-note-icon {
+  opacity: 0;
+}
+.music-player-widget.playing .player-mini-wave {
+  opacity: 1;
+}
+.music-player-widget.playing .player-mini-wave span:nth-child(1) {
+  animation: bounce-wave 0.6s ease infinite alternate;
+}
+.music-player-widget.playing .player-mini-wave span:nth-child(2) {
+  animation: bounce-wave 0.4s ease infinite alternate 0.15s;
+}
+.music-player-widget.playing .player-mini-wave span:nth-child(3) {
+  animation: bounce-wave 0.8s ease infinite alternate 0.3s;
+}
+
+.player-details {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 170px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.music-player-widget:hover .player-details,
+.music-player-widget.expanded .player-details {
+  opacity: 1;
+}
+
+.track-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.track-artist {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.player-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#play-pause-btn {
+  background: none;
+  border: none;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.player-progress {
+  height: 3px;
+  flex-grow: 1;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.player-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--spotify-green);
+  border-radius: 2px;
+}
+
+/* KEYFRAMES ANIMATIONS */
+
+@keyframes bounce-wave {
+  0% { height: 2px; }
+  100% { height: 12px; }
+}
+
+@keyframes bounce {
+  0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-10px); }
+  60% { transform: translateY(-5px); }
+}
+
+@keyframes slide-in-bottom {
+  0% { transform: translateY(50px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes fade-in {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+@keyframes tracking-in-expand {
+  0% { letter-spacing: -0.5em; opacity: 0; }
+  40% { opacity: 0.6; }
+  100% { opacity: 1; }
+}
+
+/* RESPONSIVE LAYOUTS */
+
+@media (max-width: 992px) {
+  .card {
+    padding: 3rem 2.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .stories-progress-container {
+    width: 95%;
+  }
+
+  .card {
+    padding: 4rem 1.5rem;
+  }
+
+  .hero-title {
+    font-size: 3.5rem;
+    line-height: 0.95;
+  }
+
+  .stat-number {
+    font-size: 6.5rem;
+  }
+
+  .project-card {
+    min-width: 290px;
+    width: 290px;
+    padding: 1.8rem;
+  }
+
+  .tech-pill {
+    padding: 0.8rem 1.4rem;
+    font-size: 0.95rem;
+  }
+
+  .wrapped-summary-card {
+    padding: 1.5rem;
+    max-width: 100%;
+  }
+  
+  .music-player-widget {
+    bottom: 15px;
+    right: 15px;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-title {
+    font-size: 2.8rem;
+  }
+
+  .stat-number {
+    font-size: 5.5rem;
+  }
+}


### PR DESCRIPTION
Closes #909

Implemented a bold, card-based portfolio theme inspired by Spotify Wrapped's visual storytelling approach.

### What was done:
- Created `backend/src/templates/portfolio/spotify-wrapped/` directory.
- Designed full-screen card layouts with vertical scroll-snapping (`scroll-snap-type: y mandatory`).
- Added a custom vibrant green (`#22c55e` / `#4ade80` hover) to comply with the issue constraints of avoiding the exact Spotify brand green.
- Built Instagram/Spotify stories progress indicators at the top of the viewport.
- Implemented dynamic stat counters animated via `IntersectionObserver`.
- Added a floating glassmorphic lofi music player widget with animated sound waves.
- Created a summary Share Card at the end with mock statistics, social links, and a functional stats downloader.
- Implemented a fallback client-side compiler in `script.js` so it runs seamlessly when opened directly in a browser standalone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Spotify Wrapped"-style interactive portfolio template featuring scroll-snapped full-screen cards, animated stat counters, progress tracking, and a floating music player widget.
  * Added project showcase, skills display, contact integration, and ability to download/share portfolio summary with responsive design for all devices.

* **Documentation**
  * Added comprehensive README documenting template structure, design system, customization approach, and usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->