### PR TITLE
fix/community-fix-likes-admin-gate → fixes #1096

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,3 +52,7 @@ ALERT_CRON_SCHEDULE=0 0 */2 * *
 AI_PROVIDER=gemini
 GROQ_API_KEY=your-groq-api-key
 OPENAI_API_KEY=your-openai-api-key
+
+# Comma-separated Firebase UIDs allowed to call admin-only endpoints (e.g. POST /api/community/fix-likes)
+# Example: ADMIN_UIDS=uid1abc,uid2def
+ADMIN_UIDS=

--- a/backend/src/routes/community.js
+++ b/backend/src/routes/community.js
@@ -38,6 +38,21 @@ const router = express.Router();
 // All routes require authentication
 router.use(verifyToken);
 
+// Restricts a route to UIDs listed in ADMIN_UIDS (comma-separated env var).
+// Must be placed after router.use(verifyToken) so req.user is already populated.
+const requireAdmin = (req, res, next) => {
+  const adminUIDs = (process.env.ADMIN_UIDS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (!adminUIDs.includes(req.user?.uid)) {
+    return res.status(403).json({ success: false, error: 'Admin access required' });
+  }
+
+  next();
+};
+
 // ============ CHANNEL ROUTES ============
 router.get('/channels', getChannels);
 router.get('/channels/:channelId', getChannel);
@@ -128,6 +143,7 @@ router.get('/presence/channel/:channelId/members', async (req, res, next) => {
 router.get('/search', searchCommunity);
 
 // ============ UTILITY ROUTES ============
-router.post('/fix-likes', fixPostLikeCounts);
+// requireAdmin enforces ADMIN_UIDS allowlist — prevents DoS via unbounded batch recalculation
+router.post('/fix-likes', requireAdmin, fixPostLikeCounts);
 
 export default router;

--- a/backend/src/routes/community.js
+++ b/backend/src/routes/community.js
@@ -35,21 +35,28 @@ import {
 
 const router = express.Router();
 
+// Parsed once at module load — ADMIN_UIDS is static for the process lifetime.
+const ADMIN_UIDS = (process.env.ADMIN_UIDS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+if (ADMIN_UIDS.length === 0) {
+  console.warn(
+    '⚠️  ADMIN_UIDS is not set — the /community/fix-likes endpoint will reject all requests. ' +
+    'Set ADMIN_UIDS to a comma-separated list of Firebase UIDs in your .env file.'
+  );
+}
+
 // All routes require authentication
 router.use(verifyToken);
 
 // Restricts a route to UIDs listed in ADMIN_UIDS (comma-separated env var).
 // Must be placed after router.use(verifyToken) so req.user is already populated.
-const requireAdmin = (req, res, next) => {
-  const adminUIDs = (process.env.ADMIN_UIDS || '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-
-  if (!adminUIDs.includes(req.user?.uid)) {
+const requireAllowlistedUID = (req, res, next) => {
+  if (!ADMIN_UIDS.includes(req.user?.uid)) {
     return res.status(403).json({ success: false, error: 'Admin access required' });
   }
-
   next();
 };
 
@@ -143,7 +150,7 @@ router.get('/presence/channel/:channelId/members', async (req, res, next) => {
 router.get('/search', searchCommunity);
 
 // ============ UTILITY ROUTES ============
-// requireAdmin enforces ADMIN_UIDS allowlist — prevents DoS via unbounded batch recalculation
-router.post('/fix-likes', requireAdmin, fixPostLikeCounts);
+// requireAllowlistedUID enforces ADMIN_UIDS allowlist — prevents DoS via unbounded batch recalculation
+router.post('/fix-likes', requireAllowlistedUID, fixPostLikeCounts);
 
 export default router;


### PR DESCRIPTION
## **User description**
## Description

  `POST /api/community/fix-likes` triggered a full-collection like-count recalculation
  across every post in MongoDB. `router.use(verifyToken)` was applied at the top of
  the file, but there was no role check — any authenticated user could invoke it freely.
  Parallel or repeated invocations cause compounding database load, making it a
  targeted self-inflicted DoS vector against the MongoDB instance.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Documentation update

  ## Related Issue

  Fixes #1096

  ## Root Cause

  The utility route was registered without a second-level authorization check. Any
  valid Firebase token was sufficient to trigger an unbounded batch database operation.

  ## What Changed and Why

  | # | Change | Reason |
  |---|--------|--------|
  | 1 | Added `requireAdmin` middleware that reads a comma-separated `ADMIN_UIDS` env var | Restricts the route to explicitly allowlisted Firebase
  UIDs only |
  | 2 | Applied `requireAdmin` between `verifyToken` and `fixPostLikeCounts` on `POST /fix-likes` | Ensures only admins can trigger the batch
  recalculation |
  | 3 | Documented `ADMIN_UIDS` in `backend/.env.example` under the Security section | Makes the new env var discoverable and configurable for all
  deployments |

  ## How to Test

  **Unauthenticated request — should return 401 (no change from before):**
  ```bash
  curl -X POST http://localhost:5000/api/community/fix-likes
  # Expected: 401 Unauthorized

  Authenticated non-admin — should now return 403:
  curl -X POST http://localhost:5000/api/community/fix-likes \
    -H "Authorization: Bearer <non_admin_firebase_token>"
  # Expected: 403 { "success": false, "error": "Admin access required" }

  Authenticated admin (UID in ADMIN_UIDS) — should return 200:
  # Set ADMIN_UIDS=<your_uid> in backend/.env, then:
  curl -X POST http://localhost:5000/api/community/fix-likes \
    -H "Authorization: Bearer <admin_firebase_token>"
  # Expected: 200 { "success": true, ... }

  Checklist

  - Code follows project style guidelines
  - Self-reviewed my code
  - No new warnings generated
  - No regressions — all other community routes unaffected
  - ADMIN_UIDS documented in .env.example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only access control added for restricted utility endpoints.
  * Administrators can now be configured via a new environment variable (comma-separated list) to manage who can access admin routes; leaving it empty disables admin routes.
* **Security**
  * Restricted sensitive utility operations to allowlisted admin accounts to prevent unauthorized use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Restrict the community like-fix tool to approved admins and document how to set it up

### What Changed
- The `/api/community/fix-likes` endpoint now rejects requests from authenticated users whose UID is not on the admin allowlist
- If no admin UIDs are configured, the endpoint refuses all requests and logs a warning at startup
- Added `ADMIN_UIDS` to the example environment file so deployments can enable the admin-only access check

### Impact
`✅ Fewer accidental database-heavy maintenance runs`
`✅ Lower risk of self-inflicted MongoDB overload`
`✅ Clearer setup for admin-only community tools`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
