### PR TITLE
fix/fellowship-verify-rate-limit` → fixes #1084

### DIFF
--- a/backend/src/routes/fellowships.js
+++ b/backend/src/routes/fellowships.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import crypto from 'crypto';
+import rateLimit from 'express-rate-limit';
 import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import FellowshipProfile from '../models/FellowshipProfile.model.js';
@@ -11,7 +12,36 @@ import { sanitizeMessageContent } from '../utils/sanitizeMessage.js';
 
 const router = express.Router();
 
+// Max 5 code-check attempts per 15 minutes per user UID.
+// The 6-digit code space (900,000 possibilities) is exhaustible within the
+// 10-minute expiry window without this limit — keyed by UID after verifyToken runs.
+const verifyCodeLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  keyGenerator: (req) => req.user?.uid || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) =>
+    res.status(429).json({
+      success: false,
+      error: 'Too many attempts. Please request a new code and try again in 15 minutes.',
+    }),
+});
 
+// Max 3 verification emails per hour per user UID to prevent email bombing
+// and SMTP quota exhaustion on arbitrary targets.
+const sendEmailLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 3,
+  keyGenerator: (req) => req.user?.uid || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) =>
+    res.status(429).json({
+      success: false,
+      error: 'Too many verification emails sent. Please wait before requesting another.',
+    }),
+});
 
 const ACADEMIC_DOMAINS = ['.edu', '.ac.in', '.edu.in', '.edu.au', '.ac.uk', '.edu.pk'];
 
@@ -70,7 +100,7 @@ router.post('/profile', verifyToken, asyncHandler(async (req, res) => {
     });
 }));
 
-router.post('/verify/send-email', verifyToken, asyncHandler(async (req, res) => {
+router.post('/verify/send-email', verifyToken, sendEmailLimiter, asyncHandler(async (req, res) => {
     const { email } = req.body;
 
     if (!email) {
@@ -107,7 +137,7 @@ router.post('/verify/send-email', verifyToken, asyncHandler(async (req, res) => 
     });
 }));
 
-router.post('/verify/confirm', verifyToken, asyncHandler(async (req, res) => {
+router.post('/verify/confirm', verifyToken, verifyCodeLimiter, asyncHandler(async (req, res) => {
     const { code } = req.body;
 
     if (!code) {


### PR DESCRIPTION
## Description

  The academic email verification system generates a 6-digit code (100,000–999,999,
  900,000 possibilities) with a 10-minute expiry. Both `/verify/send-email` and
  `/verify/confirm` had zero rate limiting — an attacker with any valid Firebase token
  could exhaust the entire code space within the expiry window by scripting requests.
  Verified student status unlocks the proposal and payment escrow system, making
  fraudulent verification a direct financial exploit. `/verify/send-email` also had no
  resend cap, enabling email bombing of arbitrary targets and SMTP quota exhaustion.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Documentation update

  ## Related Issue

  Fixes #1084

  ## Root Cause

  Neither endpoint applied `express-rate-limit`, despite the 2FA verify endpoint
  in `twoFactor.js` already using the same library with the same pattern.

  ## What Changed and Why

  | # | Change | Reason |
  |---|--------|--------|
  | 1 | Added `verifyCodeLimiter`: max 5 attempts per 15 min per UID on `/verify/confirm` | Matches the 2FA limiter in `twoFactor.js`; makes brute-force infeasible within the 10-min code window |
  | 2 | Added `sendEmailLimiter`: max 3 sends per hour per UID on `/verify/send-email` | Prevents email bombing and SMTP quota exhaustion |
  | 3 | Both limiters use `keyGenerator: (req) => req.user?.uid \|\| req.ip` | Keys by authenticated UID so limits cannot be bypassed by IP rotation via proxies |
  | 4 | Applied `sendEmailLimiter` after `verifyToken`, before the handler | Rate limit is per-user, not per-IP |
  | 5 | Applied `verifyCodeLimiter` after `verifyToken`, before the handler | Same reasoning; also locks out the specific user after 5 failed attempts |

  ## How to Test

  **Brute-force attempt on `/verify/confirm` — 6th attempt should return 429:**
  ```bash
  for i in {1..6}; do
    curl -X POST http://localhost:5000/api/fellowship/verify/confirm \
      -H "Authorization: Bearer <firebase_token>" \
      -H "Content-Type: application/json" \
      -d '{"code":"000000"}'
  done
  # Attempts 1–5: 400 Invalid verification code
  # Attempt 6: 429 { "error": "Too many attempts. Please request a new code and try again in 15 minutes." }

  Email resend cap — 4th send within an hour should return 429:
  for i in {1..4}; do
    curl -X POST http://localhost:5000/api/fellowship/verify/send-email \
      -H "Authorization: Bearer <firebase_token>" \
      -H "Content-Type: application/json" \
      -d '{"email":"test@university.edu"}'
  done
  # Sends 1–3: 200 Verification code sent
  # Send 4: 429 { "error": "Too many verification emails sent. Please wait before requesting another." }

  Checklist

  - Code follows project style guidelines
  - Self-reviewed my code
  - No new warnings generated
  - No regressions — happy path for both endpoints is completely unchanged
  - Rate limiting keyed by UID, not IP, to prevent bypass via proxy rotation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added rate limiting to email verification flows. Users can now send up to 3 verification emails per hour and attempt verification confirmation up to 5 times per 15 minutes. Exceeding these limits returns an appropriate error response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->