### PR TITLE
fix(portfolio): add missing GET / route — fixes dashboard portfolio count always showing 0

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -295,4 +295,24 @@ router.get(
   })
 );
 
+/**
+ * GET /api/portfolio
+ * Returns a list of available portfolio template slugs.
+ */
+router.get('/', asyncHandler(async (req, res) => {
+  const templatesDir = new URL('../templates/portfolio', import.meta.url);
+  let slugs = [];
+  try {
+    const entries = await fs.readdir(templatesDir);
+    slugs = entries.filter((e) => !e.startsWith('.'));
+  } catch {
+    slugs = [];
+  }
+  const portfolios = slugs.map((slug) => ({
+    slug,
+    url: `/portfolio/public/${slug}`,
+  }));
+  res.status(200).json({ success: true, portfolios, data: portfolios });
+}));
+
 export default router;


### PR DESCRIPTION
## Summary

- Adds the missing `GET /api/portfolio` route that lists all available portfolio template slugs
- The route reads the `templates/portfolio` directory and returns slug + URL for each template
- Without this route, the dashboard always shows a portfolio count of 0 and any frontend code calling `GET /api/portfolio` receives a 404

## Root Cause

The portfolio router had no handler for `GET /`. Every call from the dashboard to fetch the portfolio list hit a 404, causing the count to never update from the default of 0.

> Note: The `export default` duplication mentioned in #1202 was already resolved in a prior refactor. This PR addresses the remaining functional gap in #1203.

## Difficulty

`difficulty: intermediate`

## Test Plan

- [ ] `GET /api/portfolio` returns `{ success: true, portfolios: [...], data: [...] }` with HTTP 200
- [ ] Dashboard portfolio count reflects the number of templates available
- [ ] If the templates directory is empty or missing, the route returns an empty array (no crash)

Closes #1202
Closes #1203