### PR TITLE
fix(interview): lazy-init Groq client — missing GROQ_API_KEY crashes server on startup

### DIFF
--- a/backend/src/services/interviewService.js
+++ b/backend/src/services/interviewService.js
@@ -3,12 +3,33 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+const GROQ_API_KEY = process.env.GROQ_API_KEY;
+
+if (!GROQ_API_KEY) {
+  console.warn('⚠️  GROQ_API_KEY is not set — Interview Prep AI features will be unavailable.');
+}
+
+let _groq = null;
+
+const getGroqClient = () => {
+  if (_groq) return _groq;
+  if (!GROQ_API_KEY) {
+    const err = new Error(
+      'Interview AI features are unavailable — GROQ_API_KEY is not configured. ' +
+      'Set it in your .env file.'
+    );
+    err.statusCode = 503;
+    throw err;
+  }
+  _groq = new Groq({ apiKey: GROQ_API_KEY });
+  return _groq;
+};
 
 const generateQuestionId = () => `q_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
 const callGroq = async (prompt) => {
-  const completion = await groq.chat.completions.create({
+  const client = getGroqClient();
+  const completion = await client.chat.completions.create({
     messages: [{ role: 'user', content: prompt }],
     model: 'llama-3.3-70b-versatile',
     temperature: 0.7,


### PR DESCRIPTION
## Summary

- Moves Groq SDK instantiation from module load time to first use (lazy init)
- Server no longer crashes on startup when `GROQ_API_KEY` is absent
- A missing key now returns a clean HTTP 503 with a descriptive message instead of an unhandled exception
- Emits a startup warning (`⚠️ GROQ_API_KEY is not set`) so operators know what to configure

## Root Cause

```js
// Before — crashes at module load if key is missing
const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
```

The Groq constructor throws synchronously when `apiKey` is `undefined`. Because `interviewService.js` is imported at startup, a missing key took down the entire server — not just Interview Prep.

## Difficulty

`difficulty: beginner`

## Test Plan

- [ ] Server starts without `GROQ_API_KEY` set — no crash, warning log appears
- [ ] `POST /api/interview/questions` returns HTTP 503 with a clear message when key is absent
- [ ] Interview Prep works normally when `GROQ_API_KEY` is set

Closes #1204