### PR TITLE
fix(auth): remove PublicRoute wrapper from LinkedIn OAuth callback — logged-in users blocked from completing OAuth

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -141,7 +141,7 @@ function App() {
               <Route path="/" element={<PublicRoute><Home /></PublicRoute>} />
               <Route path="/login" element={<PublicRoute><Login /></PublicRoute>} />
               <Route path="/register" element={<PublicRoute><Register /></PublicRoute>} />
-              <Route path="/auth/linkedin/callback" element={<PublicRoute><LinkedInCallback /></PublicRoute>} />
+              <Route path="/auth/linkedin/callback" element={<LinkedInCallback />} />
               
               {/* Legal Pages (Public) */}
               <Route path="/privacy" element={<PrivacyPolicy />} />


### PR DESCRIPTION
## Summary

- Removes `<PublicRoute>` wrapper from `/auth/linkedin/callback` in `App.jsx`
- Authenticated users can now reach the callback handler after completing LinkedIn OAuth

## Root Cause

`PublicRoute` redirects any authenticated user to `/dashboard` before the component renders. This meant that when a logged-in user initiated the LinkedIn OAuth flow, they were redirected away from the callback URL before `LinkedInCallback` could exchange the authorization code — silently failing the entire LinkedIn integration.

```jsx
// Before — authenticated users never reach LinkedInCallback
<Route path="/auth/linkedin/callback" element={<PublicRoute><LinkedInCallback /></PublicRoute>} />

// After — accessible to both authenticated and unauthenticated users
<Route path="/auth/linkedin/callback" element={<LinkedInCallback />} />
```

## Difficulty

`difficulty: beginner`

## Test Plan

- [ ] Logged-in user initiates LinkedIn OAuth → completes flow without being redirected to `/dashboard`
- [ ] Unauthenticated user can still reach the callback (for initial LinkedIn sign-up flows)
- [ ] No other routes affected

Closes #1206