### PR TITLE
fix(pdf): guard JSON-LD injection — only embed structured data for portfolio PDFs

### DIFF
--- a/backend/src/services/pdfGenerator.js
+++ b/backend/src/services/pdfGenerator.js
@@ -16,15 +16,17 @@ export const generatePDF = async (markdownText, options = {}) => {
 
   // Convert markdown to HTML
   const htmlContent = marked.parse(markdownText);
-  const structuredData = generateStructuredData(options.portfolio || {});
-const jsonLd = JSON.stringify(structuredData, null, 2)
-  .replace(/<\/script>/gi, '<\\/script>');
-
-const jsonLdScript = `
-<script type="application/ld+json">
-${jsonLd}
-</script>
-`;
+  const jsonLdScript =
+    options.portfolio && Object.keys(options.portfolio).length > 0
+      ? (() => {
+          const structuredData = generateStructuredData(options.portfolio);
+          const jsonLd = JSON.stringify(structuredData, null, 2).replace(
+            /<\/script>/gi,
+            '<\\/script>'
+          );
+          return `<script type="application/ld+json">\n${jsonLd}\n</script>`;
+        })()
+      : '';
   // Read full HTML structure with styles
   const fullHtml = `
     <!DOCTYPE html>


### PR DESCRIPTION
## Summary

- `generatePDF` no longer injects a `<script type="application/ld+json">` block into every PDF
- The JSON-LD script is now conditional: it is only generated and embedded when `options.portfolio` is a non-empty object
- Resume PDFs (the common case) are no longer polluted with irrelevant portfolio structured data

## Root Cause

`generateStructuredData(options.portfolio || {})` was called unconditionally. Passing an empty object still produced a JSON-LD block describing a blank portfolio, which was injected into every resume PDF — adding noise and potentially confusing search engines or PDF validators.

## Difficulty

`difficulty: beginner`

## Test Plan

- [ ] `generatePDF(markdown, {})` — no `<script type="application/ld+json">` in the HTML
- [ ] `generatePDF(markdown, { portfolio: { name: 'Jane', ... } })` — JSON-LD block present and correct
- [ ] Downloaded resume PDFs no longer contain portfolio structured data

Closes #1207