### PR TITLE
fix(pdf): replace deprecated headless: 'new' with headless: true in Puppeteer launch

### DIFF
--- a/backend/src/services/pdfGenerator.js
+++ b/backend/src/services/pdfGenerator.js
@@ -133,7 +133,7 @@ ${jsonLd}
 
   // Launch puppeteer
   const browser = await puppeteer.launch({
-    headless: 'new', // Use new headless mode
+    headless: true,
     args: ['--no-sandbox', '--disable-setuid-sandbox']
   });
 


### PR DESCRIPTION
## Summary

- Changes `headless: 'new'` to `headless: true` in the Puppeteer `launch()` config
- Fixes PDF download failures on Puppeteer v22+, which removed the `'new'` string shorthand

## Root Cause

Puppeteer v22 dropped support for the `headless: 'new'` string option. Passing an unrecognised string value caused Puppeteer to fall back to the deprecated legacy headless mode, and in newer versions throws entirely — breaking all PDF generation (resume download, portfolio export).

The correct value for current Puppeteer is the boolean `true`.

## Difficulty

`difficulty: beginner`

## Test Plan

- [ ] Resume PDF download completes without errors on Puppeteer v22+
- [ ] Generated PDF renders correctly (fonts, layout, page breaks)

Closes #1208