### PR TITLE
fix(linkedin): return mock profile in dev when PROXYCURL_API_KEY is absent — unblocks contributors

### DIFF
--- a/backend/src/services/linkedinImporter.js
+++ b/backend/src/services/linkedinImporter.js
@@ -6,14 +6,53 @@ import { jobsScrapedCounter } from '../middleware/metrics.js';
 
 const PROXYCURL_ENDPOINT = 'https://nubela.co/proxycurl/api/v2/linkedin';
 
+const getMockProfile = (url) => ({
+  name: 'Alex Developer',
+  headline: 'Full-Stack Engineer | React · Node.js · TypeScript',
+  location: 'San Francisco, CA',
+  about:
+    'Passionate software engineer with 4 years of experience building scalable web applications. ' +
+    'Strong background in React, Node.js, and cloud infrastructure.',
+  experience: [
+    {
+      title: 'Senior Software Engineer',
+      company: 'TechCorp',
+      duration: '2022 – Present',
+      description: 'Led migration of monolith to microservices, reducing latency by 40%.',
+    },
+    {
+      title: 'Software Engineer',
+      company: 'StartupXYZ',
+      duration: '2020 – 2022',
+      description: 'Built React dashboard used by 50k+ users.',
+    },
+  ],
+  education: [
+    {
+      school: 'University of California, Berkeley',
+      degree: 'B.S. Computer Science',
+      duration: '2016 – 2020',
+    },
+  ],
+  skills: ['JavaScript', 'TypeScript', 'React', 'Node.js', 'PostgreSQL', 'Docker', 'AWS'],
+  _mock: true,
+  _mockNote: `DEV MODE — set PROXYCURL_API_KEY to fetch the real profile for: ${url}`,
+});
+
 export const scrapeLinkedInProfile = async (url) => {
   const apiKey = process.env.PROXYCURL_API_KEY;
 
   if (!apiKey) {
-    throw new Error(
-      'LinkedIn import requires a Proxycurl API key. Set PROXYCURL_API_KEY in your .env file. ' +
-      'Get a free key (10 credits) at https://proxycurl.com.'
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'LinkedIn import requires a Proxycurl API key. Set PROXYCURL_API_KEY in your .env file. ' +
+        'Get a free key (10 credits) at https://proxycurl.com.'
+      );
+    }
+    console.warn(
+      '⚠️  PROXYCURL_API_KEY is not set — returning mock LinkedIn profile (development only).'
     );
+    return getMockProfile(url);
   }
 
   const requestUrl = `${PROXYCURL_ENDPOINT}?url=${encodeURIComponent(url)}&fallback_to_cache=on-error&use_cache=if-present`;

--- a/backend/src/services/linkedinImporter.js
+++ b/backend/src/services/linkedinImporter.js
@@ -43,16 +43,17 @@ export const scrapeLinkedInProfile = async (url) => {
   const apiKey = process.env.PROXYCURL_API_KEY;
 
   if (!apiKey) {
-    if (process.env.NODE_ENV === 'production') {
-      throw new Error(
-        'LinkedIn import requires a Proxycurl API key. Set PROXYCURL_API_KEY in your .env file. ' +
-        'Get a free key (10 credits) at https://proxycurl.com.'
+    const env = process.env.NODE_ENV;
+    if (env === 'development' || env === 'test') {
+      console.warn(
+        '⚠️  PROXYCURL_API_KEY is not set — returning mock LinkedIn profile (development/test only).'
       );
+      return getMockProfile(url);
     }
-    console.warn(
-      '⚠️  PROXYCURL_API_KEY is not set — returning mock LinkedIn profile (development only).'
+    throw new Error(
+      'LinkedIn import requires a Proxycurl API key. Set PROXYCURL_API_KEY in your .env file. ' +
+      'Get a free key (10 credits) at https://proxycurl.com.'
     );
-    return getMockProfile(url);
   }
 
   const requestUrl = `${PROXYCURL_ENDPOINT}?url=${encodeURIComponent(url)}&fallback_to_cache=on-error&use_cache=if-present`;


### PR DESCRIPTION
## **User description**
## Summary

- Adds `getMockProfile(url)` that returns a realistic stub profile (name, experience, education, skills)
- When `PROXYCURL_API_KEY` is not set and `NODE_ENV !== 'production'`, returns the mock instead of throwing
- In production with no key, the original clear error is still thrown — no change to production behaviour
- The mock response includes `_mock: true` and a `_mockNote` so the caller knows it is synthetic data

## Root Cause

Contributors working locally have no Proxycurl API key. The import feature immediately throws an error, making it impossible to test the LinkedIn → Resume flow without paying for a key. This blocks local development and contributions.

The fix is strictly gated — `NODE_ENV === 'production'` always takes the real path. The mock is only reachable in development/test environments.

## Difficulty

`difficulty: beginner`

## Test Plan

- [ ] `NODE_ENV=development`, no `PROXYCURL_API_KEY` → mock profile returned, warning logged
- [ ] `NODE_ENV=production`, no `PROXYCURL_API_KEY` → error thrown (unchanged)
- [ ] `PROXYCURL_API_KEY` set (any env) → real Proxycurl API called (unchanged)

Closes #1210


___

## **CodeAnt-AI Description**
**Allow LinkedIn import to keep working in development when no API key is set**

### What Changed
- LinkedIn imports now return a realistic mock profile in development and test when `PROXYCURL_API_KEY` is missing, so local LinkedIn-to-resume flows can still be checked
- The mock profile includes sample work history, education, skills, and a clear note that the data is synthetic
- Production still stops with the original error if the API key is missing, so live behavior stays unchanged

### Impact
`✅ Unblocked local LinkedIn import testing`
`✅ Fewer setup blockers for contributors`
`✅ No change to production error handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
