### PR TITLE
Feat/editor skeleton

### DIFF
--- a/frontend/src/components/portfolio/EditorSkeleton.jsx
+++ b/frontend/src/components/portfolio/EditorSkeleton.jsx
@@ -1,20 +1,22 @@
 const EditorSkeleton = () => {
   return (
-    <div className="flex flex-col h-screen w-full bg-background animate-pulse">
+    <div className="flex flex-col h-screen w-full animate-pulse" style={{backgroundColor: '#0f172a'}}>
       
-      <div className="h-14 w-full bg-muted rounded-md mb-4 px-4" />
+      {/* Top header bar */}
+      <div className="h-14 w-full rounded-md mb-4 px-4" style={{backgroundColor: '#1e293b'}} />
 
+      {/* Main content */}
       <div className="flex flex-1 gap-4 px-4 pb-4">
         
-       
+        {/* Left panel - section cards */}
         <div className="w-1/3 flex flex-col gap-3">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-20 w-full bg-muted rounded-md" />
+            <div key={i} className="h-20 w-full rounded-md" style={{backgroundColor: '#1e293b'}} />
           ))}
         </div>
 
-      
-        <div className="w-2/3 bg-muted rounded-md" />
+        {/* Right panel - preview area */}
+        <div className="w-2/3 rounded-md" style={{backgroundColor: '#1e293b'}} />
 
       </div>
     </div>

--- a/frontend/src/components/portfolio/EditorSkeleton.jsx
+++ b/frontend/src/components/portfolio/EditorSkeleton.jsx
@@ -1,0 +1,24 @@
+const EditorSkeleton = () => {
+  return (
+    <div className="flex flex-col h-screen w-full bg-background animate-pulse">
+      
+      <div className="h-14 w-full bg-muted rounded-md mb-4 px-4" />
+
+      <div className="flex flex-1 gap-4 px-4 pb-4">
+        
+       
+        <div className="w-1/3 flex flex-col gap-3">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="h-20 w-full bg-muted rounded-md" />
+          ))}
+        </div>
+
+      
+        <div className="w-2/3 bg-muted rounded-md" />
+
+      </div>
+    </div>
+  );
+};
+
+export default EditorSkeleton;


### PR DESCRIPTION
## Summary
Creates a new `EditorSkeleton` component that displays a loading skeleton for the portfolio editor page while data is being fetched.

## Changes
- Added `frontend/src/components/portfolio/EditorSkeleton.jsx` (new file)

## What was implemented
- **Header bar**: Full-width skeleton bar at the top matching the editor's header
- **Left panel**: 5 stacked skeleton cards representing the section list
- **Right panel**: Large skeleton rectangle representing the preview area
- **Animation**: `animate-pulse` for the standard pulsing loading effect
- No spinners used — skeleton pattern only, as specified

## Usage
```jsx
import EditorSkeleton from '../components/portfolio/EditorSkeleton';

// Inside the portfolio editor component:
if (loading) return <EditorSkeleton />;
```

## Preview
<img width="1880" height="989" alt="Screenshot from 2026-05-21 23-58-18" src="https://github.com/user-attachments/assets/1986c61d-81c5-4a6f-821d-b0eb2aa24aa6" />

## Notes
- Only one new file added — no existing files were modified
- Component is ready to be dropped into the portfolio editor page wherever data loading occurs

Closes #[786]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a skeleton loading screen for the editor interface, displaying placeholder content while data is being fetched.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->