### PR TITLE
feat: add Badge component for status tags and labels

### DIFF
--- a/frontend/src/components/Badge.jsx
+++ b/frontend/src/components/Badge.jsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+
+export default function Badge({
+  children,
+  variant = "default",
+  size = "md",
+  dot = false,
+  className = "",
+}) {
+  const baseStyles =
+    "inline-flex items-center gap-1.5 font-semibold rounded-full";
+
+  const variants = {
+    default: "bg-muted text-muted-foreground",
+    success: "bg-green-500/10 text-green-400 border border-green-500/20",
+    warning: "bg-yellow-500/10 text-yellow-400 border border-yellow-500/20",
+    error: "bg-red-500/10 text-red-400 border border-red-500/20",
+    info: "bg-blue-500/10 text-blue-400 border border-blue-500/20",
+  };
+
+  const sizes = {
+    sm: "px-2 py-0.5 text-xs",
+    md: "px-3 py-1 text-sm",
+  };
+
+  const dotColors = {
+    default: "bg-muted-foreground",
+    success: "bg-green-400",
+    warning: "bg-yellow-400",
+    error: "bg-red-400",
+    info: "bg-blue-400",
+  };
+
+  return (
+    <span className={cn(baseStyles, variants[variant], sizes[size], className)}>
+      {dot && (
+        <span
+          className={cn(
+            "inline-block w-1.5 h-1.5 rounded-full",
+            dotColors[variant]
+          )}
+        />
+      )}
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
## **User description**
## What
Created a reusable Badge component for status indicators, labels, and tags.

## Why
Closes #763. Needed a consistent pill-shaped badge across the UI for deploy status, match score, skill level, etc.

## How
- frontend/src/components/Badge.jsx with variant (default/success/warning/error/info), size (sm/md), dot, and children props
- Rounded pill shape with color coding per variant
- Optional dot indicator left of text
- Uses cn() utility matching existing component conventions

## Testing
- Matches existing code style (see Button.jsx for reference)


___

## **CodeAnt-AI Description**
**Add a reusable badge for status tags and labels**

### What Changed
- Added a new badge style that can be used for status labels, tags, and short text markers
- Supports multiple visual states: default, success, warning, error, and info
- Supports two sizes and an optional colored dot next to the text

### Impact
`✅ Consistent status labels across the UI`
`✅ Clearer visual distinction for success, warning, error, and info states`
`✅ Smaller and compact badges for tight layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customizable Badge component for use throughout the application, supporting multiple style variants, sizes, and an optional indicator dot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->