### PR TITLE
fix(jobFetcher): isolate email and database error handling

### DIFF
--- a/backend/src/services/jobFetcher.js
+++ b/backend/src/services/jobFetcher.js
@@ -188,35 +188,37 @@ export const processAlert = async (alertData) => {
 
         // Always send email if there are jobs
         if (jobsToSend.length > 0) {
+            // Use the current email from the database to ensure accuracy
+            const recipientEmail = currentEmail;
+            const recipientName = alertExists.userName || userName || 'Job Seeker';
+
+            console.log(`\n${'='.repeat(60)}`);
+            console.log(`📧 SENDING EMAIL NOW`);
+            console.log(`${'='.repeat(60)}`);
+            console.log(`📬 To: ${recipientEmail}`);
+            console.log(`👤 Name: ${recipientName}`);
+            console.log(`🎯 Alert: "${title}"`);
+            console.log(`📊 Jobs Count: ${jobsToSend.length}`);
+            console.log(`${'='.repeat(60)}\n`);
+
+            // Emit socket event to user about new jobs found
+            emitNewJobsFound(userId, {
+                alertId,
+                alertTitle: title,
+                jobCount: jobsToSend.length,
+                jobs: jobsToSend.map(job => ({
+                    title: job.title,
+                    company: job.company,
+                    location: job.location,
+                    applyLink: job.applyLink
+                }))
+            });
+
+            // First try: send email and emit success
+            let emailResult;
             try {
-                // Use the current email from the database to ensure accuracy
-                const recipientEmail = currentEmail;
-                const recipientName = alertExists.userName || userName || 'Job Seeker';
-
-                console.log(`\n${'='.repeat(60)}`);
-                console.log(`📧 SENDING EMAIL NOW`);
-                console.log(`${'='.repeat(60)}`);
-                console.log(`📬 To: ${recipientEmail}`);
-                console.log(`👤 Name: ${recipientName}`);
-                console.log(`🎯 Alert: "${title}"`);
-                console.log(`📊 Jobs Count: ${jobsToSend.length}`);
-                console.log(`${'='.repeat(60)}\n`);
-
-                // Emit socket event to user about new jobs found
-                emitNewJobsFound(userId, {
-                    alertId,
-                    alertTitle: title,
-                    jobCount: jobsToSend.length,
-                    jobs: jobsToSend.map(job => ({
-                        title: job.title,
-                        company: job.company,
-                        location: job.location,
-                        applyLink: job.applyLink
-                    }))
-                });
-
                 console.log(`⏳ Calling email service...`);
-                const emailResult = await sendJobAlertEmail({
+                emailResult = await sendJobAlertEmail({
                     userEmail: recipientEmail,
                     userName: recipientName,
                     alertTitle: title,
@@ -240,6 +242,35 @@ export const processAlert = async (alertData) => {
                     messageId: emailResult.messageId
                 });
 
+                consecutiveFailures = 0; // Reset on successful send
+            } catch (emailError) {
+                console.error('❌ Failed to send email:', emailError.message);
+
+                // Emit socket event about email failure
+                emitEmailFailed(userId, {
+                    alertId,
+                    alertTitle: title,
+                    error: emailError.message
+                });
+
+                // Log failed notifications
+                await Promise.all(jobsToSend.map(job =>
+                    NotificationLog.create({
+                        userId,
+                        alertId,
+                        jobListingId: job._id,
+                        externalJobId: job.externalId,
+                        emailStatus: 'failed',
+                        errorMessage: emailError.message
+                    }).catch(() => { })
+                ));
+
+                // Do not proceed to notification persistence/update on email failure
+                return { success: false, error: 'Email send failed', newJobs: 0 };
+            }
+
+            // Second try: persist notifications and update alert stats
+            try {
                 // Log all notifications
                 const notificationPromises = jobsToSend.map(async job => {
                     try {
@@ -281,29 +312,8 @@ export const processAlert = async (alertData) => {
                 });
 
                 console.log(`✉️ Email sent with ${jobsToSend.length} jobs`);
-                consecutiveFailures = 0; // Reset on success
-
-            } catch (emailError) {
-                console.error('❌ Failed to send email:', emailError.message);
-
-                // Emit socket event about email failure
-                emitEmailFailed(userId, {
-                    alertId,
-                    alertTitle: title,
-                    error: emailError.message
-                });
-
-                // Log failed notifications
-                await Promise.all(jobsToSend.map(job =>
-                    NotificationLog.create({
-                        userId,
-                        alertId,
-                        jobListingId: job._id,
-                        externalJobId: job.externalId,
-                        emailStatus: 'failed',
-                        errorMessage: emailError.message
-                    }).catch(() => { })
-                ));
+            } catch (persistError) {
+                console.warn('⚠️ Failed to persist notifications or update alert:', persistError.message);
             }
         }
 

--- a/backend/src/services/jobFetcher.js
+++ b/backend/src/services/jobFetcher.js
@@ -253,20 +253,31 @@ export const processAlert = async (alertData) => {
                     error: emailError.message
                 });
 
-                // Log failed notifications
-                await Promise.all(jobsToSend.map(job =>
-                    NotificationLog.create({
-                        userId,
-                        alertId,
-                        jobListingId: job._id,
-                        externalJobId: job.externalId,
-                        emailStatus: 'failed',
-                        errorMessage: emailError.message
-                    }).catch(() => { })
-                ));
+                // Log failed notifications without swallowing persistence errors
+                const logResults = await Promise.allSettled(
+                    jobsToSend.map(job =>
+                        NotificationLog.create({
+                            userId,
+                            alertId,
+                            jobListingId: job._id,
+                            externalJobId: job.externalId,
+                            emailStatus: 'failed',
+                            errorMessage: emailError.message
+                        })
+                    )
+                );
 
-                // Do not proceed to notification persistence/update on email failure
-                return { success: false, error: 'Email send failed', newJobs: 0 };
+                logResults.forEach((result, index) => {
+                    if (result.status === 'rejected') {
+                        console.warn(
+                            `⚠️ Failed to write failure log for job ${index}:`,
+                            result.reason
+                        );
+                    }
+                });
+
+                // Rethrow so BullMQ can retry transient email failures
+                throw emailError;
             }
 
             // Second try: persist notifications and update alert stats


### PR DESCRIPTION
## Description

Separated email delivery and database persistence into isolated try/catch blocks inside `processAlert()`.

Previously, MongoDB failures occurring after successful email delivery incorrectly triggered `emailFailed` socket events and logged false failed notifications.

This fix ensures:

* email failures are handled independently
* persistence failures only log warnings
* false `emailFailed` events are no longer emitted after successful email delivery

## Type of Change

* [x] Bug fix

## Related Issue

Fixes #1149

## Testing

* [x] Tested Locally

## Screenshots

N/A

## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [x] No new warnings generated
