### PR TITLE
fix: atomic escrow release to prevent race condition double-payout

### DIFF
--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import mongoose from 'mongoose';
 import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import { createOrder, verifyPaymentSignature } from '../services/paymentService.js';
@@ -203,22 +204,30 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
 router.post('/release-funds/:roomId', verifyToken, asyncHandler(async (req, res) => {
     const { roomId } = req.params;
 
-    const chatRoom = await FellowshipChatRoom.findOneAndUpdate(
-        { _id: roomId, corporateId: req.user.uid, paymentStatus: 'escrow' },
-        { $set: { paymentStatus: 'released', releasedAt: new Date(), status: 'closed' } },
-        { new: true }
-    );
-    if (!chatRoom) throw new ApiError(400, 'Cannot release funds or access denied');
+    const session = await mongoose.startSession();
+    session.startTransaction();
+    let chatRoom;
+    let challenge;
+    try {
+        chatRoom = await FellowshipChatRoom.findOneAndUpdate(
+            { _id: roomId, corporateId: req.user.uid, paymentStatus: 'escrow' },
+            { $set: { paymentStatus: 'released', releasedAt: new Date(), status: 'closed' } },
+            { new: true, session }
+        );
+        if (!chatRoom) throw new ApiError(400, 'Cannot release funds or access denied');
 
-    // Find the challenge
-    const challenge = await Challenge.findById(chatRoom.challengeId);
-    if (!challenge) {
-        throw new ApiError(404, 'Challenge not found');
+        challenge = await Challenge.findById(chatRoom.challengeId).session(session);
+        if (!challenge) throw new ApiError(404, 'Challenge not found');
+        challenge.status = 'completed';
+        await challenge.save({ session });
+
+        await session.commitTransaction();
+    } catch (err) {
+        await session.abortTransaction();
+        throw err;
+    } finally {
+        session.endSession();
     }
-
-    // Update challenge status to completed
-    challenge.status = 'completed';
-    await challenge.save();
 
     console.log('✅ Funds released and challenge completed:', {
         roomId: chatRoom._id,

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -203,33 +203,18 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
 router.post('/release-funds/:roomId', verifyToken, asyncHandler(async (req, res) => {
     const { roomId } = req.params;
 
-    // Find the chat room
-    const chatRoom = await FellowshipChatRoom.findById(roomId);
-    if (!chatRoom) {
-        throw new ApiError(404, 'Chat room not found');
-    }
-
-    // Verify user is the corporate (only corporate can release funds)
-    if (chatRoom.corporateId?.toString() !== req.user.uid) {
-        throw new ApiError(403, 'Only the company can release funds');
-    }
-
-    // Check payment status
-    if (chatRoom.paymentStatus !== 'escrow') {
-        throw new ApiError(400, `Cannot release funds. Current status: ${chatRoom.paymentStatus}`);
-    }
+    const chatRoom = await FellowshipChatRoom.findOneAndUpdate(
+        { _id: roomId, corporateId: req.user.uid, paymentStatus: 'escrow' },
+        { $set: { paymentStatus: 'released', releasedAt: new Date(), status: 'closed' } },
+        { new: true }
+    );
+    if (!chatRoom) throw new ApiError(400, 'Cannot release funds or access denied');
 
     // Find the challenge
     const challenge = await Challenge.findById(chatRoom.challengeId);
     if (!challenge) {
         throw new ApiError(404, 'Challenge not found');
     }
-
-    // Update chat room - release funds and close chat
-    chatRoom.paymentStatus = 'released';
-    chatRoom.releasedAt = new Date();
-    chatRoom.status = 'closed';
-    await chatRoom.save();
 
     // Update challenge status to completed
     challenge.status = 'completed';


### PR DESCRIPTION
## **User description**
## Summary
Closes #1274

## Root Cause
The release-funds endpoint used a non-atomic read-then-write pattern
(`findById` + check + `save()`). Two concurrent requests could both
read `paymentStatus: 'escrow'` before either write completed, allowing
funds to be released twice.

## Fix
Replaced the read-check-save pattern with a single atomic
`findOneAndUpdate` that matches only when `paymentStatus` is `'escrow'`
and the caller is the corporate owner. The second concurrent request
gets `null` and returns `400` instead of double-releasing.

## Files Changed
- `backend/src/routes/payments.js` only

## Test Plan
- [ ] Single release request succeeds and sets status to `released`
- [ ] Second concurrent request returns `400 Cannot release funds or access denied`
- [ ] Challenge status correctly updates to `completed` on first release only
- [ ] No regression on normal payment flow


___

## **CodeAnt-AI Description**
**Prevent duplicate escrow releases and tighten access checks**

### What Changed
- Releasing funds now happens in one step, so two overlapping requests can’t both pay out the same escrow balance
- Only the company that owns the room can release funds; other users now get a single access denied message
- If the room is missing or the payment is no longer in escrow, the request fails with one clear error
- On a successful release, the chat room closes and the related challenge is marked completed

### Impact
`✅ Fewer double payouts`
`✅ Safer escrow releases`
`✅ Clearer release-funds errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
