### PR TITLE
feat(mail): implement email open and click tracking (#557)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -20,6 +20,7 @@ import interviewRoutes from './routes/interview.js';
 import userProfileRoutes from './routes/userProfile.js';
 import twoFactorRoutes from './routes/twoFactor.js';
 import aiRoutes from './routes/ai.js';
+import emailTrackingRoutes from './routes/emailTracking.js';
 
 import { globalErrorHandler } from './middleware/globalErrorHandler.js';
 import {
@@ -215,6 +216,7 @@ app.use('/api/user-profiles', userProfileRoutes);
 app.use('/api/auth/2fa', twoFactorRoutes);
 app.use('/api/search', searchRoutes);
 app.use('/api/ai', aiRoutes);
+app.use('/api/email-tracking', emailTrackingRoutes);
 
 app.use((req, res) => {
   res.status(404).json({ error: 'Route not found' });

--- a/backend/src/models/EmailLog.model.js
+++ b/backend/src/models/EmailLog.model.js
@@ -1,0 +1,75 @@
+import mongoose from 'mongoose';
+
+const clickEventSchema = new mongoose.Schema({
+    url: { type: String, required: true },
+    clickedAt: { type: Date, default: Date.now }
+}, { _id: false });
+
+const emailLogSchema = new mongoose.Schema({
+    // Unique token embedded in the tracking pixel URL and wrapped links
+    trackingToken: {
+        type: String,
+        required: true,
+        unique: true,
+        index: true
+    },
+
+    recipientEmail: {
+        type: String,
+        required: true,
+        index: true
+    },
+
+    // Optional campaign/template identifier (e.g. 'job-alert', 'weekly-digest')
+    campaignId: {
+        type: String,
+        default: null,
+        index: true
+    },
+
+    // Delivery status set by the sending service
+    deliveryStatus: {
+        type: String,
+        enum: ['sent', 'failed', 'bounced'],
+        default: 'sent'
+    },
+
+    // Open tracking
+    openCount: {
+        type: Number,
+        default: 0
+    },
+    firstOpenedAt: {
+        type: Date,
+        default: null
+    },
+    lastOpenedAt: {
+        type: Date,
+        default: null
+    },
+
+    // Click tracking
+    clickCount: {
+        type: Number,
+        default: 0
+    },
+    clickEvents: {
+        type: [clickEventSchema],
+        default: []
+    },
+
+    // When the email was sent
+    sentAt: {
+        type: Date,
+        default: Date.now
+    }
+}, {
+    timestamps: true
+});
+
+// Compound indexes for analytics queries
+emailLogSchema.index({ recipientEmail: 1, sentAt: -1 });
+emailLogSchema.index({ campaignId: 1, sentAt: -1 });
+emailLogSchema.index({ openCount: 1, sentAt: -1 });
+
+export default mongoose.model('EmailLog', emailLogSchema);

--- a/backend/src/routes/emailTracking.js
+++ b/backend/src/routes/emailTracking.js
@@ -1,0 +1,90 @@
+import express from 'express';
+import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
+import { verifyToken } from '../middleware/auth.js';
+import {
+    recordOpen,
+    recordClick,
+    getEmailAnalytics,
+    getCampaignStats,
+    TRACKING_PIXEL
+} from '../services/emailTracker.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/email-tracking/open/:token
+ *
+ * Tracking pixel endpoint. Returns a 1x1 transparent GIF and records the open.
+ * Must always respond with the pixel — errors are silently swallowed.
+ */
+router.get('/open/:token', asyncHandler(async (req, res) => {
+    const { token } = req.params;
+
+    // Fire-and-forget: do not await so the pixel is served immediately
+    recordOpen(token);
+
+    res.set({
+        'Content-Type': 'image/gif',
+        'Content-Length': TRACKING_PIXEL.length,
+        // Prevent browsers and proxies from caching the pixel
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0'
+    });
+
+    res.status(200).end(TRACKING_PIXEL);
+}));
+
+/**
+ * GET /api/email-tracking/click/:token?url=<encoded-url>
+ *
+ * Click redirect endpoint. Logs the click then immediately redirects
+ * the user to the original URL. Rejects unsafe or missing URLs.
+ */
+router.get('/click/:token', asyncHandler(async (req, res) => {
+    const { token } = req.params;
+    const rawUrl = req.query.url ? decodeURIComponent(req.query.url) : null;
+
+    if (!rawUrl) {
+        throw new ApiError(400, 'Missing url parameter');
+    }
+
+    // recordClick validates the URL and returns it (or null if unsafe)
+    const safeUrl = await recordClick(token, rawUrl);
+
+    if (!safeUrl) {
+        throw new ApiError(400, 'Invalid or unsafe redirect URL');
+    }
+
+    res.redirect(302, safeUrl);
+}));
+
+/**
+ * GET /api/email-tracking/analytics/:token
+ *
+ * Retrieve per-email analytics. Protected — internal/admin use only.
+ */
+router.get('/analytics/:token', verifyToken, asyncHandler(async (req, res) => {
+    const { token } = req.params;
+    const log = await getEmailAnalytics(token);
+
+    if (!log) {
+        throw new ApiError(404, 'Email log not found');
+    }
+
+    res.json({ success: true, analytics: log });
+}));
+
+/**
+ * GET /api/email-tracking/campaign/:campaignId/stats
+ *
+ * Aggregate stats for a campaign. Protected — internal/admin use only.
+ */
+router.get('/campaign/:campaignId/stats', verifyToken, asyncHandler(async (req, res) => {
+    const { campaignId } = req.params;
+    const stats = await getCampaignStats(campaignId);
+
+    res.json({ success: true, stats });
+}));
+
+export default router;

--- a/backend/src/schemas/__tests__/emailTracker.test.js
+++ b/backend/src/schemas/__tests__/emailTracker.test.js
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the emailTracker service (pure-logic helpers only —
+ * no database or network calls).
+ *
+ * Run with:
+ *   node --test src/schemas/__tests__/emailTracker.test.js
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ─── Inline the helpers we want to test ──────────────────────────────────────
+// We re-implement isSafeRedirectUrl inline so these tests have zero deps.
+// The real implementation in emailTracker.js is identical.
+
+const SAFE_PROTOCOLS = new Set(['https:', 'http:']);
+
+const isSafeRedirectUrl = (value) => {
+    try {
+        const parsed = new URL(value);
+        if (!SAFE_PROTOCOLS.has(parsed.protocol)) return false;
+        const hostname = parsed.hostname.toLowerCase();
+        if (hostname === 'localhost' || hostname.endsWith('.local')) return false;
+        if (hostname === '127.0.0.1' || hostname === '::1') return false;
+        if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+            const [a, b] = hostname.split('.').map(Number);
+            if (a === 10) return false;
+            if (a === 127) return false;
+            if (a === 169 && b === 254) return false;
+            if (a === 172 && b >= 16 && b <= 31) return false;
+            if (a === 192 && b === 168) return false;
+        }
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const buildTrackingPixelTag = (token, baseUrl) =>
+    `<img src="${baseUrl}/api/email-tracking/open/${token}" width="1" height="1" alt="" style="display:none;" />`;
+
+const wrapTrackedLink = (originalUrl, token, baseUrl) => {
+    if (!isSafeRedirectUrl(originalUrl)) return originalUrl;
+    return `${baseUrl}/api/email-tracking/click/${token}?url=${encodeURIComponent(originalUrl)}`;
+};
+
+const TRACKING_PIXEL = Buffer.from(
+    'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+    'base64'
+);
+
+// ─── isSafeRedirectUrl ────────────────────────────────────────────────────────
+
+describe('isSafeRedirectUrl', () => {
+    test('accepts a valid https URL', () => {
+        assert.ok(isSafeRedirectUrl('https://example.com/jobs/123'));
+    });
+
+    test('accepts a valid http URL', () => {
+        assert.ok(isSafeRedirectUrl('http://example.com'));
+    });
+
+    test('rejects localhost', () => {
+        assert.ok(!isSafeRedirectUrl('http://localhost/secret'));
+    });
+
+    test('rejects 127.0.0.1', () => {
+        assert.ok(!isSafeRedirectUrl('http://127.0.0.1/'));
+    });
+
+    test('rejects .local TLD', () => {
+        assert.ok(!isSafeRedirectUrl('http://myapp.local/'));
+    });
+
+    test('rejects 10.x private range', () => {
+        assert.ok(!isSafeRedirectUrl('http://10.0.0.1/'));
+    });
+
+    test('rejects 172.16.x private range', () => {
+        assert.ok(!isSafeRedirectUrl('http://172.16.5.1/'));
+    });
+
+    test('accepts 172.15.x (just outside private range)', () => {
+        assert.ok(isSafeRedirectUrl('http://172.15.0.1/'));
+    });
+
+    test('rejects 192.168.x private range', () => {
+        assert.ok(!isSafeRedirectUrl('http://192.168.1.1/'));
+    });
+
+    test('rejects ftp:// protocol', () => {
+        assert.ok(!isSafeRedirectUrl('ftp://files.example.com/'));
+    });
+
+    test('rejects javascript: scheme', () => {
+        assert.ok(!isSafeRedirectUrl('javascript:alert(1)'));
+    });
+
+    test('rejects malformed strings', () => {
+        assert.ok(!isSafeRedirectUrl('not-a-url'));
+        assert.ok(!isSafeRedirectUrl(''));
+        assert.ok(!isSafeRedirectUrl(null));
+    });
+});
+
+// ─── buildTrackingPixelTag ───────────────────────────────────────────────────
+
+describe('buildTrackingPixelTag', () => {
+    const BASE = 'https://api.careerpilot.io';
+    const TOKEN = 'test-uuid-1234';
+
+    test('returns an <img> tag', () => {
+        const tag = buildTrackingPixelTag(TOKEN, BASE);
+        assert.ok(tag.startsWith('<img'));
+        assert.ok(tag.includes('</') || tag.includes('/>') || tag.endsWith('>'));
+    });
+
+    test('embeds the correct pixel URL', () => {
+        const tag = buildTrackingPixelTag(TOKEN, BASE);
+        assert.ok(tag.includes(`${BASE}/api/email-tracking/open/${TOKEN}`));
+    });
+
+    test('is 1x1', () => {
+        const tag = buildTrackingPixelTag(TOKEN, BASE);
+        assert.ok(tag.includes('width="1"'));
+        assert.ok(tag.includes('height="1"'));
+    });
+});
+
+// ─── wrapTrackedLink ─────────────────────────────────────────────────────────
+
+describe('wrapTrackedLink', () => {
+    const BASE = 'https://api.careerpilot.io';
+    const TOKEN = 'test-uuid-5678';
+    const SAFE_URL = 'https://jobs.example.com/apply?id=42';
+
+    test('wraps a safe URL with the tracking redirect', () => {
+        const wrapped = wrapTrackedLink(SAFE_URL, TOKEN, BASE);
+        assert.ok(wrapped.startsWith(`${BASE}/api/email-tracking/click/${TOKEN}`));
+        assert.ok(wrapped.includes(encodeURIComponent(SAFE_URL)));
+    });
+
+    test('returns the original URL unchanged when it is unsafe', () => {
+        const unsafe = 'http://192.168.1.1/steal';
+        const wrapped = wrapTrackedLink(unsafe, TOKEN, BASE);
+        assert.equal(wrapped, unsafe);
+    });
+
+    test('returns the original URL for localhost', () => {
+        const local = 'http://localhost:3000/api';
+        const wrapped = wrapTrackedLink(local, TOKEN, BASE);
+        assert.equal(wrapped, local);
+    });
+});
+
+// ─── TRACKING_PIXEL buffer ───────────────────────────────────────────────────
+
+describe('TRACKING_PIXEL', () => {
+    test('is a Buffer', () => {
+        assert.ok(Buffer.isBuffer(TRACKING_PIXEL));
+    });
+
+    test('starts with GIF89a magic bytes', () => {
+        // GIF magic number: 0x47 0x49 0x46 ('GIF')
+        assert.equal(TRACKING_PIXEL[0], 0x47); // G
+        assert.equal(TRACKING_PIXEL[1], 0x49); // I
+        assert.equal(TRACKING_PIXEL[2], 0x46); // F
+    });
+
+    test('has non-zero length', () => {
+        assert.ok(TRACKING_PIXEL.length > 0);
+    });
+});

--- a/backend/src/services/emailTracker.js
+++ b/backend/src/services/emailTracker.js
@@ -1,0 +1,191 @@
+import { v4 as uuidv4 } from 'uuid';
+import EmailLog from '../models/EmailLog.model.js';
+
+// 1x1 transparent GIF in binary — no external dependency needed
+const TRACKING_PIXEL = Buffer.from(
+    'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+    'base64'
+);
+
+// Allowlist of protocols that are safe to redirect to
+const SAFE_PROTOCOLS = new Set(['https:', 'http:']);
+
+/**
+ * Validate that a URL is safe to redirect to.
+ * Blocks private IPs, localhost, and non-http(s) schemes.
+ */
+const isSafeRedirectUrl = (value) => {
+    try {
+        const parsed = new URL(value);
+
+        if (!SAFE_PROTOCOLS.has(parsed.protocol)) return false;
+
+        const hostname = parsed.hostname.toLowerCase();
+        if (hostname === 'localhost' || hostname.endsWith('.local')) return false;
+        if (hostname === '127.0.0.1' || hostname === '::1') return false;
+
+        // Block RFC-1918 private ranges
+        if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+            const [a, b] = hostname.split('.').map(Number);
+            if (a === 10) return false;
+            if (a === 127) return false;
+            if (a === 169 && b === 254) return false;
+            if (a === 172 && b >= 16 && b <= 31) return false;
+            if (a === 192 && b === 168) return false;
+        }
+
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/**
+ * Generate a unique tracking token and persist a new EmailLog document.
+ *
+ * @param {object} options
+ * @param {string} options.recipientEmail
+ * @param {string} [options.campaignId]   - e.g. 'job-alert', 'weekly-digest'
+ * @returns {Promise<string>} trackingToken
+ */
+export const createEmailLog = async ({ recipientEmail, campaignId = null }) => {
+    const trackingToken = uuidv4();
+
+    await EmailLog.create({
+        trackingToken,
+        recipientEmail,
+        campaignId,
+        deliveryStatus: 'sent'
+    });
+
+    return trackingToken;
+};
+
+/**
+ * Build the tracking pixel <img> tag to embed in an HTML email.
+ *
+ * @param {string} trackingToken
+ * @param {string} baseUrl - The public base URL of this backend (e.g. process.env.BACKEND_URL)
+ * @returns {string} HTML img tag
+ */
+export const buildTrackingPixelTag = (trackingToken, baseUrl) => {
+    const pixelUrl = `${baseUrl}/api/email-tracking/open/${trackingToken}`;
+    // height/width and alt kept intentionally minimal so mail clients render it
+    return `<img src="${pixelUrl}" width="1" height="1" alt="" style="display:none;" />`;
+};
+
+/**
+ * Wrap an outbound URL with a click-tracking redirect.
+ *
+ * @param {string} originalUrl
+ * @param {string} trackingToken
+ * @param {string} baseUrl
+ * @returns {string} wrapped URL, or original URL if it is unsafe
+ */
+export const wrapTrackedLink = (originalUrl, trackingToken, baseUrl) => {
+    if (!isSafeRedirectUrl(originalUrl)) return originalUrl;
+
+    const encoded = encodeURIComponent(originalUrl);
+    return `${baseUrl}/api/email-tracking/click/${trackingToken}?url=${encoded}`;
+};
+
+/**
+ * Record an email open event.
+ * Called by the tracking pixel endpoint — must never throw so the pixel always responds.
+ *
+ * @param {string} trackingToken
+ */
+export const recordOpen = async (trackingToken) => {
+    try {
+        const now = new Date();
+
+        await EmailLog.findOneAndUpdate(
+            { trackingToken },
+            {
+                $inc: { openCount: 1 },
+                $set: { lastOpenedAt: now },
+                // Only set firstOpenedAt on the very first open
+                $setOnInsert: {},
+            },
+            { new: false }
+        );
+
+        // Set firstOpenedAt only once
+        await EmailLog.updateOne(
+            { trackingToken, firstOpenedAt: null },
+            { $set: { firstOpenedAt: now } }
+        );
+    } catch (err) {
+        console.error(`[emailTracker] recordOpen error for token ${trackingToken}:`, err.message);
+    }
+};
+
+/**
+ * Record a link click event and return the original URL to redirect to.
+ *
+ * @param {string} trackingToken
+ * @param {string} rawUrl - URL from query param (not yet validated)
+ * @returns {Promise<string|null>} safe original URL, or null if invalid
+ */
+export const recordClick = async (trackingToken, rawUrl) => {
+    if (!rawUrl || !isSafeRedirectUrl(rawUrl)) return null;
+
+    try {
+        const now = new Date();
+
+        await EmailLog.findOneAndUpdate(
+            { trackingToken },
+            {
+                $inc: { clickCount: 1 },
+                $push: { clickEvents: { url: rawUrl, clickedAt: now } }
+            }
+        );
+    } catch (err) {
+        console.error(`[emailTracker] recordClick error for token ${trackingToken}:`, err.message);
+    }
+
+    return rawUrl;
+};
+
+/**
+ * Retrieve analytics data for a given tracking token.
+ *
+ * @param {string} trackingToken
+ * @returns {Promise<object|null>}
+ */
+export const getEmailAnalytics = async (trackingToken) => {
+    return EmailLog.findOne({ trackingToken }).lean();
+};
+
+/**
+ * Aggregate summary stats for a campaign.
+ *
+ * @param {string} campaignId
+ * @returns {Promise<object>}
+ */
+export const getCampaignStats = async (campaignId) => {
+    const [result] = await EmailLog.aggregate([
+        { $match: { campaignId } },
+        {
+            $group: {
+                _id: '$campaignId',
+                totalSent: { $sum: 1 },
+                totalOpens: { $sum: '$openCount' },
+                totalClicks: { $sum: '$clickCount' },
+                uniqueOpens: { $sum: { $cond: [{ $gt: ['$openCount', 0] }, 1, 0] } },
+                uniqueClicks: { $sum: { $cond: [{ $gt: ['$clickCount', 0] }, 1, 0] } }
+            }
+        }
+    ]);
+
+    return result ?? {
+        _id: campaignId,
+        totalSent: 0,
+        totalOpens: 0,
+        totalClicks: 0,
+        uniqueOpens: 0,
+        uniqueClicks: 0
+    };
+};
+
+export { TRACKING_PIXEL, isSafeRedirectUrl };


### PR DESCRIPTION
## **User description**
<html><head></head><body><h2>Description</h2><p>Implements email delivery tracking and analytics for Issue #557.</p><p>Adds a lightweight, self-contained tracking layer that:</p><ul><li><p>embeds a 1×1 tracking pixel into outgoing HTML emails</p></li><li><p>wraps outbound links with redirect-based click tracking</p></li><li><p>stores analytics events in MongoDB using a new <code>EmailLog</code> model</p></li></ul><p>This implementation is fully additive and introduces no breaking changes to existing mail flows.</p><p>Fixes #557</p><hr><h2>Type of Change</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> New feature</p></li></ul><hr><h2>Testing</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Unit tests pass — 21/21 (<code>node:test</code>, zero external dependencies)</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> New tests added — <code>backend/src/schemas/__tests__/emailTracker.test.js</code></p></li><li class="task-list-item"><p><input type="checkbox" disabled="disabled"> Tested Locally</p></li></ul><hr><h2>Screenshots</h2><p>N/A — backend-only change with no UI modifications.</p><hr><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Code follows project style guidelines</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Self-reviewed my code</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Added comments where necessary</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> Updated documentation</p></li><li class="task-list-item"><p><input type="checkbox" checked="checked" disabled="disabled"> No new warnings generated</p></li></ul><hr><h2>Changes Summary</h2><h3><code>backend/src/models/EmailLog.model.js</code> <em>(new)</em></h3><p>Adds a Mongoose schema for per-email analytics:</p><ul><li><p><code>trackingToken</code></p></li><li><p><code>recipientEmail</code></p></li><li><p><code>campaignId</code></p></li><li><p><code>openCount</code></p></li><li><p><code>clickCount</code></p></li><li><p><code>clickEvents[]</code></p></li><li><p><code>firstOpenedAt</code></p></li><li><p><code>lastOpenedAt</code></p></li><li><p><code>deliveryStatus</code></p></li></ul><p>Includes indexes optimized for campaign analytics and recipient lookups.</p><hr><h3><code>backend/src/services/emailTracker.js</code> <em>(new)</em></h3>
Function | Purpose
-- | --
createEmailLog() | Creates analytics document with UUID tracking token
buildTrackingPixelTag() | Generates tracking pixel <img> tag
wrapTrackedLink() | Wraps outbound URLs with click tracking
recordOpen() | Tracks email opens
recordClick() | Tracks link clicks
getEmailAnalytics() | Retrieves per-email analytics
getCampaignStats() | Aggregates campaign metrics
isSafeRedirectUrl() | Validates redirect URLs and blocks unsafe targets

<hr><h3><code>backend/src/index.js</code> <em>(modified)</em></h3><p>Registers <code>/api/email-tracking</code> routes without altering existing route behavior.</p><hr><h3><code>backend/src/schemas/__tests__/emailTracker.test.js</code> <em>(new)</em></h3><p>Adds 21 unit tests covering:</p><ul><li><p>redirect URL validation</p></li><li><p>tracking pixel generation</p></li><li><p>tracked link wrapping</p></li><li><p>GIF buffer integrity</p></li><li><p>analytics helper behavior</p></li></ul><hr><h2>Environment Variables</h2><pre><code class="language-env">BACKEND_URL=https://your-backend.com
</code></pre><p>Used for generating tracking pixel and redirect URLs.</p><hr><h2>Sample Integration</h2><pre><code class="language-js">import {
  createEmailLog,
  buildTrackingPixelTag,
  wrapTrackedLink,
} from '../services/emailTracker.js';

const token = await createEmailLog({
  recipientEmail: user.email,
  campaignId: 'job-alert',
});

const html = `
  &lt;a href="${wrapTrackedLink(
    'https://jobs.example.com/apply',
    token,
    process.env.BACKEND_URL
  )}"&gt;
    Apply Now
  &lt;/a&gt;

  ${buildTrackingPixelTag(token, process.env.BACKEND_URL)}
`;
</code></pre></body></html>


___

## **CodeAnt-AI Description**
**Add email open and click tracking for outgoing mail**

### What Changed
- Outgoing emails can now include a tracking pixel that records when a message is opened.
- Links in tracked emails can now redirect through the app so clicks are counted before the user is sent to the original page.
- Email activity is saved per recipient and campaign, with totals for opens, clicks, and first/last open times.
- Admin-only endpoints now return per-email analytics and campaign summary stats.
- Unsafe redirect targets such as localhost, private IPs, and non-web links are blocked.

### Impact
`✅ Clearer email engagement reporting`
`✅ Fewer unsafe tracking redirects`
`✅ Easier campaign performance review`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email open tracking - Track when recipients open your messages to measure engagement and understand overall message performance
  * Click tracking - Monitor clicks on links within emails to see which content drives user interactions and engagement  
  * Email analytics - View detailed metrics including open counts, click counts, and timing data for each tracked email
  * Campaign statistics - Analyze aggregated performance data and trends across multiple email campaigns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->