### PR TITLE
fix(perf): resolve memory leaks and zombie socket event listeners in presence and voice hooks

### DIFF
--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -1,18 +1,24 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useSocket } from '../context/SocketContext';
 
 /**
- * Custom hook to track user presence status
+ * Custom hook to track user presence status safely with optimized event cleanup
  * @param {string[]} userIds - Array of user IDs to track
  */
 export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
-  // Update presence map when online users change
+  // Create a stable primitive key based on array content to prevent unnecessary effect triggers
+  const serializedUserIds = userIds.join(',');
+
+  // Memoize the target user IDs array so its reference remains stable between renders
+  const stableUserIds = useMemo(() => userIds, [serializedUserIds]);
+
+  // 1. Synchronize local map when global onlineUsers change or target user IDs change
   useEffect(() => {
     const map = {};
-    userIds.forEach(uid => {
+    stableUserIds.forEach(uid => {
       const user = onlineUsers.find(u => u.uid === uid);
       map[uid] = {
         isOnline: !!user,
@@ -21,12 +27,15 @@ export function usePresence(userIds = []) {
       };
     });
     setPresenceMap(map);
-  }, [userIds, onlineUsers]);
+  }, [stableUserIds, onlineUsers]);
 
-  // Subscribe to status changes
+  // 2. Subscribe to real-time status changes with a stabilized dependency array
   useEffect(() => {
+    // If no target users are provided, skip setting up socket listeners entirely
+    if (stableUserIds.length === 0) return;
+
     const unsubOnline = subscribe('user_online', ({ uid }) => {
-      if (userIds.includes(uid)) {
+      if (stableUserIds.includes(uid)) {
         setPresenceMap(prev => ({
           ...prev,
           [uid]: { isOnline: true, status: 'online', lastSeen: new Date() }
@@ -35,7 +44,7 @@ export function usePresence(userIds = []) {
     });
 
     const unsubOffline = subscribe('user_offline', ({ uid }) => {
-      if (userIds.includes(uid)) {
+      if (stableUserIds.includes(uid)) {
         setPresenceMap(prev => ({
           ...prev,
           [uid]: { isOnline: false, status: 'offline', lastSeen: new Date() }
@@ -44,7 +53,7 @@ export function usePresence(userIds = []) {
     });
 
     const unsubStatusChange = subscribe('user_status_changed', ({ uid, status }) => {
-      if (userIds.includes(uid)) {
+      if (stableUserIds.includes(uid)) {
         setPresenceMap(prev => ({
           ...prev,
           [uid]: { ...prev[uid], status, lastSeen: new Date() }
@@ -52,18 +61,23 @@ export function usePresence(userIds = []) {
       }
     });
 
+    // CRITICAL CLEANUP: Ensures old subscriptions are cleanly unwound 
+    // before re-executing or upon hook unmount.
     return () => {
       unsubOnline();
       unsubOffline();
       unsubStatusChange();
     };
-  }, [userIds, subscribe]);
+  }, [stableUserIds, subscribe]);
 
-  // Helper function to check if a specific user is online
-  const isUserOnline = (uid) => presenceMap[uid]?.isOnline || false;
+  // 3. Wrap helper utility methods in useCallback to prevent parent re-renders
+  const isUserOnline = useCallback((uid) => {
+    return presenceMap[uid]?.isOnline || false;
+  }, [presenceMap]);
 
-  // Helper function to get user status
-  const getUserStatus = (uid) => presenceMap[uid]?.status || 'offline';
+  const getUserStatus = useCallback((uid) => {
+    return presenceMap[uid]?.status || 'offline';
+  }, [presenceMap]);
 
   return {
     presenceMap,

--- a/frontend/src/hooks/useVoskRecognition.js
+++ b/frontend/src/hooks/useVoskRecognition.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 
 let voskModule = null;
 let voskModel = null;
@@ -110,12 +110,19 @@ export const useVoskRecognition = () => {
         }
 
         if (audioContextRef.current) {
-            audioContextRef.current.close();
+            // Check if audioContext is open before closing to avoid errors
+            if (audioContextRef.current.state !== 'closed') {
+                audioContextRef.current.close().catch(err => console.error("Error closing AudioContext:", err));
+            }
             audioContextRef.current = null;
         }
 
         if (streamRef.current) {
-            streamRef.current.getTracks().forEach(track => track.stop());
+            streamRef.current.getTracks().forEach(track => {
+                if (track.readyState === 'live') {
+                    track.stop();
+                }
+            });
             streamRef.current = null;
         }
 
@@ -132,6 +139,14 @@ export const useVoskRecognition = () => {
         transcriptRef.current = '';
         setTranscript('');
     }, []);
+
+    // CRITICAL FIX: Global lifecycle cleanup mechanism
+    useEffect(() => {
+        // Return a cleanup wrapper that terminates background recordings if components unmount mid-session
+        return () => {
+            stopListening();
+        };
+    }, [stopListening]);
 
     return {
         isLoading,


### PR DESCRIPTION
## **User description**
## Description
Addresses and resolves the core architectural memory leaks and background hardware drainage profiles identified in #1621.

### Changes Implemented
* **`usePresence.js`**: Stabilized the dynamically passed `userIds` array identity using string primitive serialization (`.join(',')`). This stops the hook from breaking reference equality on every render, preventing continuous execution of teardown/setup socket subscription cycles.
* **`useVoskRecognition.js`**: Introduced a baseline lifecycle `useEffect` wrapper that automatically intercepts component unmount pathways. This forces immediate cleanup on lingering audio nodes, processing modules, and media recording tracks if a user leaves a dashboard panel mid-stream.

### Verification Matrix
* Verified using browser profiling tools that rapid navigation between community tabs no longer generates a linear growth of dangling socket event handler arrays.
* Confirmed physical microphone hardware indicators (tab recording lights) immediately shut down upon component unmount cycles.

Closes #1621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio recognition to properly stop and clean up resources when navigating away or closing the app
  * Improved audio context error handling and resource management

* **Improvements**
  * Stabilized user presence tracking for more reliable online/offline status synchronization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Stop leftover socket and microphone activity when presence or voice features are no longer in use

### What Changed
- Presence tracking now keeps a stable user list, which prevents repeated subscribe/unsubscribe cycles and reduces extra event listeners
- Presence updates no longer set up socket listeners when there are no users to track
- Voice recognition now cleans up audio recording, microphone tracks, and speech processing automatically when the panel closes or the component unmounts
- Closing voice recognition now avoids errors by only stopping live tracks and closing audio when it is still open

### Impact
`✅ Fewer duplicate presence updates`
`✅ Lower battery and microphone use after leaving voice input`
`✅ Fewer cleanup-related errors when switching away from active panels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
