### PR TITLE
fix: improve DM empty-state alignment

### DIFF
--- a/frontend/src/pages/Community.jsx
+++ b/frontend/src/pages/Community.jsx
@@ -276,17 +276,16 @@ export default function Community() {
     <div className="h-full bg-background">
       <div className="h-full flex">
         {/* Left Sidebar - Channels/Navigation */}
-        <div className={`${sidebarOpen ? 'w-64' : 'w-0'} bg-background border-r border-border flex flex-col transition-all duration-300 overflow-hidden`}>
-          {/* View Tabs */}
+<div className={`${sidebarOpen ? 'w-72' : 'w-0'} bg-background border-r border-border flex flex-col transition-all duration-300 overflow-hidden shrink-0`}>          {/* View Tabs */}
           <div className="p-3 border-b border-border">
-            <div className="flex gap-1 bg-muted p-1 rounded-lg">
-              <button
+<div className="flex gap-1 bg-muted p-1 rounded-lg w-full">
+                <button
                 onClick={() => handleTabChange('channels')}
                 className={`flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-md text-sm font-medium transition-colors ${activeView === 'channels' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
                   }`}
               >
                 <MessageSquare className="w-4 h-4" />
-                <span className="hidden lg:inline">Chat</span>
+                <span className="inline">Chat</span>
               </button>
               <button
                 onClick={() => handleTabChange('posts')}
@@ -294,7 +293,7 @@ export default function Community() {
                   }`}
               >
                 <FileText className="w-4 h-4" />
-                <span className="hidden lg:inline">Posts</span>
+                <span className="inline">Posts</span>
               </button>
               <button
                 onClick={() => handleTabChange('dms')}
@@ -302,7 +301,7 @@ export default function Community() {
                   }`}
               >
                 <Mail className="w-4 h-4" />
-                <span className="hidden lg:inline">DMs</span>
+                <span className="inline">DMs</span>
               </button>
             </div>
           </div>
@@ -357,8 +356,8 @@ export default function Community() {
           ) : activeView === 'posts' ? (
             <PostsFeed />
           ) : activeView === 'dms' ? (
-            <div className="flex-1 flex items-center justify-center text-muted-foreground">
-              <div className="text-center">
+            <div className="flex-1 flex items-center justify-center text-muted-foreground bg-background min-w-0">
+              <div className="text-center px-6">
                 <Mail className="w-12 h-12 mx-auto mb-3 text-muted-foreground/30" />
                 <p className="text-muted-foreground">Select a conversation to start messaging</p>
               </div>


### PR DESCRIPTION
## **User description**
## Description

Improved the alignment and spacing of the Direct Messages (DMs) empty-state section in the Community page for better UI consistency and responsiveness.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Other (describe)

## Related Issue

Fixes #1669 

## Testing

* [x] Tested Locally
* [ ] Unit tests pass
* [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)

* [x] Before

<img width="1919" height="971" alt="Screenshot 2026-05-24 171255" src="https://github.com/user-attachments/assets/adf6bf0f-5f29-4775-864c-3808c1b8260e" />

* [x] After

<img width="1919" height="967" alt="Screenshot 2026-05-24 183405" src="https://github.com/user-attachments/assets/6f645dfd-273a-4fac-b656-e9d56a689b9a" />


## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [ ] Added comments where necessary
* [ ] Updated documentation
* [x] No new warnings generated

## Code Changes

### File Modified

```txt
frontend/src/pages/Community.jsx
```

### Changes Made

* Improved alignment of the DM empty-state container
* Centered placeholder icon and text properly
* Adjusted spacing for better visual consistency
* Maintained responsive layout behavior
* Kept styling consistent with Chat and Posts sections

## Code Changes

### File Modified

```txt id="f0xv3m"
frontend/src/pages/Community.jsx
```

### Updated Sections

* Adjusted sidebar/container alignment classes around lines `279-283`
* Fixed text visibility/alignment for Chat, Posts, and DMs labels around lines `288-305`
* Improved DM empty-state centering and spacing around lines `359-363`

### Main UI Fix

```jsx
<div className="flex-1 flex items-center justify-center text-muted-foreground bg-background min-w-0">
  <div className="text-center px-6">
    <Mail className="w-12 h-12 mx-auto mb-3 text-muted-foreground/30" />
    <p className="text-muted-foreground">
      Select a conversation to start messaging
    </p>
  </div>
</div>
```


___

## **CodeAnt-AI Description**
**Fix the Community page sidebar and DM empty state layout**

### What Changed
- The Community page sidebar now keeps a wider, fixed layout so the Chat, Posts, and DMs tabs stay visible and aligned.
- The DM empty state is now centered with consistent spacing and padding, making the placeholder message fit the page more cleanly.
- The empty DM panel now fills the available space more reliably on different screen sizes.

### Impact
`✅ Clearer Community navigation`
`✅ Better DM empty-state layout`
`✅ Fewer layout shifts on wider and smaller screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded sidebar width for improved visibility of navigation controls and enhanced feature accessibility
  * Enhanced visibility of Chat, Posts, and DMs navigation tab labels
  * Refined spacing and visual styling for empty state messaging when no active conversation is selected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->