### PR TITLE
fix(portfolio): resolve dark mode styling inconsistencies on /templat…

### DIFF
--- a/frontend/src/components/portfolio/ThemeSelector.jsx
+++ b/frontend/src/components/portfolio/ThemeSelector.jsx
@@ -13,10 +13,10 @@ export default function ThemeSelector({ selectedTheme, onSelectTheme }) {
   return (
     <div className="w-full p-4">
       <div className="flex items-center gap-2 mb-6">
-        <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Preview mode:</span>
-        <div className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
-          <button onClick={() => setIsDarkPreview(false)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${!isDarkPreview ? 'bg-indigo-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300'}`}>☀️ Light</button>
-          <button onClick={() => setIsDarkPreview(true)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${isDarkPreview ? 'bg-indigo-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300'}`}>🌙 Dark</button>
+        <span className="text-sm font-medium text-muted-foreground">Preview mode:</span>
+        <div className="flex rounded-lg overflow-hidden border border-border">
+          <button onClick={() => setIsDarkPreview(false)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${!isDarkPreview ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground hover:bg-muted'}`}>☀️ Light</button>
+          <button onClick={() => setIsDarkPreview(true)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${isDarkPreview ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground hover:bg-muted'}`}>🌙 Dark</button>
         </div>
       </div>
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
@@ -33,9 +33,9 @@ export default function ThemeSelector({ selectedTheme, onSelectTheme }) {
                 if (onSelectTheme) onSelectTheme(t.id)
               }} 
               className={`relative rounded-xl border-2 overflow-hidden transition-all ${
-                isDisabled ? 'cursor-not-allowed opacity-90 border-gray-200 dark:border-gray-700' 
-                : isSelected ? 'cursor-pointer border-indigo-500 shadow-lg scale-105' 
-                : 'cursor-pointer border-gray-200 dark:border-gray-700 hover:border-indigo-300'
+                isDisabled ? 'cursor-not-allowed opacity-90 border-border' 
+                : isSelected ? 'cursor-pointer border-primary shadow-lg scale-105' 
+                : 'cursor-pointer border-border hover:border-primary/50'
               }`}
             >
               {t.isPremium && (
@@ -44,8 +44,8 @@ export default function ThemeSelector({ selectedTheme, onSelectTheme }) {
                 </span>
               )}
               {isDisabled && (
-                <div className="absolute inset-0 z-20 flex items-center justify-center bg-white/60 dark:bg-black/60 backdrop-blur-[2px]">
-                  <span className="px-3 py-1 text-sm font-semibold text-gray-800 dark:text-white bg-white/90 dark:bg-gray-800/90 rounded-md shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/60 backdrop-blur-[2px]">
+                  <span className="px-3 py-1 text-sm font-semibold text-foreground bg-card/90 rounded-md shadow-sm border border-border">
                     Coming Soon
                   </span>
                 </div>
@@ -53,14 +53,14 @@ export default function ThemeSelector({ selectedTheme, onSelectTheme }) {
               <div className="h-24 w-full flex items-center justify-center" style={{ backgroundColor: previewColor }}>
                 <div className="w-8 h-8 rounded-full" style={{ backgroundColor: t.accent }} />
               </div>
-              <div className="p-2 bg-white dark:bg-gray-900">
-                <p className="text-sm font-medium text-gray-800 dark:text-gray-100">{t.name}</p>
+              <div className="p-2 bg-card">
+                <p className="text-sm font-medium text-foreground">{t.name}</p>
                 {t.supportsDarkMode && (
-                  <span className="inline-block mt-1 text-xs px-2 py-0.5 rounded-full bg-indigo-100 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300">🌙 Dark mode supported</span>
+                  <span className="inline-block mt-1 text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary border border-primary/20">🌙 Dark mode supported</span>
                 )}
               </div>
               {isSelected && !isDisabled && (
-                <div className="absolute top-2 right-2 z-10 bg-indigo-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs">✓</div>
+                <div className="absolute top-2 right-2 z-10 bg-primary text-primary-foreground rounded-full w-5 h-5 flex items-center justify-center text-xs">✓</div>
               )}
             </div>
           )

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -384,7 +384,7 @@ export default function TemplateGallery() {
           </span>
           <h2 className="text-lg font-semibold text-foreground/70">Culinary Restaurant Theme — About Section</h2>
         </div>
-        <div className="overflow-hidden rounded-2xl border border-[#c5a880]/20">
+        <div className="overflow-hidden rounded-2xl border border-border">
           <CulinaryAbout />
         </div>
       </div>

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -5,6 +5,7 @@ import { useTheme } from "../hooks/useTheme";
 import { motion, AnimatePresence } from "framer-motion";
 import { Moon, Sun, ChevronDown, Check, Eye, Star } from "lucide-react";
 import HolographicAbout from "../components/portfolio/templates/Holographic/About";
+import CulinaryAbout from "../components/portfolio/templates/Culinary_Restaurant/About";
 
 /* ─────────────────────────────────────────────────────────
    Custom FilterSelect
@@ -36,12 +37,12 @@ function FilterSelect({ value, onChange, options, className = "" }) {
         onClick={() => setOpen((prev) => !prev)}
         className={`
           flex items-center justify-between gap-3 min-w-[160px] px-4 py-2.5
-          rounded-xl border text-sm font-medium text-white
-          bg-zinc-900/80 backdrop-blur-sm
+          rounded-xl border text-sm font-medium text-foreground
+          bg-card backdrop-blur-sm
           transition-all duration-300 cursor-pointer select-none
           ${open
             ? "border-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.45)] ring-1 ring-cyan-400/30"
-            : "border-zinc-700 hover:border-cyan-500/60 hover:shadow-[0_0_8px_rgba(34,211,238,0.25)]"
+            : "border-border hover:border-cyan-500/60 hover:shadow-[0_0_8px_rgba(34,211,238,0.25)]"
           }
         `}
       >
@@ -61,7 +62,7 @@ function FilterSelect({ value, onChange, options, className = "" }) {
             transition={{ duration: 0.18, ease: "easeOut" }}
             className="
               absolute z-50 left-0 top-[calc(100%+6px)] min-w-full
-              bg-zinc-900 border border-cyan-500/40
+              bg-card border border-border
               shadow-[0_0_20px_rgba(34,211,238,0.2)]
               rounded-xl overflow-hidden py-1
             "
@@ -78,7 +79,7 @@ function FilterSelect({ value, onChange, options, className = "" }) {
                     transition-all duration-200
                     ${isSelected
                       ? "bg-cyan-500/20 text-cyan-300 font-semibold"
-                      : "text-white hover:bg-cyan-500 hover:text-white"
+                      : "text-foreground hover:bg-cyan-500 hover:text-white"
                     }
                   `}
                 >
@@ -312,15 +313,15 @@ export default function TemplateGallery() {
         </button>
       </div>
 
-      <div className="mb-8 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-5">
+      <div className="mb-8 rounded-2xl border border-border bg-card p-5">
         <div className="mb-4 flex items-center justify-between gap-4">
           <div>
-            <h2 className="text-xl font-semibold">Portfolio theme</h2>
-            <p className="text-sm text-gray-400">
+            <h2 className="text-xl font-semibold text-foreground">Portfolio theme</h2>
+            <p className="text-sm text-muted-foreground">
               Pick a theme before deploying. Premium themes are shown and locked in the live gallery flow.
             </p>
           </div>
-          <span className="rounded-full border border-zinc-700 bg-zinc-900 px-3 py-1 text-xs text-zinc-300">
+          <span className="rounded-full border border-border bg-muted px-3 py-1 text-xs text-muted-foreground">
             Selected: {selectedTheme}
           </span>
         </div>
@@ -369,10 +370,22 @@ export default function TemplateGallery() {
           <span className="rounded-full bg-cyan-500/20 px-3 py-1 text-xs font-bold uppercase tracking-widest text-cyan-400 border border-cyan-500/30">
             Preview
           </span>
-          <h2 className="text-lg font-semibold text-white/70">Holographic Theme — About Section</h2>
+          <h2 className="text-lg font-semibold text-foreground/70">Holographic Theme — About Section</h2>
         </div>
-        <div className="overflow-hidden rounded-2xl border border-white/10">
+        <div className="overflow-hidden rounded-2xl border border-border">
           <HolographicAbout />
+        </div>
+      </div>
+
+      <div className="mt-12">
+        <div className="mb-4 flex items-center gap-3 px-1">
+          <span className="rounded-full bg-amber-500/20 px-3 py-1 text-xs font-bold uppercase tracking-widest text-amber-400 border border-amber-500/30">
+            Preview
+          </span>
+          <h2 className="text-lg font-semibold text-foreground/70">Culinary Restaurant Theme — About Section</h2>
+        </div>
+        <div className="overflow-hidden rounded-2xl border border-[#c5a880]/20">
+          <CulinaryAbout />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## **User description**
## Related Issue

Closes #1721

---

## Problem

The `/templates` route (`TemplateGallery.jsx` and `ThemeSelector.jsx`) had hardcoded `zinc` and `gray` color classes (e.g., `bg-zinc-900`, `text-white`, `border-zinc-800`). 
This caused the UI to completely ignore the global theme context, resulting in dark elements (dropdowns, cards, badges) incorrectly rendering on top of the bright background in Light Mode, making the page unreadable and visually broken.

---

## Solution

Replaced all hardcoded colors with Tailwind's semantic theme CSS variables (which automatically respond to the `.dark` class toggled by `ThemeProvider`). 

**Changes made:**
1. **`TemplateGallery.jsx`**:
   - Refactored `FilterSelect` dropdowns to use `bg-card`, `text-foreground`, and `border-border`.
   - Updated the Portfolio Theme section wrapper to use `bg-card`.
   - Fixed section badges and headings to use `text-foreground`, `bg-muted`, and `text-muted-foreground`.
2. **`ThemeSelector.jsx`**:
   - Replaced `dark:bg-gray-800` and `bg-white` classes with responsive variables like `bg-card` and `bg-primary`.
   - Ensured all borders, badges, and text automatically adapt to both light and dark themes consistently without needing explicit `dark:` variants.

---

## Checklist

- [x] Bug explicitly reproduced and confirmed
- [x] All hardcoded colors replaced with semantic CSS variables
- [x] Tested in Light Mode (fixes unreadable dropdowns/cards)
- [x] Tested in Dark Mode (maintains correct aesthetic)
- [x] No external CSS added, only Tailwind utility classes used

---

## Screenshots

> **Before (Light Mode broken with dark elements)**

<img width="1026" height="377" alt="Screenshot 2026-05-25 083802" src="https://github.com/user-attachments/assets/2cea5bb4-e8b8-4bf7-b8c6-9e8686b101db" />

> **After (Light Mode rendering correctly)**

<img width="1886" height="549" alt="Screenshot 2026-05-25 120237" src="https://github.com/user-attachments/assets/3c91872a-8923-4eb4-896b-d6591b3167db" />
<img width="1874" height="545" alt="Screenshot 2026-05-25 120250" src="https://github.com/user-attachments/assets/12c0c8f1-c00c-4101-9b21-1672b6107182" />

Video of the same: 

Uploading Screen Recording 2026-05-25 121805.mp4…


___

## **CodeAnt-AI Description**
**Fix theme styling on the templates page so light and dark modes render correctly**

### What Changed
- The templates page now uses theme-aware colors for dropdowns, cards, badges, and headings, so light mode no longer shows dark elements on a bright background
- Theme selection tiles now match the active theme more consistently, including selected, disabled, and “dark mode supported” states
- The templates page now includes a preview for the Culinary Restaurant theme alongside the existing Holographic theme

### Impact
`✅ Readable templates page in light mode`
`✅ Consistent theme selector appearance`
`✅ Clearer theme previews before deployment`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated theme selector and gallery visuals to use consistent design-system tokens, refining toggle states, card hover/selected/disabled styles, "Coming Soon" overlay, badge colors, and selected-checkmark appearance for improved consistency and accessibility.

* **New Features**
  * Added a Culinary Restaurant Theme preview in the gallery so users can explore an additional template option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->