### PR TITLE
feat: add AI reasoning tooltips to scoring and job-match components

### DIFF
--- a/frontend/src/components/ResumeScore.jsx
+++ b/frontend/src/components/ResumeScore.jsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 import { CheckCircle, Lightbulb, RefreshCw } from 'lucide-react'
+import AIReasoningTooltip from './ui/AIReasoningTooltip'
 
 const getScoreColor = (score) => {
   if (score >= 70) return { bar: 'bg-green-500', text: 'text-green-400', ring: '#22c55e' }
@@ -67,7 +68,16 @@ const SectionBar = ({ section, score, feedback, index }) => {
     >
       <div className="flex justify-between text-sm">
         <span className="text-foreground capitalize font-medium">{section}</span>
-        <span className={`font-semibold ${text}`}>{score}</span>
+        <span className={`flex items-center gap-1 font-semibold ${text}`}>
+          {score}
+          {feedback && (
+            <AIReasoningTooltip
+              title={`${section} Score Explanation`}
+              reason={feedback}
+              details={[`Section score: ${score}/100`]}
+            />
+          )}
+        </span>
       </div>
       <div className="h-2 bg-card rounded-full overflow-hidden">
         <motion.div
@@ -104,7 +114,19 @@ export default function ResumeScore({ data, onRescore }) {
       <div className="bg-background/50 border border-border rounded-2xl p-6 flex flex-col sm:flex-row items-center gap-6">
         <ScoreRing score={overallScore} />
         <div className="text-center sm:text-left">
-          <p className={`text-2xl font-bold ${scoreText}`}>{label}</p>
+          <div className="flex items-center justify-center gap-2 sm:justify-start">
+            <p className={`text-2xl font-bold ${scoreText}`}>{label}</p>
+            <AIReasoningTooltip
+              title="Overall Resume Score Explanation"
+              reason={`Your resume scored ${overallScore}/100 based on section analysis and keyword alignment.`}
+              details={[
+                ...Object.entries(sections || {}).map(
+                  ([name, { score: sectionScore, feedback: sectionFeedback }]) =>
+                    `${name}: ${sectionScore}/100 — ${sectionFeedback}`
+                ),
+              ]}
+            />
+          </div>
           <p className="text-muted-foreground text-sm mt-1">Overall Resume Score</p>
           {onRescore && (
             <button
@@ -145,7 +167,14 @@ export default function ResumeScore({ data, onRescore }) {
                 className="flex items-start gap-3"
               >
                 <CheckCircle className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
-                <span className="text-foreground text-sm">{tip}</span>
+                <span className="flex flex-1 items-start gap-1.5 text-foreground text-sm">
+                  {tip}
+                  <AIReasoningTooltip
+                    title="Suggestion Rationale"
+                    reason={tip}
+                    details={['Actioning this tip can improve ATS visibility and overall resume score.']}
+                  />
+                </span>
               </motion.li>
             ))}
           </ul>

--- a/frontend/src/components/ui/AIReasoningTooltip.jsx
+++ b/frontend/src/components/ui/AIReasoningTooltip.jsx
@@ -1,0 +1,112 @@
+import { useState, useRef, useEffect, useId } from 'react';
+import { Info, X } from 'lucide-react';
+
+export default function AIReasoningTooltip({
+  title = 'AI Insight',
+  reason = '',
+  details = [],
+}) {
+  const [hovered, setHovered] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef(null);
+  const tooltipId = useId();
+
+  const detailList = (Array.isArray(details) ? details : [])
+    .map((item) => (typeof item === 'string' ? item.trim() : String(item)))
+    .filter(Boolean);
+
+  const hasContent = Boolean(reason?.trim()) || detailList.length > 0;
+  if (!hasContent) return null;
+
+  useEffect(() => {
+    if (!expanded) return undefined;
+
+    const handleOutside = (event) => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setExpanded(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutside);
+    document.addEventListener('touchstart', handleOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      document.removeEventListener('touchstart', handleOutside);
+    };
+  }, [expanded]);
+
+  const showHoverTip = hovered && !expanded && Boolean(reason?.trim());
+
+  return (
+    <div ref={containerRef} className="relative inline-flex shrink-0 align-middle">
+      <button
+        type="button"
+        className="inline-flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+        aria-label={title}
+        aria-expanded={expanded}
+        aria-describedby={showHoverTip || expanded ? tooltipId : undefined}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setHovered(true)}
+        onBlur={() => setHovered(false)}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setExpanded((prev) => !prev);
+        }}
+      >
+        <Info className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+
+      {showHoverTip && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-56 max-w-[min(16rem,calc(100vw-2rem))] -translate-x-1/2 rounded-lg border border-border bg-popover px-3 py-2 text-xs leading-relaxed text-popover-foreground shadow-lg"
+        >
+          <p className="line-clamp-4">{reason}</p>
+        </div>
+      )}
+
+      {expanded && (
+        <div
+          id={tooltipId}
+          role="dialog"
+          aria-label={title}
+          className="absolute left-1/2 top-full z-50 mt-2 w-72 max-w-[min(18rem,calc(100vw-2rem))] -translate-x-1/2 rounded-xl border border-border bg-popover p-3 shadow-xl"
+        >
+          <div className="mb-2 flex items-start justify-between gap-2">
+            <p className="text-xs font-semibold text-foreground">{title}</p>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setExpanded(false);
+              }}
+              className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Dismiss details"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          {reason?.trim() && (
+            <p className="mb-2 text-xs leading-relaxed text-muted-foreground">{reason}</p>
+          )}
+
+          {detailList.length > 0 && (
+            <ul className="max-h-40 space-y-1.5 overflow-y-auto text-xs text-foreground">
+              {detailList.map((detail, index) => (
+                <li key={index} className="flex gap-2">
+                  <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+                  <span>{detail}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Enhance.jsx
+++ b/frontend/src/pages/Enhance.jsx
@@ -31,6 +31,7 @@ import {
 } from 'lucide-react'
 import { SkeletonList } from '../components/ui/Skeleton'
 import ResumeScore from '../components/ResumeScore'
+import AIReasoningTooltip from '../components/ui/AIReasoningTooltip'
 
 // Score ring component
 const ScoreRing = ({ score, size = 120, strokeWidth = 8 }) => {
@@ -87,7 +88,7 @@ const ScoreRing = ({ score, size = 120, strokeWidth = 8 }) => {
 }
 
 // Score breakdown bar
-const ScoreBar = ({ label, score, delay = 0 }) => {
+const ScoreBar = ({ label, score, delay = 0, reasoning }) => {
   const getBarColor = (score) => {
     if (score >= 80) return 'bg-green-500'
     if (score >= 60) return 'bg-yellow-500'
@@ -98,7 +99,10 @@ const ScoreBar = ({ label, score, delay = 0 }) => {
   return (
     <div className="space-y-1">
       <div className="flex justify-between text-sm">
-        <span className="text-muted-foreground">{label}</span>
+        <span className="flex items-center gap-1 text-muted-foreground">
+          {label}
+          {reasoning && <AIReasoningTooltip {...reasoning} />}
+        </span>
         <span className="text-foreground font-medium">{score}%</span>
       </div>
       <div className="h-2 bg-card rounded-full overflow-hidden">
@@ -144,7 +148,18 @@ const ImprovementCard = ({ improvement, index }) => {
             </span>
             <span className="text-xs text-muted-foreground">{improvement.category}</span>
           </div>
-          <p className="text-foreground font-medium">{improvement.issue}</p>
+          <p className="flex flex-1 items-start gap-1.5 text-foreground font-medium">
+            {improvement.issue}
+            <AIReasoningTooltip
+              title="Improvement Rationale"
+              reason={improvement.issue}
+              details={[
+                improvement.suggestion && `Suggestion: ${improvement.suggestion}`,
+                improvement.priority && `Priority: ${improvement.priority}`,
+                improvement.category && `Category: ${improvement.category}`,
+              ].filter(Boolean)}
+            />
+          </p>
         </div>
         {expanded ? (
           <ChevronUp className="w-5 h-5 text-muted-foreground ml-2 flex-shrink-0" />
@@ -193,8 +208,20 @@ const SectionGradeCard = ({ section, data, icon: Icon }) => {
           <Icon className="w-5 h-5 text-primary" />
           <span className="font-medium text-foreground capitalize">{section}</span>
         </div>
-        <div className={`w-10 h-10 rounded-lg bg-gradient-to-br ${getGradeColor(data?.grade)} flex items-center justify-center`}>
-          <span className="text-foreground font-bold text-lg">{data?.grade || 'N/A'}</span>
+        <div className="flex items-center gap-1">
+          <div className={`w-10 h-10 rounded-lg bg-gradient-to-br ${getGradeColor(data?.grade)} flex items-center justify-center`}>
+            <span className="text-foreground font-bold text-lg">{data?.grade || 'N/A'}</span>
+          </div>
+          {data?.feedback && (
+            <AIReasoningTooltip
+              title={`${section} Grade Explanation`}
+              reason={data.feedback}
+              details={[
+                data?.score != null && `Section score: ${data.score}/100`,
+                data?.grade && `Grade: ${data.grade}`,
+              ].filter(Boolean)}
+            />
+          )}
         </div>
       </div>
       <div className="space-y-2">
@@ -233,8 +260,18 @@ const BulletAnalysisCard = ({ bullet, index }) => {
         <div className="flex items-start justify-between gap-4">
           <p className="text-foreground text-sm flex-1">{bullet.original}</p>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <span className={`text-xs px-2 py-1 rounded-lg border ${getScoreColor(bullet.score)}`}>
+            <span className={`flex items-center gap-1 text-xs px-2 py-1 rounded-lg border ${getScoreColor(bullet.score)}`}>
               {bullet.score}/10
+              {(bullet.issues?.length > 0 || bullet.improved) && (
+                <AIReasoningTooltip
+                  title="Bullet Analysis"
+                  reason={bullet.issues?.[0] || 'This bullet could be strengthened for greater impact.'}
+                  details={[
+                    ...(bullet.issues || []),
+                    bullet.improved && `Improved: ${bullet.improved}`,
+                  ].filter(Boolean)}
+                />
+              )}
             </span>
             {expanded ? (
               <ChevronUp className="w-4 h-4 text-muted-foreground" />
@@ -335,7 +372,18 @@ const SeniorTipCard = ({ tip, index }) => {
               <span className="text-xs px-1.5 py-0.5 bg-red-500/30 text-red-300 rounded">High Priority</span>
             )}
           </div>
-          <p className="text-sm font-medium">{tip.tip}</p>
+          <p className="flex items-start gap-1.5 text-sm font-medium">
+            {tip.tip}
+            <AIReasoningTooltip
+              title="Expert Tip Rationale"
+              reason={tip.tip}
+              details={[
+                tip.category && `Category: ${tip.category}`,
+                tip.priority && `Priority: ${tip.priority}`,
+                tip.example && `Example: ${tip.example}`,
+              ].filter(Boolean)}
+            />
+          </p>
           {tip.example && (
             <p className="text-xs opacity-75 mt-2 italic">"{tip.example}"</p>
           )}
@@ -587,7 +635,22 @@ export default function Enhance() {
                 className="lg:col-span-1 bg-background/50 border border-border rounded-2xl p-6"
               >
                 <div className="flex flex-col items-center">
-                  <ScoreRing score={atsAnalysis.atsScore} size={160} strokeWidth={12} />
+                  <div className="relative">
+                    <ScoreRing score={atsAnalysis.atsScore} size={160} strokeWidth={12} />
+                    <div className="absolute -right-1 top-2">
+                      <AIReasoningTooltip
+                        title="ATS Score Explanation"
+                        reason={atsAnalysis.summary || `Your resume scored ${atsAnalysis.atsScore}/100 for this role.`}
+                        details={[
+                          `Overall ATS score: ${atsAnalysis.atsScore}/100`,
+                          ...(atsAnalysis.strengths?.slice(0, 3).map((s) => `Strength: ${s}`) || []),
+                          ...(atsAnalysis.missingKeywords?.length
+                            ? [`Missing keywords: ${atsAnalysis.missingKeywords.join(', ')}`]
+                            : []),
+                        ]}
+                      />
+                    </div>
+                  </div>
                   <div className="mt-4 text-center">
                     <p className="text-lg font-medium text-foreground mb-1">
                       {atsAnalysis.atsScore >= 80 ? 'Excellent!' :
@@ -631,11 +694,70 @@ export default function Enhance() {
                   Score Breakdown
                 </h3>
                 <div className="space-y-4">
-                  <ScoreBar label="Keyword Match" score={atsAnalysis.scoreBreakdown?.keywordMatch || 0} delay={0.1} />
-                  <ScoreBar label="Formatting" score={atsAnalysis.scoreBreakdown?.formatting || 0} delay={0.2} />
-                  <ScoreBar label="Experience Relevance" score={atsAnalysis.scoreBreakdown?.experienceRelevance || 0} delay={0.3} />
-                  <ScoreBar label="Skills Alignment" score={atsAnalysis.scoreBreakdown?.skillsAlignment || 0} delay={0.4} />
-                  <ScoreBar label="Education Match" score={atsAnalysis.scoreBreakdown?.educationMatch || 0} delay={0.5} />
+                  <ScoreBar
+                    label="Keyword Match"
+                    score={atsAnalysis.scoreBreakdown?.keywordMatch || 0}
+                    delay={0.1}
+                    reasoning={{
+                      title: 'Keyword Match Explanation',
+                      reason: `Keyword match scored ${atsAnalysis.scoreBreakdown?.keywordMatch || 0}% for ${jobRole}.`,
+                      details: [
+                        ...(atsAnalysis.missingKeywords?.length
+                          ? [`Missing: ${atsAnalysis.missingKeywords.join(', ')}`]
+                          : ['No critical keywords missing']),
+                        ...(atsAnalysis.strengths?.slice(0, 2).map((s) => `Strength: ${s}`) || []),
+                      ],
+                    }}
+                  />
+                  <ScoreBar
+                    label="Formatting"
+                    score={atsAnalysis.scoreBreakdown?.formatting || 0}
+                    delay={0.2}
+                    reasoning={{
+                      title: 'Formatting Score Explanation',
+                      reason: `Formatting scored ${atsAnalysis.scoreBreakdown?.formatting || 0}% based on structure and ATS readability.`,
+                      details: [atsAnalysis.summary].filter(Boolean),
+                    }}
+                  />
+                  <ScoreBar
+                    label="Experience Relevance"
+                    score={atsAnalysis.scoreBreakdown?.experienceRelevance || 0}
+                    delay={0.3}
+                    reasoning={{
+                      title: 'Experience Relevance Explanation',
+                      reason: `Experience relevance scored ${atsAnalysis.scoreBreakdown?.experienceRelevance || 0}% for ${jobRole}.`,
+                      details: atsAnalysis.improvements
+                        ?.filter((i) => i.category?.toLowerCase().includes('experience'))
+                        .slice(0, 3)
+                        .map((i) => i.issue) || [],
+                    }}
+                  />
+                  <ScoreBar
+                    label="Skills Alignment"
+                    score={atsAnalysis.scoreBreakdown?.skillsAlignment || 0}
+                    delay={0.4}
+                    reasoning={{
+                      title: 'Skills Alignment Explanation',
+                      reason: `Skills alignment scored ${atsAnalysis.scoreBreakdown?.skillsAlignment || 0}% against role requirements.`,
+                      details: atsAnalysis.improvements
+                        ?.filter((i) => i.category?.toLowerCase().includes('skill'))
+                        .slice(0, 3)
+                        .map((i) => i.suggestion || i.issue) || [],
+                    }}
+                  />
+                  <ScoreBar
+                    label="Education Match"
+                    score={atsAnalysis.scoreBreakdown?.educationMatch || 0}
+                    delay={0.5}
+                    reasoning={{
+                      title: 'Education Match Explanation',
+                      reason: `Education match scored ${atsAnalysis.scoreBreakdown?.educationMatch || 0}% for this role.`,
+                      details: atsAnalysis.improvements
+                        ?.filter((i) => i.category?.toLowerCase().includes('education'))
+                        .slice(0, 2)
+                        .map((i) => i.issue) || ['Education section evaluated for role fit'],
+                    }}
+                  />
                 </div>
               </motion.div>
             </div>
@@ -650,6 +772,14 @@ export default function Enhance() {
               <h3 className="text-lg font-semibold text-foreground mb-3 flex items-center gap-2">
                 <AlertCircle className="w-5 h-5 text-primary" />
                 Analysis Summary
+                <AIReasoningTooltip
+                  title="Analysis Summary"
+                  reason={atsAnalysis.summary}
+                  details={[
+                    ...(atsAnalysis.strengths?.map((s) => `Strength: ${s}`) || []),
+                    ...(atsAnalysis.missingKeywords?.map((k) => `Gap: ${k}`) || []),
+                  ]}
+                />
               </h3>
               <p className="text-foreground leading-relaxed">{atsAnalysis.summary}</p>
             </motion.div>
@@ -885,6 +1015,14 @@ export default function Enhance() {
                         <h4 className="font-semibold text-foreground mb-3 flex items-center gap-2">
                           <Star className="w-5 h-5 text-amber-400" />
                           Competitive Edge Score: {comprehensiveAnalysis.competitiveEdge.score}/100
+                          <AIReasoningTooltip
+                            title="Competitive Edge Explanation"
+                            reason={`Competitive edge score of ${comprehensiveAnalysis.competitiveEdge.score}/100 reflects how you compare to typical candidates.`}
+                            details={[
+                              ...(comprehensiveAnalysis.competitiveEdge.standoutFactors || []),
+                              ...(comprehensiveAnalysis.competitiveEdge.differentiators || []),
+                            ]}
+                          />
                         </h4>
                         {comprehensiveAnalysis.competitiveEdge.standoutFactors?.length > 0 && (
                           <div className="mb-3">

--- a/frontend/src/pages/ResumeView.jsx
+++ b/frontend/src/pages/ResumeView.jsx
@@ -9,6 +9,7 @@ import Card from '../components/Card'
 import CustomSection from '../components/CustomSection'
 import { sectionsToMarkdown } from '../components/customSectionUtils'
 import { SkeletonList } from '../components/ui/Skeleton'
+import AIReasoningTooltip from '../components/ui/AIReasoningTooltip'
 
 export default function ResumeView() {
   const { resumeId } = useParams()
@@ -415,8 +416,17 @@ export default function ResumeView() {
     </h3>
 
     <div className="flex flex-col items-center mb-8">
-      <div className="w-32 h-32 rounded-full border-8 border-primary flex items-center justify-center text-3xl font-bold">
-        {scoreData.overallScore}
+      <div className="flex items-center gap-2">
+        <div className="w-32 h-32 rounded-full border-8 border-primary flex items-center justify-center text-3xl font-bold">
+          {scoreData.overallScore}
+        </div>
+        <AIReasoningTooltip
+          title="Overall Resume Score Explanation"
+          reason={`Your resume scored ${scoreData.overallScore}/100 based on section analysis and keyword alignment.`}
+          details={Object.entries(scoreData.sections || {}).map(
+            ([name, { score, feedback }]) => `${name}: ${score}/100 — ${feedback}`
+          )}
+        />
       </div>
 
       <p className="mt-3 text-muted-foreground">
@@ -431,7 +441,16 @@ export default function ResumeView() {
             <span className="capitalize font-medium">
               {section}
             </span>
-            <span>{value.score}/100</span>
+            <span className="flex items-center gap-1">
+              {value.score}/100
+              {value.feedback && (
+                <AIReasoningTooltip
+                  title={`${section} Score Explanation`}
+                  reason={value.feedback}
+                  details={[`Section score: ${value.score}/100`]}
+                />
+              )}
+            </span>
           </div>
 
           <div className="w-full bg-muted rounded-full h-3">
@@ -457,9 +476,15 @@ export default function ResumeView() {
         {scoreData.topSuggestions.map((tip, index) => (
           <li
             key={index}
-            className="bg-muted p-3 rounded-lg"
+            className="bg-muted p-3 rounded-lg flex items-start gap-2"
           >
-            • {tip}
+            <span>•</span>
+            <span className="flex-1">{tip}</span>
+            <AIReasoningTooltip
+              title="Suggestion Rationale"
+              reason={tip}
+              details={['Actioning this tip can improve ATS visibility and overall resume score.']}
+            />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## **User description**
## Description
Implements AI reasoning tooltips across all scoring and job-match
components, giving users contextual explanations behind every AI
decision — improving transparency, trust, and learning value.

## Type of Change
- [x] New feature

## Related Issue
Fixes #1732

## What Was Built

### New Component
`frontend/src/components/ui/AIReasoningTooltip.jsx`
- Info icon trigger (lucide-react)
- Hover → short reason preview (`role="tooltip"`)
- Click → expandable panel with full details list
- Outside click + X button to dismiss
- Touch-friendly for mobile
- Accessible (`aria-label`, `aria-expanded`, `role="dialog"`)
- Unique IDs via `useId()` — safe for multiple instances

### Integrations (no new API calls — existing data only)

| Location | Tooltips Added |
|---|---|
| `Enhance.jsx` | ATS score ring, 5 score breakdown bars, analysis summary, improvement cards, section grade cards, bullet scores, senior tips, competitive edge score |
| `ResumeScore.jsx` | Overall score, each section score bar, each top suggestion |
| `ResumeView.jsx` | Overall score, section scores, suggestions |

## Testing
- [x] Tested Locally
- [x] No new warnings generated

## Screenshots (MANDATORY for UI/UX changes)
<!-- DRAG AND DROP SCREENSHOT HERE -->

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings generated
- [x] No extra API calls introduced
- [x] Existing component functionality unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explanation tooltips throughout the resume analysis experience. Users can now hover over or tap score indicators, section grades, improvement suggestions, and analysis metrics to reveal detailed reasoning and supporting information. Expandable dialogs provide comprehensive breakdowns of how scores and recommendations are determined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add explanation tooltips to resume and ATS scoring details

### What Changed
- Score cards, section grades, and improvement tips now include clickable or hoverable explanations that show why each score or suggestion appears
- Resume analysis pages now explain the overall score, section scores, and top suggestions with supporting details
- ATS review screens now explain score breakdowns, analysis summaries, improvement items, senior tips, and competitive edge results
- Tooltip panels can be dismissed, work on touch devices, and show a short preview before expanding into full details

### Impact
`✅ Clearer resume score explanations`
`✅ Easier-to-understand ATS feedback`
`✅ Faster review of improvement suggestions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
