### PR TITLE
[GSSoC'26]fix(usePresence): stabilize stableUserIds ref to prevent socket listener churn

### DIFF
--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -9,11 +9,22 @@ export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
-  // Create a stable primitive key based on array content to prevent unnecessary effect triggers
-  const serializedUserIds = userIds.join(',');
+  // Serialize the array to a stable primitive so effect dependency comparisons
+  // use value equality rather than reference equality. Sorting guarantees that
+  // ['a','b'] and ['b','a'] are treated as the same set of tracked users.
+  const serializedUserIds = useMemo(
+    () => [...userIds].sort().join(','),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [userIds.length, ...userIds]
+  );
 
-  // Memoize the target user IDs array so its reference remains stable between renders
-  const stableUserIds = useMemo(() => userIds, [serializedUserIds]);
+  // Reconstruct a stable array reference from the serialized string so that
+  // inline arrays (e.g. usePresence(['user1','user2'])) do not cause the
+  // subscription effects below to re-run on every parent render.
+  const stableUserIds = useMemo(
+    () => (serializedUserIds ? serializedUserIds.split(',') : []),
+    [serializedUserIds]
+  );
 
   // 1. Synchronize local map when global onlineUsers change or target user IDs change
   useEffect(() => {

--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -9,20 +9,21 @@ export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
-  // Serialize the array to a stable primitive so effect dependency comparisons
-  // use value equality rather than reference equality. Sorting guarantees that
-  // ['a','b'] and ['b','a'] are treated as the same set of tracked users.
+  // Serialize to a collision-safe JSON string so that user IDs containing
+  // commas (or any delimiter) are encoded correctly. Sorting first ensures
+  // ['a','b'] and ['b','a'] produce the same key and don't trigger extra
+  // subscriptions due to order differences.
   const serializedUserIds = useMemo(
-    () => [...userIds].sort().join(','),
+    () => JSON.stringify([...userIds].sort()),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [userIds.length, ...userIds]
   );
 
-  // Reconstruct a stable array reference from the serialized string so that
+  // Reconstruct a stable array reference by parsing the JSON string so that
   // inline arrays (e.g. usePresence(['user1','user2'])) do not cause the
   // subscription effects below to re-run on every parent render.
   const stableUserIds = useMemo(
-    () => (serializedUserIds ? serializedUserIds.split(',') : []),
+    () => JSON.parse(serializedUserIds),
     [serializedUserIds]
   );
 

--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -9,21 +9,26 @@ export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
+  // Normalize to a safe array first so null callers don't throw on spread/length.
+  const safeUserIds = Array.isArray(userIds) ? userIds : [];
+
   // Serialize to a collision-safe JSON string so that user IDs containing
   // commas (or any delimiter) are encoded correctly. Sorting first ensures
   // ['a','b'] and ['b','a'] produce the same key and don't trigger extra
-  // subscriptions due to order differences.
+  // subscriptions due to order differences. Using safeUserIds.length and the
+  // individual IDs as primitive deps avoids the need for an eslint-disable.
   const serializedUserIds = useMemo(
-    () => JSON.stringify([...userIds].sort()),
+    () => (safeUserIds.length === 0 ? '' : JSON.stringify([...safeUserIds].sort())),
+    // safeUserIds.length + individual IDs are primitive deps React can compare
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [userIds.length, ...userIds]
+    [safeUserIds.length, ...safeUserIds]
   );
 
-  // Reconstruct a stable array reference by parsing the JSON string so that
-  // inline arrays (e.g. usePresence(['user1','user2'])) do not cause the
-  // subscription effects below to re-run on every parent render.
+  // Reconstruct a stable array reference from the parsed JSON so that inline
+  // arrays (e.g. usePresence(['user1','user2'])) do not cause subscription
+  // effects below to re-run on every parent render.
   const stableUserIds = useMemo(
-    () => JSON.parse(serializedUserIds),
+    () => (serializedUserIds ? JSON.parse(serializedUserIds) : []),
     [serializedUserIds]
   );
 

--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -12,16 +12,20 @@ export function usePresence(userIds = []) {
   // Normalize to a safe array first so null callers don't throw on spread/length.
   const safeUserIds = Array.isArray(userIds) ? userIds : [];
 
+  // Deduplicate so callers passing repeated IDs don't trigger extra subscriptions.
+  const uniqueUserIds = [...new Set(safeUserIds)];
+
   // Serialize to a collision-safe JSON string so that user IDs containing
   // commas (or any delimiter) are encoded correctly. Sorting first ensures
   // ['a','b'] and ['b','a'] produce the same key and don't trigger extra
-  // subscriptions due to order differences. Using safeUserIds.length and the
-  // individual IDs as primitive deps avoids the need for an eslint-disable.
+  // subscriptions due to order differences.
   const serializedUserIds = useMemo(
-    () => (safeUserIds.length === 0 ? '' : JSON.stringify([...safeUserIds].sort())),
-    // safeUserIds.length + individual IDs are primitive deps React can compare
+    () => (uniqueUserIds.length === 0 ? '' : JSON.stringify([...uniqueUserIds].sort())),
+    // We spread individual primitive IDs rather than passing the array reference
+    // so React can compare each element by value. Passing the array directly
+    // would always appear changed on re-renders with inline arrays.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeUserIds.length, ...safeUserIds]
+    [uniqueUserIds.length, ...uniqueUserIds]
   );
 
   // Reconstruct a stable array reference from the parsed JSON so that inline


### PR DESCRIPTION
## **User description**
## Description

The `usePresence` hook was experiencing socket listener churn due to an unstable
`stableUserIds` array reference. The previous implementation called
`useMemo(() => userIds, [serializedUserIds])`, which captured the raw `userIds`
reference and returned it as-is — meaning inline arrays like
`usePresence(['user1', 'user2'])` created a new reference on every parent render.
This caused both `useEffect`s to re-run continuously, triggering repeated
unsubscribe/re-subscribe cycles even when the actual user IDs had not changed.

**Fix:**
- Promoted `serializedUserIds` to a real `useMemo` with individual IDs spread as
  primitive deps, enabling React to perform stable value comparisons.
- Added sort before joining so order-variant arrays (`['b','a']` vs `['a','b']`)
  are treated as identical, preventing spurious re-subscriptions.
- Derived `stableUserIds` by splitting the stable serialized string inside
  `useMemo`, ensuring the returned array reference only changes when content
  genuinely changes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #1703

## Testing
- [x] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

**Verified manually:**
- `usePresence(['user1', 'user2'])` called from a parent that re-renders
  frequently no longer recreates socket subscriptions on each render.
- Subscriptions fire exactly once per unique set of user IDs.
- Cleanup runs correctly when IDs change or the component unmounts.
- No duplicate listeners or stale subscriptions observed.

## Screenshots (MANDATORY for UI/UX changes)
N/A — this is a hook-level performance fix with no UI/visual changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presence tracking now behaves consistently regardless of the order of provided user IDs.
  * Reduces unnecessary re-subscriptions and improves synchronization stability when the tracked user list changes.
  * No changes to the hook’s public signature or returned API; integrations continue to work as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep presence subscriptions stable when the same users are tracked**

### What Changed
- Presence tracking no longer re-subscribes on every parent render when the same user IDs are passed in an inline list.
- User IDs are treated as the same set even if their order changes, so reordering users does not restart presence updates.
- The tracked user list now keeps a stable reference unless the actual user IDs change, reducing duplicate listener churn.

### Impact
`✅ Fewer repeated presence updates`
`✅ Reduced socket listener churn`
`✅ Stable tracking for the same users across re-renders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
