### PR TITLE
[GSSoC'26]feat(weeklyDigest): offload digest processing to BullMQ background queue

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -57,7 +57,9 @@ const connectDB = async (...args) => {
 };
 
 import {
-  scheduleWeeklyDigest
+  scheduleWeeklyDigest,
+  initializeDigestQueue,
+  startDigestWorker
 } from './services/weeklyDigestService.js';
 
 const app = express();
@@ -278,6 +280,12 @@ const startServer = async () => {
     }
 
     try {
+      const digestQueueReady = await initializeDigestQueue();
+
+      if (digestQueueReady) {
+        startDigestWorker();
+      }
+
       scheduleWeeklyDigest();
     } catch (digestError) {
       console.warn(

--- a/backend/src/services/weeklyDigestService.js
+++ b/backend/src/services/weeklyDigestService.js
@@ -2,6 +2,9 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { Queue, Worker } from 'bullmq';
+import IORedis from 'ioredis';
+
 import User from '../models/User.model.js';
 import TrackedJob from '../models/TrackedJob.model.js';
 
@@ -9,9 +12,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 
 import cron from 'node-cron';
 
-import {
-  sendWeeklyDigestEmail
-} from './mailService.js';
+import { sendWeeklyDigestEmail } from './mailService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,14 +23,33 @@ const model = genAI.getGenerativeModel({
   model: 'gemini-2.5-flash'
 });
 
+// ---------------------------------------------------------------------------
+// Queue state — mirrors the pattern in jobAlertQueue.js
+// ---------------------------------------------------------------------------
+
+let redisAvailable = false;
+let redisConnection = null;
+let weeklyDigestQueue = null;
+let redisUrl = null;
+
+const QUEUE_NAME = 'weekly-digests';
+
+// Worker processes up to 3 users concurrently; keeps Gemini pressure low.
+// Tune via WEEKLY_DIGEST_CONCURRENCY env var.
+const WORKER_CONCURRENCY = parseInt(process.env.WEEKLY_DIGEST_CONCURRENCY || '3', 10);
+
+// ---------------------------------------------------------------------------
+// Helpers (unchanged from original)
+// ---------------------------------------------------------------------------
+
 const escapeHtml = (unsafe = '') => {
-    return String(unsafe)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#039;');
-  };
+  return String(unsafe)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};
 
 const generateWeeklyInsights = async (user, trackedJobs) => {
   try {
@@ -72,13 +92,12 @@ Keep response concise.
 `;
 
     const result = await model.generateContent(prompt);
-
     const response = await result.response;
-
     return response.text();
   } catch (error) {
     console.error('Error generating weekly insights:', error);
 
+    // Graceful fallback so a Gemini outage doesn't swallow the entire batch
     return `
 MARKET_TRENDS:
 - Hiring demand remains steady for ${user.jobRole} roles.
@@ -96,11 +115,7 @@ SKILL_RECOMMENDATIONS:
   }
 };
 
-const buildDigestHtml = async ({
-  user,
-  insights,
-  trackedJobs
-}) => {
+const buildDigestHtml = async ({ user, insights, trackedJobs }) => {
   const templatePath = path.join(
     __dirname,
     '../templates/emails/weekly-digest.html'
@@ -120,107 +135,340 @@ const buildDigestHtml = async ({
     .join('');
 
   template = template
+    .replace('{{USER_NAME}}', escapeHtml(user.username))
     .replace(
-    '{{USER_NAME}}',
-    escapeHtml(user.username)
-     )
-    .replace(
-    '{{INSIGHTS}}',
-    escapeHtml(insights).replace(/\n/g, '<br>')
+      '{{INSIGHTS}}',
+      escapeHtml(insights).replace(/\n/g, '<br>')
     )
     .replace('{{TRACKED_JOBS}}', trackedJobsHtml);
 
-return template;
+  return template;
 };
 
+// ---------------------------------------------------------------------------
+// Core per-user digest logic (exported for direct use and worker reuse)
+// ---------------------------------------------------------------------------
+
 export const generateWeeklyDigestForUser = async (user) => {
-  const trackedJobs = await TrackedJob.find({
-    userId: user.uid
-  })
+  const trackedJobs = await TrackedJob.find({ userId: user.uid })
     .sort({ updatedAt: -1 })
     .limit(10);
 
-  const insights = await generateWeeklyInsights(
-    user,
-    trackedJobs
-  );
+  const insights = await generateWeeklyInsights(user, trackedJobs);
 
-  const html = await buildDigestHtml({
-    user,
-    insights,
-    trackedJobs
-  });
+  const html = await buildDigestHtml({ user, insights, trackedJobs });
 
-  return {
-    insights,
-    html
-  };
+  return { insights, html };
 };
 
 export const getWeeklyDigestUsers = async () => {
-  return User.find({
-    'notificationPreferences.jobAlerts': true
-  });
+  return User.find({ 'notificationPreferences.jobAlerts': true });
 };
 
+// ---------------------------------------------------------------------------
+// Redis / Queue initialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a dedicated Redis connection for the BullMQ worker.
+ * BullMQ requires a separate connection because workers use blocking commands.
+ */
+const createWorkerConnection = () => {
+  if (!redisUrl) {
+    console.log('⚠️  [WeeklyDigest] Redis URL not available for worker connection');
+    return null;
+  }
+
+  const conn = new IORedis(redisUrl, {
+    maxRetriesPerRequest: null,
+    enableReadyCheck: false,
+    retryStrategy: (times) => {
+      if (times > 3) return null;
+      return Math.min(times * 200, 1000);
+    }
+  });
+
+  conn.on('error', (err) => {
+    console.error('❌ [WeeklyDigest] Worker Redis connection error:', err.message);
+  });
+
+  return conn;
+};
+
+/**
+ * Initialize the weekly-digests BullMQ queue.
+ * Returns true when Redis is reachable and the queue is ready.
+ */
+export const initializeDigestQueue = async () => {
+  redisUrl = process.env.REDIS_URL;
+
+  if (!redisUrl) {
+    console.log('ℹ️  [WeeklyDigest] REDIS_URL not configured - digest queue disabled');
+    return false;
+  }
+
+  try {
+    redisConnection = new IORedis(redisUrl, {
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      retryStrategy: (times) => {
+        if (times > 3) {
+          console.log('⚠️  [WeeklyDigest] Redis connection failed after 3 attempts');
+          return null;
+        }
+        return Math.min(times * 200, 1000);
+      }
+    });
+
+    // Test connection before declaring success
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Redis connection timeout'));
+      }, 5000);
+
+      redisConnection.once('ready', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      redisConnection.once('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+
+    weeklyDigestQueue = new Queue(QUEUE_NAME, {
+      connection: redisConnection,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 10000 // Start at 10 s; grows to 40 s on 3rd attempt
+        },
+        removeOnComplete: {
+          age: 24 * 3600,  // Keep completed jobs 24 h for monitoring
+          count: 500
+        },
+        removeOnFail: {
+          age: 7 * 24 * 3600 // Keep failed jobs 7 days for debugging
+        }
+      }
+    });
+
+    weeklyDigestQueue.on('error', (error) => {
+      console.error('❌ [WeeklyDigest] Queue error:', error.message);
+    });
+
+    redisAvailable = true;
+    console.log('✅ [WeeklyDigest] Redis connected - digest queue enabled');
+    return true;
+
+  } catch (error) {
+    console.log('⚠️  [WeeklyDigest] Redis not available:', error.message);
+    console.log('ℹ️  [WeeklyDigest] Digest queue disabled - falling back to sequential processing');
+    redisAvailable = false;
+    return false;
+  }
+};
+
+const isDigestQueueAvailable = () => redisAvailable && weeklyDigestQueue !== null;
+
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the BullMQ worker that processes individual digest jobs.
+ * Each job carries only { userId } to keep the payload lightweight.
+ * The worker fetches the full user document itself so restarts are safe.
+ */
+export const startDigestWorker = () => {
+  if (!isDigestQueueAvailable()) {
+    console.log('⚠️  [WeeklyDigest] Queue not available - worker not started');
+    return null;
+  }
+
+  const workerConnection = createWorkerConnection();
+
+  if (!workerConnection) {
+    console.log('⚠️  [WeeklyDigest] Could not create worker Redis connection');
+    return null;
+  }
+
+  const worker = new Worker(
+    QUEUE_NAME,
+    async (job) => {
+      const { userId } = job.data;
+
+      console.log(`[WeeklyDigest] ▶️  Processing digest for user: ${userId}`);
+
+      // Re-fetch the user so we always have fresh data even after retries
+      const user = await User.findOne({ uid: userId }).lean();
+
+      if (!user) {
+        // User deleted between enqueue and processing — skip gracefully
+        console.warn(`[WeeklyDigest] ⚠️  User ${userId} not found, skipping`);
+        return { skipped: true, reason: 'user_not_found' };
+      }
+
+      if (!user.email) {
+        console.warn(`[WeeklyDigest] ⚠️  User ${userId} has no email, skipping`);
+        return { skipped: true, reason: 'no_email' };
+      }
+
+      const { html } = await generateWeeklyDigestForUser(user);
+
+      await sendWeeklyDigestEmail({
+        userEmail: user.email,
+        userName: user.username,
+        html
+      });
+
+      console.log(`[WeeklyDigest] ✅ Digest sent to ${user.email}`);
+      return { success: true, email: user.email };
+    },
+    {
+      connection: workerConnection,
+      concurrency: WORKER_CONCURRENCY,
+      autorun: true
+    }
+  );
+
+  worker.on('completed', (job, result) => {
+    if (result?.skipped) {
+      console.log(`[WeeklyDigest] ⏭️  Job ${job.id} skipped: ${result.reason}`);
+    } else {
+      console.log(`[WeeklyDigest] ✅ Job ${job.id} completed for ${result?.email}`);
+    }
+  });
+
+  worker.on('failed', (job, error) => {
+    console.error(
+      `[WeeklyDigest] ❌ Job ${job?.id} failed (attempt ${job?.attemptsMade}/${job?.opts?.attempts}):`,
+      error.message
+    );
+  });
+
+  worker.on('error', (error) => {
+    console.error('[WeeklyDigest] ❌ Worker error:', error.message);
+  });
+
+  worker.on('stalled', (jobId) => {
+    console.warn(`[WeeklyDigest] ⚠️  Job ${jobId} stalled`);
+  });
+
+  console.log(
+    `👷 [WeeklyDigest] Worker started (concurrency: ${WORKER_CONCURRENCY})`
+  );
+
+  return worker;
+};
+
+// ---------------------------------------------------------------------------
+// Public API — sendWeeklyDigests
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue one lightweight digest job per eligible user.
+ * Falls back to the original sequential loop when Redis is unavailable.
+ */
 export const sendWeeklyDigests = async () => {
-    try {
-      console.log('Starting weekly digest generation...');
-  
-      const users = await getWeeklyDigestUsers();
-  
-      console.log(`Found ${users.length} users for digest`);
-  
+  try {
+    console.log('[WeeklyDigest] Starting weekly digest run...');
+
+    const users = await getWeeklyDigestUsers();
+
+    if (!users.length) {
+      console.log('[WeeklyDigest] No eligible users found, nothing to do');
+      return;
+    }
+
+    console.log(`[WeeklyDigest] Found ${users.length} users to process`);
+
+    if (isDigestQueueAvailable()) {
+      // ── Queue path: enqueue one job per user ──────────────────────────────
+      // Use a week-scoped jobId so duplicate cron triggers within the same
+      // week don't create duplicate digest sends.
+      const weekKey = `${new Date().getUTCFullYear()}-W${getISOWeek(new Date())}`;
+
+      const jobs = users.map((user) => ({
+        name: 'send-digest',
+        data: { userId: user.uid },
+        opts: {
+          jobId: `digest-${user.uid}-${weekKey}`,
+          // Stagger jobs slightly to spread Gemini API load
+          delay: 0
+        }
+      }));
+
+      await weeklyDigestQueue.addBulk(jobs);
+
+      console.log(
+        `[WeeklyDigest] ✅ Enqueued ${jobs.length} digest jobs (week: ${weekKey})`
+      );
+    } else {
+      // ── Fallback path: sequential processing (no Redis) ───────────────────
+      console.log('[WeeklyDigest] ⚠️  Queue unavailable, processing sequentially...');
+
       for (const user of users) {
         try {
-          const { html } =
-            await generateWeeklyDigestForUser(user);
-  
+          const { html } = await generateWeeklyDigestForUser(user);
+
           await sendWeeklyDigestEmail({
             userEmail: user.email,
             userName: user.username,
             html
           });
-  
-          console.log(
-            `Weekly digest sent to ${user.email}`
-          );
+
+          console.log(`[WeeklyDigest] ✅ Sent to ${user.email}`);
         } catch (error) {
           console.error(
-            `Failed weekly digest for ${user.email}:`,
+            `[WeeklyDigest] ❌ Failed for ${user.email}:`,
             error.message
           );
         }
       }
-  
-      console.log('Weekly digest process completed');
-    } catch (error) {
-      console.error(
-        'Weekly digest scheduler failed:',
-        error
-      );
     }
-  };
-  
-  export const scheduleWeeklyDigest = () => {
-    const schedule = '0 9 * * 1';
-  
-    console.log(
-      `Weekly digest scheduled with cron: ${schedule}`
-    );
-  
-    cron.schedule(
-        schedule,
-        async () => {
-          console.log(
-            'Weekly digest cron triggered'
-          );
-      
-          await sendWeeklyDigests();
-        },
-        {
-          timezone:
-            process.env.WEEKLY_DIGEST_TIMEZONE || 'UTC'
-        }
-      );
-  };
+
+    console.log('[WeeklyDigest] Digest run complete');
+  } catch (error) {
+    console.error('[WeeklyDigest] ❌ Weekly digest run failed:', error);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Cron scheduler
+// ---------------------------------------------------------------------------
+
+export const scheduleWeeklyDigest = () => {
+  const schedule = '0 9 * * 1'; // Every Monday at 09:00
+
+  console.log(`[WeeklyDigest] Cron scheduled: ${schedule}`);
+
+  cron.schedule(
+    schedule,
+    async () => {
+      console.log('[WeeklyDigest] Cron triggered');
+      await sendWeeklyDigests();
+    },
+    {
+      timezone: process.env.WEEKLY_DIGEST_TIMEZONE || 'UTC'
+    }
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ISO week helper (no external dependency)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the ISO week number for a given date.
+ * @param {Date} date
+ * @returns {number}
+ */
+function getISOWeek(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+}

--- a/backend/src/services/weeklyDigestService.js
+++ b/backend/src/services/weeklyDigestService.js
@@ -303,7 +303,7 @@ export const startDigestWorker = () => {
       console.log(`[WeeklyDigest] ▶️  Processing digest for user: ${userId}`);
 
       // Re-fetch the user so we always have fresh data even after retries
-      const user = await User.findOne({ uid: userId }).lean();
+      const user = await User.findById(userId).lean();
 
       if (!user) {
         // User deleted between enqueue and processing — skip gracefully
@@ -393,9 +393,9 @@ export const sendWeeklyDigests = async () => {
 
       const jobs = users.map((user) => ({
         name: 'send-digest',
-        data: { userId: user.uid },
+        data: { userId: user._id.toString() },
         opts: {
-          jobId: `digest-${user.uid}-${weekKey}`,
+          jobId: `digest-${user._id.toString()}-${weekKey}`,
           // Stagger jobs slightly to spread Gemini API load
           delay: 0
         }

--- a/backend/src/services/weeklyDigestService.js
+++ b/backend/src/services/weeklyDigestService.js
@@ -391,13 +391,13 @@ export const sendWeeklyDigests = async () => {
       // week don't create duplicate digest sends.
       const weekKey = `${new Date().getUTCFullYear()}-W${getISOWeek(new Date())}`;
 
-      const jobs = users.map((user) => ({
+      const jobs = users.map((user, index) => ({
         name: 'send-digest',
         data: { userId: user._id.toString() },
         opts: {
           jobId: `digest-${user._id.toString()}-${weekKey}`,
-          // Stagger jobs slightly to spread Gemini API load
-          delay: 0
+          // Stagger jobs by 500 ms each to spread Gemini API pressure
+          delay: index * 500
         }
       }));
 

--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -9,11 +9,22 @@ export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
-  // Create a stable primitive key based on array content to prevent unnecessary effect triggers
-  const serializedUserIds = userIds.join(',');
+  // Serialize the array to a stable primitive so effect dependency comparisons
+  // use value equality rather than reference equality. Sorting guarantees that
+  // ['a','b'] and ['b','a'] are treated as the same set of tracked users.
+  const serializedUserIds = useMemo(
+    () => [...userIds].sort().join(','),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [userIds.length, ...userIds]
+  );
 
-  // Memoize the target user IDs array so its reference remains stable between renders
-  const stableUserIds = useMemo(() => userIds, [serializedUserIds]);
+  // Reconstruct a stable array reference from the serialized string so that
+  // inline arrays (e.g. usePresence(['user1','user2'])) do not cause the
+  // subscription effects below to re-run on every parent render.
+  const stableUserIds = useMemo(
+    () => (serializedUserIds ? serializedUserIds.split(',') : []),
+    [serializedUserIds]
+  );
 
   // 1. Synchronize local map when global onlineUsers change or target user IDs change
   useEffect(() => {

--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -9,20 +9,21 @@ export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
-  // Serialize the array to a stable primitive so effect dependency comparisons
-  // use value equality rather than reference equality. Sorting guarantees that
-  // ['a','b'] and ['b','a'] are treated as the same set of tracked users.
+  // Serialize to a collision-safe JSON string so that user IDs containing
+  // commas (or any delimiter) are encoded correctly. Sorting first ensures
+  // ['a','b'] and ['b','a'] produce the same key and don't trigger extra
+  // subscriptions due to order differences.
   const serializedUserIds = useMemo(
-    () => [...userIds].sort().join(','),
+    () => JSON.stringify([...userIds].sort()),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [userIds.length, ...userIds]
   );
 
-  // Reconstruct a stable array reference from the serialized string so that
+  // Reconstruct a stable array reference by parsing the JSON string so that
   // inline arrays (e.g. usePresence(['user1','user2'])) do not cause the
   // subscription effects below to re-run on every parent render.
   const stableUserIds = useMemo(
-    () => (serializedUserIds ? serializedUserIds.split(',') : []),
+    () => JSON.parse(serializedUserIds),
     [serializedUserIds]
   );
 

--- a/frontend/src/hooks/usePresence.js
+++ b/frontend/src/hooks/usePresence.js
@@ -9,21 +9,26 @@ export function usePresence(userIds = []) {
   const { onlineUsers, subscribe } = useSocket();
   const [presenceMap, setPresenceMap] = useState({});
 
+  // Normalize to a safe array first so null callers don't throw on spread/length.
+  const safeUserIds = Array.isArray(userIds) ? userIds : [];
+
   // Serialize to a collision-safe JSON string so that user IDs containing
   // commas (or any delimiter) are encoded correctly. Sorting first ensures
   // ['a','b'] and ['b','a'] produce the same key and don't trigger extra
-  // subscriptions due to order differences.
+  // subscriptions due to order differences. Using safeUserIds.length and the
+  // individual IDs as primitive deps avoids the need for an eslint-disable.
   const serializedUserIds = useMemo(
-    () => JSON.stringify([...userIds].sort()),
+    () => (safeUserIds.length === 0 ? '' : JSON.stringify([...safeUserIds].sort())),
+    // safeUserIds.length + individual IDs are primitive deps React can compare
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [userIds.length, ...userIds]
+    [safeUserIds.length, ...safeUserIds]
   );
 
-  // Reconstruct a stable array reference by parsing the JSON string so that
-  // inline arrays (e.g. usePresence(['user1','user2'])) do not cause the
-  // subscription effects below to re-run on every parent render.
+  // Reconstruct a stable array reference from the parsed JSON so that inline
+  // arrays (e.g. usePresence(['user1','user2'])) do not cause subscription
+  // effects below to re-run on every parent render.
   const stableUserIds = useMemo(
-    () => JSON.parse(serializedUserIds),
+    () => (serializedUserIds ? JSON.parse(serializedUserIds) : []),
     [serializedUserIds]
   );
 


### PR DESCRIPTION
## **User description**
## Description

The existing `sendWeeklyDigests()` function processed all eligible users
sequentially inside a synchronous `for...of` loop — generating Gemini AI
insights and sending emails one-by-one in the request/event loop. This
caused event loop starvation, no retry/recovery on failures, duplicate sends
on server restarts mid-run, and poor scalability as the user base grows.

This PR refactors weekly digest processing into a dedicated BullMQ background
queue (`weekly-digests`), following the same patterns already established in
`jobAlertQueue.js` and `jobFetcher.js`:

- **`initializeDigestQueue()`** — sets up an IORedis connection and BullMQ
  `Queue` with 3-attempt exponential backoff (10s base delay).
- **`startDigestWorker()`** — spawns a BullMQ `Worker` on its own dedicated
  Redis connection (required by BullMQ). The worker re-fetches the user
  document on each attempt so restarts are safe and data is always fresh.
- **`sendWeeklyDigests()`** — now enqueues lightweight `{ userId }` jobs in
  bulk instead of doing the work inline. Week-scoped `jobId`s
  (e.g. `digest-<uid>-2026-W21`) make jobs idempotent — duplicate cron
  triggers in the same week are no-ops.
- **Sequential fallback** preserved for environments without Redis — zero
  regression when the queue is unavailable.
- **`index.js`** updated to initialize the queue and start the worker at
  server startup, guarded by the existing try/catch so failures are
  non-fatal warnings.

All existing logic (`generateWeeklyInsights`, `buildDigestHtml`,
`generateWeeklyDigestForUser`, `getWeeklyDigestUsers`, `scheduleWeeklyDigest`)
is preserved unchanged.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #1700 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

**Verified manually:**
- Digest jobs enqueue correctly when Redis is available.
- Worker picks up jobs individually with correct user data.
- Week-scoped `jobId` prevents duplicate sends on repeated cron triggers.
- Sequential fallback works correctly when `REDIS_URL` is not set.
- Failed jobs retry automatically with exponential backoff.
- Server startup does not fail when Redis is unavailable.

## Screenshots (MANDATORY for UI/UX changes)
N/A — backend-only refactor with no UI/visual changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Process weekly digests in the background and make presence tracking more reliable**

### What Changed
- Weekly digests now run through a background queue, so email generation and sending no longer block the main request flow.
- Duplicate weekly digest runs in the same week are ignored, and failed jobs can retry automatically.
- If Redis is unavailable, weekly digests still run one user at a time as a fallback.
- Presence tracking now handles empty, null, and comma-containing user IDs without breaking subscriptions or matching the wrong users.
- Presence updates no longer re-subscribe on every re-render when the same user IDs are passed in a different order.

### Impact
`✅ Faster weekly digest runs`
`✅ Fewer duplicate digest emails`
`✅ Fewer missed digests during temporary failures`
`✅ More reliable online status tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly digest delivery system upgraded to use a queue-based architecture for improved reliability and performance.

* **Bug Fixes**
  * Weekly digest generation now gracefully handles AI insight generation failures with fallback content.
  * Improved presence detection to handle edge cases in user tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->