### PR TITLE
Enhance: Replace preset emojis with Lucide icons in CustomSection

### DIFF
--- a/frontend/src/components/community/ChannelList.jsx
+++ b/frontend/src/components/community/ChannelList.jsx
@@ -49,13 +49,13 @@ export default function ChannelList({
   }, {});
 
   const categoryLabels = {
-    general: '💬 General',
-    'job-hunting': '🔍 Job Hunting',
-    'interview-prep': '🎯 Interview Prep',
-    'resume-tips': '📄 Resume Tips',
-    networking: '🤝 Networking',
-    announcements: '📢 Announcements',
-    other: '📌 Other'
+    general: 'General',
+    'job-hunting': 'Job Hunting',
+    'interview-prep': 'Interview Prep',
+    'resume-tips': 'Resume Tips',
+    networking: 'Networking',
+    announcements: 'Announcements',
+    other: 'Other'
   };
 
   const toggleCategory = (category) => {
@@ -141,7 +141,7 @@ export default function ChannelList({
                     {channel.type === 'private' ? (
                       <Lock className="w-4 h-4 text-muted-foreground flex-shrink-0" />
                     ) : (
-                      <span className="text-base flex-shrink-0">{channel.icon || '💬'}</span>
+                      <Hash className="w-4 h-4 text-muted-foreground flex-shrink-0" />
                     )}
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-1">


### PR DESCRIPTION
## **User description**
Closed #1769

## Description
This PR upgrades the `CustomSection.jsx` component in the Resume Builder by replacing hardcoded emojis in the quick preset options with crisp Lucide React icons.

## Changes Made
- Imported and mapped `lucide-react` icons (Trophy, FileText, GraduationCap, Users, etc.) to the `SECTION_PRESETS`.
- Replaced the large folder emoji (`📂`) in the empty state with the `FolderOpen` icon, adding a muted opacity styling.

## Impact
Creates a much more cohesive and modern interface for users building their resume sections.


___

## **CodeAnt-AI Description**
**Use plain icons and labels in the channel list**

### What Changed
- Channel categories now show plain text names instead of emoji-prefixed labels.
- Public channels now use a hash icon instead of custom emoji channel symbols, while private channels still show a lock icon.
- The channel list now looks more consistent and easier to scan at a glance.

### Impact
`✅ Clearer channel navigation`
`✅ More consistent community sidebar`
`✅ Easier-to-scan channel lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
