### PR TITLE
Upgrade resume card typography and metadata icons

### DIFF
--- a/frontend/src/components/ai/LinkedInHeadlineGenerator.jsx
+++ b/frontend/src/components/ai/LinkedInHeadlineGenerator.jsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import toast from 'react-hot-toast'
+import { Zap, Copy, RefreshCw, Wand2 } from 'lucide-react'
 
 const SAMPLE_HEADLINES = [
   'Frontend Developer | React & Tailwind Enthusiast',
-  'Building modern web experiences with React ⚡',
+  'Building modern web experiences with React',
   'Full Stack Developer | MERN Stack | Open Source',
   'Turning ideas into scalable digital products',
   'Software Engineer passionate about clean UI/UX',
@@ -30,19 +31,22 @@ export default function LinkedInHeadlineGenerator() {
   return (
     <div className="p-6 rounded-xl bg-gray-900 text-white space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold">
+        <h2 className="text-2xl font-bold flex items-center gap-2">
+          <Zap className="text-amber-400" />
           LinkedIn Headline Generator
         </h2>
 
         <button
           onClick={regenerateHeadlines}
-          className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 transition"
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600/10 text-blue-400 hover:bg-blue-600/20 border border-blue-500/20 transition-colors text-sm font-medium"
         >
+          <RefreshCw size={16} />
           Regenerate
         </button>
       </div>
 
-      <button className="w-full py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 transition font-medium">
+      <button className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 shadow-lg shadow-indigo-500/20 transition-all font-medium text-lg">
+        <Wand2 size={20} />
         Generate Headlines
       </button>
 
@@ -65,8 +69,9 @@ export default function LinkedInHeadlineGenerator() {
 
               <button
                 onClick={() => copyHeadline(headline)}
-                className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 text-sm"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-700/50 hover:bg-gray-600 text-sm font-medium transition-colors border border-gray-600 shrink-0"
               >
+                <Copy size={14} />
                 Copy
               </button>
             </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -21,7 +21,8 @@ import {
   GraduationCap,
   Bell,
   Mic,
-  Globe
+  Globe,
+  Calendar
 } from 'lucide-react'
 import { resumeApi, jobTrackerApi, portfolioApi } from '../services/api'
 import Button from '../components/Button'
@@ -399,7 +400,7 @@ export default function Dashboard() {
                   <div className="rounded-[2rem] bg-card border border-border overflow-hidden shadow-sm">
                     <div className="divide-y divide-border">
                       {resumes.slice(0, 5).map(resume => (
-                        <div key={resume.id} className="p-5 hover:bg-muted/50 transition-all group">
+                        <div key={resume.id} className="p-5 hover:bg-muted/80 transition-all group hover:shadow-md relative rounded-xl hover:z-10 bg-transparent hover:bg-card">
                           <div className="flex justify-between items-center">
                             <div className="flex-1">
                               <div className="flex items-center gap-3">
@@ -408,7 +409,10 @@ export default function Dashboard() {
                                   <span className="px-2 py-0.5 bg-primary/10 text-primary border border-primary/20 rounded text-[10px] font-black uppercase tracking-widest animate-pulse">Enhanced</span>
                                 )}
                               </div>
-                              <p className="text-sm text-muted-foreground font-semibold">{resume.jobRole || 'General'} • {formatDate(resume.createdAt)}</p>
+                              <div className="flex items-center gap-4 text-xs text-muted-foreground font-semibold mt-1.5">
+                                <span className="flex items-center gap-1.5"><Briefcase className="w-3.5 h-3.5" /> {resume.jobRole || 'General'}</span>
+                                <span className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /> {formatDate(resume.createdAt)}</span>
+                              </div>
                             </div>
                             <div className="flex gap-2">
                               <Link to={`/resume/${resume.id}`}>


### PR DESCRIPTION
## **User description**
## Description
This PR elevates the user dashboard (`Dashboard.jsx`) by improving the visual hierarchy and metadata display of the user's saved resumes.

## Changes Made
- Upgraded the resume list items to card styles using `rounded-xl`, `hover:shadow-md`, and `hover:bg-card`.
- Replaced standard bullet points (`•`) with `Briefcase` and `Calendar` icons to display the job role and creation date.

## Impact
Provides a premium, "dashboard-ready" feel with better visual parsing of user data.

Closed #1775


___

## **CodeAnt-AI Description**
**Modernize dashboard cards and headline generator controls**

### What Changed
- Saved resumes on the dashboard now appear as cleaner cards with clearer hover states and stronger visual separation.
- Resume role and creation date are now shown with icons instead of a single text line, making the details easier to scan.
- The LinkedIn headline generator now uses icon-based controls and removes emoji from sample headlines for a cleaner look.

### Impact
`✅ Easier resume scanning on the dashboard`
`✅ Clearer resume metadata display`
`✅ Cleaner headline generator controls`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
