### PR TITLE
fix(frontend): prevent stale dashboard state during failed optimistic updates

### DIFF
--- a/frontend/src/pages/JobTracker.jsx
+++ b/frontend/src/pages/JobTracker.jsx
@@ -110,7 +110,9 @@ const JobTracker = () => {
     }
 
     const newStatus = destination.droppableId;
-    
+    const oldStatus = source.droppableId;
+    const originalJob = trackedJobs.find((j) => j.id === draggableId);
+
     // Optimistic UI update
     setTrackedJobs((prev) =>
       prev.map((job) =>
@@ -120,16 +122,42 @@ const JobTracker = () => {
       ),
     );
 
+    // Optimistic stats update
+    setStats((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [oldStatus]: Math.max(0, (prev[oldStatus] || 0) - 1),
+        [newStatus]: (prev[newStatus] || 0) + 1,
+      };
+    });
+
     // Backend update
     try {
       await jobTrackerApi.updateStatus(draggableId, newStatus);
       toast.success("Status updated!");
-      fetchStats();
+      fetchStats(); // keep background sync for eventual consistency
     } catch (error) {
       console.error("Error updating status:", error);
       toast.error("Failed to update status");
-      // Revert on failure
-      fetchJobs();
+      
+      // Localized atomic revert on failure to prevent concurrent state corruption
+      if (originalJob) {
+        setTrackedJobs((prev) =>
+          prev.map((job) =>
+            job.id === draggableId ? { ...originalJob } : job,
+          ),
+        );
+      }
+      
+      setStats((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          [newStatus]: Math.max(0, (prev[newStatus] || 0) - 1),
+          [oldStatus]: (prev[oldStatus] || 0) + 1,
+        };
+      });
     }
   };
 

--- a/frontend/src/pages/JobTracker.jsx
+++ b/frontend/src/pages/JobTracker.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 import { motion } from "framer-motion";
 import { toast } from "react-hot-toast";
@@ -24,6 +24,7 @@ import { SkeletonDashboard } from "../components/ui/Skeleton.jsx";
 const JobTracker = () => {
   const [trackedJobs, setTrackedJobs] = useState([]);
   const [stats, setStats] = useState(null);
+  const mutationTrackerRef = useRef({});
   const [loading, setLoading] = useState(true);
   const [filterStatus, setFilterStatus] = useState("all");
   const [updateLoading, setUpdateLoading] = useState({});
@@ -111,7 +112,12 @@ const JobTracker = () => {
 
     const newStatus = destination.droppableId;
     const oldStatus = source.droppableId;
-    const originalJob = trackedJobs.find((j) => j.id === draggableId);
+    const foundJob = trackedJobs.find((j) => j.id === draggableId);
+    const originalJob = foundJob ? JSON.parse(JSON.stringify(foundJob)) : null;
+
+    // Concurrency protection: Generate a unique requestId for this mutation on the job
+    const requestId = Date.now() + Math.random();
+    mutationTrackerRef.current[draggableId] = requestId;
 
     // Optimistic UI update
     setTrackedJobs((prev) =>
@@ -122,42 +128,50 @@ const JobTracker = () => {
       ),
     );
 
-    // Optimistic stats update
-    setStats((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        [oldStatus]: Math.max(0, (prev[oldStatus] || 0) - 1),
-        [newStatus]: (prev[newStatus] || 0) + 1,
-      };
-    });
+    // Optimistic stats update - skip if same-column drag to prevent stat corruption
+    if (oldStatus !== newStatus) {
+      setStats((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          [oldStatus]: Math.max(0, (prev[oldStatus] || 0) - 1),
+          [newStatus]: (prev[newStatus] || 0) + 1,
+        };
+      });
+    }
 
     // Backend update
     try {
       await jobTrackerApi.updateStatus(draggableId, newStatus);
       toast.success("Status updated!");
-      fetchStats(); // keep background sync for eventual consistency
+      // Removed fetchStats() to avoid overwriting newer optimistic state with stale data
     } catch (error) {
       console.error("Error updating status:", error);
       toast.error("Failed to update status");
       
-      // Localized atomic revert on failure to prevent concurrent state corruption
-      if (originalJob) {
-        setTrackedJobs((prev) =>
-          prev.map((job) =>
-            job.id === draggableId ? { ...originalJob } : job,
-          ),
-        );
+      // Concurrency protection check: ONLY rollback if this request is still the latest mutation
+      if (mutationTrackerRef.current[draggableId] === requestId) {
+        // Localized atomic revert on failure to prevent concurrent state corruption
+        if (originalJob) {
+          setTrackedJobs((prev) =>
+            prev.map((job) =>
+              job.id === draggableId ? { ...originalJob } : job,
+            ),
+          );
+        }
+        
+        // Revert counters symmetrically on failure - skip if same-column drag
+        if (oldStatus !== newStatus) {
+          setStats((prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              [newStatus]: Math.max(0, (prev[newStatus] || 0) - 1),
+              [oldStatus]: (prev[oldStatus] || 0) + 1,
+            };
+          });
+        }
       }
-      
-      setStats((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          [newStatus]: Math.max(0, (prev[newStatus] || 0) - 1),
-          [oldStatus]: (prev[oldStatus] || 0) + 1,
-        };
-      });
     }
   };
 


### PR DESCRIPTION
## **User description**
## Description
This PR resolves a frontend state consistency issue where failed optimistic dashboard updates could leave the Job Tracker UI in a stale or partially reverted state during API failures.

Previously, the optimistic drag-and-drop flow relied on a full asynchronous `fetchJobs()` rollback after failed requests. Under slow networks or rapid interactions, this created race conditions where stale backend responses could overwrite newer optimistic state, resulting in:
- duplicated cards
- phantom job entries
- desynchronized counters
- partially reverted dashboard state

The implementation introduces an atomic localized rollback strategy that restores only the failed optimistic mutation directly from memory without triggering global state resynchronization.

## Type of Change
- [x] Bug fix
- [x] Performance improvement
- [ ] New feature
- [ ] Documentation update
- [ ] Other (describe)

## Related Issue
Fixes #1729

## Testing
- [x] Tested Locally
- [x] Verified failed API rollback behavior
- [x] Verified rapid drag/drop interactions
- [x] Verified counter synchronization during rollback
- [x] Verified slow-network rollback behavior
- [x] Verified backend failure recovery
- [x] Verified no duplicate/phantom cards remain
- [x] Verified existing Kanban workflow still works
- [ ] Unit tests pass
- [ ] New tests added

## Implementation Summary

### Atomic Rollback Strategy
- Captured immutable snapshots of:
  - original job state
  - previous column status
  - updated column status
- Removed dependency on asynchronous `fetchJobs()` rollback synchronization
- Implemented direct localized rollback restoration from memory

### State Synchronization Improvements
- Added synchronized optimistic `setStats()` updates
- Restored counters atomically on rollback failures
- Prevented stale backend responses from overwriting newer optimistic state

### Reliability Improvements
- Eliminated duplicate/phantom job cards during failed requests
- Prevented state corruption during rapid interactions
- Preserved responsive optimistic drag-and-drop UX

## Regression Review
Verified:
- drag-and-drop behavior remains intact
- existing API contracts remain unchanged
- delete/update flows continue functioning correctly
- no unrelated dashboard components were modified

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Keep job tracker cards and counters in sync after a failed drag-and-drop update**

### What Changed
- When moving a job fails, the card now returns to its original column instead of refreshing the whole dashboard.
- Job counts update immediately during the move and are restored if the update fails.
- Successful moves still refresh stats in the background to keep the dashboard consistent.

### Impact
`✅ Fewer duplicate or missing job cards after failed moves`
`✅ Correct job counts after drag-and-drop errors`
`✅ More reliable dashboard state during rapid updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced drag-and-drop job status changes with optimistic stat updates and improved error recovery, eliminating unnecessary full-page refreshes during failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->