### PR TITLE
fix: convert require to ESM import in screenshotService.js

### DIFF
--- a/backend/src/services/screenshotService.js
+++ b/backend/src/services/screenshotService.js
@@ -1,4 +1,4 @@
-const puppeteer = require("puppeteer-core");
+import puppeteer from 'puppeteer';
 
 async function generateScreenshot(htmlContent, viewport) {
   let browser;
@@ -34,6 +34,4 @@ async function generateScreenshot(htmlContent, viewport) {
   }
 }
 
-module.exports = {
-  generateScreenshot,
-};
+export { generateScreenshot };


### PR DESCRIPTION
﻿## Description
Changes `require("puppeteer-core")` to ESM `import puppeteer from 'puppeteer'` in screenshotService.js. The backend is configured as ESM (`"type": "module"`), so `require()` throws `ReferenceError` at runtime. Also updates `module.exports` to `export` syntax for consistency.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #1682

## Testing
- [x] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [x] N/A — Backend-only change, no visual impact

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code structure for improved maintainability. No changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->