### PR TITLE
 feat: implement Figma Canvas portfolio template and fix deploy modal layout

### DIFF
--- a/frontend/src/components/portfolio/DeployModal.jsx
+++ b/frontend/src/components/portfolio/DeployModal.jsx
@@ -298,7 +298,7 @@ export default function DeployModal({ isOpen, onClose, portfolioTitle = "My Port
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.96, y: 15 }}
           transition={{ type: "spring", duration: 0.5, bounce: 0.2 }}
-          className="relative w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-3xl shadow-2xl overflow-hidden flex flex-col z-10"
+          className="relative w-full max-w-md bg-zinc-900 border border-zinc-800 rounded-3xl shadow-2xl flex flex-col z-10 max-h-[90vh] overflow-hidden"
         >
           {/* Tilted Asymmetrical Hand-crafted Ribbon Stamp */}
           <div className="absolute -top-1 -right-1 bg-amber-500 text-zinc-950 text-[9px] font-bold font-mono px-3 py-1 rounded-bl-xl shadow-md uppercase tracking-wider select-none rotate-1 border-b border-l border-amber-600">
@@ -328,7 +328,7 @@ export default function DeployModal({ isOpen, onClose, portfolioTitle = "My Port
           </div>
 
           {/* Modal Body */}
-          <div className="p-6">
+          <div className="p-6 overflow-y-auto custom-scrollbar flex-1">
             <AnimatePresence mode="wait">
               {/* State 1: Provider Selection */}
               {step === 'select' && (
@@ -410,19 +410,7 @@ export default function DeployModal({ isOpen, onClose, portfolioTitle = "My Port
                             </div>
                           )}
 
-                          {/* Cloudflare: server-side token — show check button with no input */}
-                          {isSelected && !provider.needsToken && (
-                            <div className="px-4 pb-4 flex justify-end" onClick={(e) => e.stopPropagation()}>
-                              <button
-                                type="button"
-                                disabled={tokenStatus === 'checking'}
-                                onClick={() => handleCheckToken(provider.id)}
-                                className="text-[10px] font-bold font-mono px-3 py-2 rounded-xl bg-indigo-600/20 border border-indigo-500/30 text-indigo-400 hover:bg-indigo-600/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                              >
-                                {tokenStatus === 'checking' ? 'Checking…' : 'Check connection'}
-                              </button>
-                            </div>
-                          )}
+
                         </div>
                       );
                     })}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/Canvas.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/Canvas.jsx
@@ -1,0 +1,97 @@
+import React, { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { motion, useAnimation } from 'framer-motion';
+import { FRAMES_CONFIG } from './config';
+import Frame from './Frame';
+import HeroFrame from './frames/HeroFrame';
+import AboutFrame from './frames/AboutFrame';
+import SkillsFrame from './frames/SkillsFrame';
+import ProjectsFrame from './frames/ProjectsFrame';
+import ExperienceFrame from './frames/ExperienceFrame';
+import TestimonialsFrame from './frames/TestimonialsFrame';
+import ContactFrame from './frames/ContactFrame';
+
+const Canvas = forwardRef(({ data, activeFrame, onFrameClick }, ref) => {
+  const containerRef = useRef(null);
+  const controls = useAnimation();
+
+  // Expose a method to pan to a specific frame
+  useImperativeHandle(ref, () => ({
+    panToFrame: (frameId) => {
+      const frame = FRAMES_CONFIG.find(f => f.id === frameId);
+      if (!frame || !containerRef.current) return;
+      
+      const containerWidth = containerRef.current.offsetWidth;
+      const containerHeight = containerRef.current.offsetHeight;
+      
+      // Calculate position to center the frame in the viewport
+      const x = -(frame.x + frame.w / 2) + containerWidth / 2;
+      const y = -(frame.y + frame.h / 2) + containerHeight / 2;
+      
+      controls.start({
+        x,
+        y,
+        transition: { type: 'spring', stiffness: 100, damping: 20 }
+      });
+    }
+  }));
+
+  // Initial pan to Hero on load
+  useEffect(() => {
+    if (ref && ref.current) {
+      setTimeout(() => ref.current.panToFrame('hero'), 100);
+    }
+  }, []);
+
+  const renderFrameContent = (id) => {
+    switch (id) {
+      case 'hero': return <HeroFrame data={data} />;
+      case 'about': return <AboutFrame data={data} />;
+      case 'skills': return <SkillsFrame data={data} />;
+      case 'projects': return <ProjectsFrame data={data} />;
+      case 'experience': return <ExperienceFrame data={data} />;
+      case 'testimonials': return <TestimonialsFrame data={data} />;
+      case 'contact': return <ContactFrame data={data} />;
+      default: return null;
+    }
+  };
+
+  return (
+    <div 
+      className="flex-1 relative overflow-hidden bg-[#1E1E1E] select-none" 
+      ref={containerRef}
+      style={{
+        backgroundImage: 'radial-gradient(circle at 2px 2px, #333 1px, transparent 0)',
+        backgroundSize: '40px 40px'
+      }}
+    >
+      <motion.div
+        drag
+        animate={controls}
+        dragElastic={0.1}
+        className="absolute inset-0 cursor-grab active:cursor-grabbing"
+        style={{ width: 4000, height: 4000 }} // Huge draggable area
+      >
+        {FRAMES_CONFIG.map(frame => (
+          <Frame 
+            key={frame.id}
+            id={frame.id}
+            title={frame.title}
+            x={frame.x}
+            y={frame.y}
+            width={frame.w}
+            height={frame.h}
+            isActive={activeFrame === frame.id}
+            onClick={(e) => {
+              e.stopPropagation();
+              onFrameClick(frame.id);
+            }}
+          >
+            {renderFrameContent(frame.id)}
+          </Frame>
+        ))}
+      </motion.div>
+    </div>
+  );
+});
+
+export default Canvas;

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/Frame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/Frame.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function Frame({ id, title, x, y, width, height, children, isActive, onClick }) {
+  return (
+    <div
+      id={id}
+      onClick={onClick}
+      className={`absolute bg-[#1E1E1E] border transition-colors duration-300 shadow-2xl cursor-default group ${
+        isActive ? 'border-blue-500' : 'border-[#333333] hover:border-[#444444]'
+      }`}
+      style={{
+        left: x,
+        top: y,
+        width: width,
+        height: height,
+      }}
+    >
+      <div 
+        className={`absolute -top-6 left-0 text-xs font-semibold transition-colors duration-300 ${
+          isActive ? 'text-blue-500' : 'text-gray-500 group-hover:text-gray-400'
+        }`}
+      >
+        # {title}
+      </div>
+      <div className="w-full h-full overflow-hidden text-gray-200">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/LeftSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/LeftSidebar.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Layers, ChevronDown, Frame, Eye, Lock } from 'lucide-react';
+import { FRAMES_CONFIG } from './config';
+
+export default function LeftSidebar({ activeFrame, onFrameClick }) {
+  return (
+    <div className="w-64 bg-[#2C2C2C] border-r border-[#1E1E1E] h-full flex flex-col z-40 shrink-0 hidden md:flex">
+      <div className="h-10 flex items-center px-4 border-b border-[#1E1E1E]">
+        <div className="flex items-center gap-2 text-xs font-semibold text-gray-300 uppercase tracking-wider">
+          <Layers size={14} />
+          Layers
+        </div>
+      </div>
+      
+      <div className="p-2 overflow-y-auto custom-scrollbar flex-1">
+        <div className="flex items-center gap-1 p-1 mb-2">
+          <ChevronDown size={16} className="text-gray-400" />
+          <span className="text-sm font-medium text-gray-300">Portfolio Design</span>
+        </div>
+        
+        <div className="pl-5">
+          {FRAMES_CONFIG.map((frame) => {
+            const isActive = activeFrame === frame.id;
+            return (
+              <div 
+                key={frame.id}
+                onClick={() => onFrameClick(frame.id)}
+                className={`flex items-center justify-between p-1.5 rounded cursor-pointer group ${
+                  isActive ? 'bg-blue-500/20 text-blue-400' : 'hover:bg-white/5 text-gray-400'
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <Frame size={14} className={isActive ? 'text-blue-400' : 'text-gray-500'} />
+                  <span className={`text-sm truncate w-32 ${isActive ? 'font-medium' : ''}`}>
+                    {frame.title}
+                  </span>
+                </div>
+                <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <Lock size={12} className="text-gray-500 hover:text-gray-300" />
+                  <Eye size={12} className="text-gray-500 hover:text-gray-300" />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/RightSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/RightSidebar.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { AlignLeft, AlignCenter, AlignRight, Layout, Maximize } from 'lucide-react';
+import { FRAMES_CONFIG } from './config';
+
+export default function RightSidebar({ activeFrame, data }) {
+  const activeFrameData = FRAMES_CONFIG.find(f => f.id === activeFrame);
+  
+  return (
+    <div className="w-64 bg-[#2C2C2C] border-l border-[#1E1E1E] h-full flex flex-col z-40 shrink-0 hidden lg:flex overflow-y-auto custom-scrollbar">
+      <div className="h-10 flex items-center px-4 border-b border-[#1E1E1E]">
+        <div className="flex items-center gap-2 text-xs font-semibold text-gray-300 uppercase tracking-wider">
+          <Layout size={14} />
+          Design
+        </div>
+      </div>
+      
+      {/* Mini-map */}
+      <div className="p-4 border-b border-[#1E1E1E]">
+        <div className="flex items-center justify-between mb-3 text-xs font-semibold text-gray-400">
+          <span>MINI MAP</span>
+          <Maximize size={12} />
+        </div>
+        <div className="bg-[#1A1A1A] rounded aspect-video relative overflow-hidden border border-[#333]">
+          {/* A tiny representation of the canvas */}
+          {FRAMES_CONFIG.map(f => (
+            <div 
+              key={f.id}
+              className={`absolute rounded-sm transition-colors ${activeFrame === f.id ? 'bg-blue-500' : 'bg-gray-700'}`}
+              style={{
+                left: `${(f.x / 3000) * 100}%`,
+                top: `${(f.y / 2500) * 100}%`,
+                width: `${(f.w / 3000) * 100}%`,
+                height: `${(f.h / 2500) * 100}%`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {activeFrameData && (
+        <div className="p-4 border-b border-[#1E1E1E]">
+          <div className="text-xs font-semibold text-gray-400 mb-3">FRAME</div>
+          
+          <div className="grid grid-cols-2 gap-2 mb-4 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">X</span>
+              <input type="text" readOnly value={activeFrameData.x} className="w-full bg-[#1A1A1A] border border-[#333] rounded px-2 py-1 text-gray-300 focus:outline-none" />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">Y</span>
+              <input type="text" readOnly value={activeFrameData.y} className="w-full bg-[#1A1A1A] border border-[#333] rounded px-2 py-1 text-gray-300 focus:outline-none" />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">W</span>
+              <input type="text" readOnly value={activeFrameData.w} className="w-full bg-[#1A1A1A] border border-[#333] rounded px-2 py-1 text-gray-300 focus:outline-none" />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">H</span>
+              <input type="text" readOnly value={activeFrameData.h} className="w-full bg-[#1A1A1A] border border-[#333] rounded px-2 py-1 text-gray-300 focus:outline-none" />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="p-4 border-b border-[#1E1E1E]">
+        <div className="text-xs font-semibold text-gray-400 mb-3">ALIGNMENT</div>
+        <div className="flex items-center gap-1">
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <AlignLeft size={16} />
+          </button>
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <AlignCenter size={16} />
+          </button>
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <AlignRight size={16} />
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4 border-b border-[#1E1E1E]">
+        <div className="text-xs font-semibold text-gray-400 mb-3">FILL</div>
+        <div className="flex items-center gap-3">
+          <div className="w-6 h-6 rounded border border-gray-600 bg-[#1A1A1A]"></div>
+          <span className="text-sm text-gray-300">#1A1A1A</span>
+          <span className="text-sm text-gray-500 ml-auto">100%</span>
+        </div>
+      </div>
+      
+      <div className="p-4 border-b border-[#1E1E1E]">
+        <div className="text-xs font-semibold text-gray-400 mb-3">STROKE</div>
+        <div className="flex items-center gap-3">
+          <div className="w-6 h-6 rounded border border-gray-600 bg-[#333333]"></div>
+          <span className="text-sm text-gray-300">#333333</span>
+          <span className="text-sm text-gray-500 ml-auto">100%</span>
+        </div>
+      </div>
+      
+      <div className="flex-1 p-4">
+        <div className="text-xs font-semibold text-gray-400 mb-3">EXPORT</div>
+        <button className="w-full py-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded text-sm text-gray-300 font-medium transition-colors">
+          Export Frame
+        </button>
+      </div>
+
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/Toolbar.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/Toolbar.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { 
+  Menu, 
+  MousePointer2, 
+  Frame, 
+  Square, 
+  PenTool, 
+  Type, 
+  MessageSquare,
+  Share2,
+  Play
+} from 'lucide-react';
+
+export default function Toolbar({ userName }) {
+  return (
+    <div className="h-12 bg-[#2C2C2C] border-b border-[#1E1E1E] flex items-center justify-between px-4 z-50 relative shrink-0">
+      <div className="flex items-center gap-4 h-full">
+        <button className="text-gray-300 hover:text-white transition-colors">
+          <Menu size={20} />
+        </button>
+        
+        <div className="w-px h-6 bg-[#444] mx-2"></div>
+        
+        <div className="flex items-center gap-1 h-full">
+          <button className="p-2 text-blue-400 bg-blue-500/10 rounded">
+            <MousePointer2 size={18} />
+          </button>
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <Frame size={18} />
+          </button>
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <Square size={18} />
+          </button>
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <PenTool size={18} />
+          </button>
+          <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+            <Type size={18} />
+          </button>
+        </div>
+      </div>
+      
+      <div className="flex-1 flex justify-center h-full items-center">
+        <div className="px-3 py-1 rounded bg-[#1E1E1E] border border-[#333] text-sm text-gray-300 cursor-pointer hover:border-gray-500 transition-colors">
+          {userName}'s Portfolio.fig
+        </div>
+      </div>
+      
+      <div className="flex items-center gap-3 h-full">
+        <button className="p-2 text-gray-400 hover:text-white rounded hover:bg-white/5 transition-colors">
+          <MessageSquare size={18} />
+        </button>
+        <button className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm font-medium flex items-center gap-2 transition-colors">
+          <Share2 size={16} />
+          <span className="hidden sm:inline">Share</span>
+        </button>
+        <button className="p-2 text-gray-300 hover:text-white rounded hover:bg-white/5 transition-colors">
+          <Play size={18} fill="currentColor" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/config.js
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/config.js
@@ -1,0 +1,9 @@
+export const FRAMES_CONFIG = [
+  { id: "hero", title: "Hero", x: 100, y: 100, w: 800, h: 600 },
+  { id: "about", title: "About", x: 1000, y: 100, w: 600, h: 600 },
+  { id: "skills", title: "Skills", x: 1000, y: 800, w: 600, h: 500 },
+  { id: "projects", title: "Projects", x: 100, y: 800, w: 800, h: 1000 },
+  { id: "experience", title: "Experience", x: 1700, y: 100, w: 600, h: 800 },
+  { id: "testimonials", title: "Testimonials", x: 1700, y: 1000, w: 600, h: 600 },
+  { id: "contact", title: "Contact", x: 1000, y: 1400, w: 600, h: 400 },
+];

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/AboutFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/AboutFrame.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { MapPin, Briefcase } from 'lucide-react';
+
+export default function AboutFrame({ data }) {
+  const { personal, stats } = data;
+  return (
+    <div className="h-full p-10 bg-[#1A1A1A] flex flex-col justify-between">
+      <div>
+        <h2 className="text-3xl font-bold mb-6 text-white border-b border-gray-800 pb-4">About Me</h2>
+        <p className="text-gray-300 leading-relaxed text-lg mb-8">
+          {personal.bio}
+        </p>
+        <div className="flex items-center gap-2 text-gray-400 mb-3">
+          <MapPin size={18} className="text-blue-500" />
+          <span>{personal.location}</span>
+        </div>
+        <div className="flex items-center gap-2 text-gray-400 mb-8">
+          <Briefcase size={18} className="text-blue-500" />
+          <span>{personal.availability}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-[#252525] p-4 rounded-lg border border-[#333]">
+          <div className="text-3xl font-bold text-white mb-1">{stats.yearsExperience}+</div>
+          <div className="text-sm text-gray-400 uppercase tracking-wider">Years Exp</div>
+        </div>
+        <div className="bg-[#252525] p-4 rounded-lg border border-[#333]">
+          <div className="text-3xl font-bold text-white mb-1">{stats.projectsCompleted}+</div>
+          <div className="text-sm text-gray-400 uppercase tracking-wider">Projects</div>
+        </div>
+        <div className="bg-[#252525] p-4 rounded-lg border border-[#333]">
+          <div className="text-3xl font-bold text-white mb-1">{stats.happyClients}</div>
+          <div className="text-sm text-gray-400 uppercase tracking-wider">Clients</div>
+        </div>
+        <div className="bg-[#252525] p-4 rounded-lg border border-[#333]">
+          <div className="text-3xl font-bold text-white mb-1">{stats.coffeeConsumed}</div>
+          <div className="text-sm text-gray-400 uppercase tracking-wider">Coffees</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ContactFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ContactFrame.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Mail, Github, Linkedin, Twitter, Globe, Dribbble } from 'lucide-react';
+
+export default function ContactFrame({ data }) {
+  const { socials } = data;
+  
+  return (
+    <div className="h-full p-10 bg-[#1A1A1A] flex flex-col justify-between">
+      <div>
+        <h2 className="text-3xl font-bold mb-4 text-white">Let's Connect</h2>
+        <p className="text-gray-400 mb-8">
+          I'm always open to discussing product design work or partnership opportunities. 
+          Feel free to reach out through any of these platforms.
+        </p>
+        
+        <a href={`mailto:${socials.email}`} className="flex items-center gap-4 p-4 rounded-lg bg-blue-600 hover:bg-blue-700 transition-colors text-white mb-8 group">
+          <Mail size={24} />
+          <div className="flex-1">
+            <div className="text-sm text-blue-200">Email Me</div>
+            <div className="font-medium">{socials.email}</div>
+          </div>
+          <span className="opacity-0 group-hover:opacity-100 transition-opacity">→</span>
+        </a>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        {socials.github && (
+          <a href={socials.github} target="_blank" rel="noreferrer" className="flex items-center justify-center gap-2 p-3 rounded-lg border border-[#333] hover:border-gray-400 hover:bg-[#252525] text-gray-400 hover:text-white transition-all">
+            <Github size={20} />
+            <span className="font-medium">GitHub</span>
+          </a>
+        )}
+        {socials.linkedin && (
+          <a href={socials.linkedin} target="_blank" rel="noreferrer" className="flex items-center justify-center gap-2 p-3 rounded-lg border border-[#333] hover:border-blue-500 hover:bg-[#252525] text-gray-400 hover:text-blue-500 transition-all">
+            <Linkedin size={20} />
+            <span className="font-medium">LinkedIn</span>
+          </a>
+        )}
+        {socials.twitter && (
+          <a href={socials.twitter} target="_blank" rel="noreferrer" className="flex items-center justify-center gap-2 p-3 rounded-lg border border-[#333] hover:border-sky-500 hover:bg-[#252525] text-gray-400 hover:text-sky-500 transition-all">
+            <Twitter size={20} />
+            <span className="font-medium">Twitter</span>
+          </a>
+        )}
+        {socials.dribbble && (
+          <a href={socials.dribbble} target="_blank" rel="noreferrer" className="flex items-center justify-center gap-2 p-3 rounded-lg border border-[#333] hover:border-pink-500 hover:bg-[#252525] text-gray-400 hover:text-pink-500 transition-all">
+            <Dribbble size={20} />
+            <span className="font-medium">Dribbble</span>
+          </a>
+        )}
+        {socials.website && (
+          <a href={socials.website} target="_blank" rel="noreferrer" className="flex items-center justify-center gap-2 p-3 rounded-lg border border-[#333] hover:border-emerald-500 hover:bg-[#252525] text-gray-400 hover:text-emerald-500 transition-all col-span-2">
+            <Globe size={20} />
+            <span className="font-medium">Personal Website</span>
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ExperienceFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ExperienceFrame.jsx
@@ -8,8 +8,8 @@ export default function ExperienceFrame({ data }) {
       <div className="mb-12">
         <h2 className="text-3xl font-bold mb-8 text-white">Work Experience</h2>
         <div className="space-y-8 relative before:absolute before:inset-0 before:ml-2 before:-translate-x-px md:before:mx-auto md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-[#333] before:to-transparent">
-          {experience.map((exp, i) => (
-            <div key={exp.id} className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active">
+          {experience && experience.map((exp, i) => (
+            <div key={exp.id || i} className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active">
               <div className="flex items-center justify-center w-5 h-5 rounded-full border-2 border-blue-500 bg-[#1A1A1A] text-slate-500 group-[.is-active]:text-emerald-50 shadow shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 z-10"></div>
               
               <div className="w-[calc(100%-2rem)] md:w-[calc(50%-1.5rem)] p-5 rounded-lg border border-[#333] bg-[#252525]">
@@ -19,32 +19,36 @@ export default function ExperienceFrame({ data }) {
                 </div>
                 <h4 className="text-gray-300 font-medium mb-4">{exp.company}</h4>
                 <p className="text-sm text-gray-400 mb-4">{exp.description}</p>
-                <div className="flex flex-wrap gap-2">
-                  {exp.techStack.map(tech => (
-                    <span key={tech} className="text-xs text-gray-500 bg-[#1A1A1A] px-2 py-1 rounded">{tech}</span>
-                  ))}
-                </div>
+                {exp.techStack && exp.techStack.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {exp.techStack.map(tech => (
+                      <span key={tech} className="text-xs text-gray-500 bg-[#1A1A1A] px-2 py-1 rounded">{tech}</span>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           ))}
         </div>
       </div>
 
-      <div>
-        <h2 className="text-3xl font-bold mb-8 text-white">Education</h2>
-        <div className="space-y-6">
-          {education.map((edu) => (
-            <div key={edu.id} className="p-6 rounded-lg border border-[#333] bg-[#252525]">
-              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-2">
-                <h3 className="font-bold text-lg text-white">{edu.degree}</h3>
-                <span className="text-xs font-mono text-gray-400">{edu.period}</span>
+      {education && education.length > 0 && (
+        <div>
+          <h2 className="text-3xl font-bold mb-8 text-white">Education</h2>
+          <div className="space-y-6">
+            {education.map((edu, i) => (
+              <div key={edu.id || i} className="p-6 rounded-lg border border-[#333] bg-[#252525]">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-2">
+                  <h3 className="font-bold text-lg text-white">{edu.degree}</h3>
+                  <span className="text-xs font-mono text-gray-400">{edu.period}</span>
+                </div>
+                <h4 className="text-blue-400 font-medium mb-3">{edu.school}</h4>
+                <p className="text-sm text-gray-400">{edu.description}</p>
               </div>
-              <h4 className="text-blue-400 font-medium mb-3">{edu.school}</h4>
-              <p className="text-sm text-gray-400">{edu.description}</p>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ExperienceFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ExperienceFrame.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export default function ExperienceFrame({ data }) {
+  const { experience, education } = data;
+  
+  return (
+    <div className="h-full p-10 bg-[#1A1A1A] overflow-y-auto custom-scrollbar">
+      <div className="mb-12">
+        <h2 className="text-3xl font-bold mb-8 text-white">Work Experience</h2>
+        <div className="space-y-8 relative before:absolute before:inset-0 before:ml-2 before:-translate-x-px md:before:mx-auto md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-[#333] before:to-transparent">
+          {experience.map((exp, i) => (
+            <div key={exp.id} className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active">
+              <div className="flex items-center justify-center w-5 h-5 rounded-full border-2 border-blue-500 bg-[#1A1A1A] text-slate-500 group-[.is-active]:text-emerald-50 shadow shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 z-10"></div>
+              
+              <div className="w-[calc(100%-2rem)] md:w-[calc(50%-1.5rem)] p-5 rounded-lg border border-[#333] bg-[#252525]">
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-2">
+                  <h3 className="font-bold text-lg text-white">{exp.role}</h3>
+                  <span className="text-xs font-mono text-blue-400 bg-blue-500/10 px-2 py-1 rounded">{exp.period}</span>
+                </div>
+                <h4 className="text-gray-300 font-medium mb-4">{exp.company}</h4>
+                <p className="text-sm text-gray-400 mb-4">{exp.description}</p>
+                <div className="flex flex-wrap gap-2">
+                  {exp.techStack.map(tech => (
+                    <span key={tech} className="text-xs text-gray-500 bg-[#1A1A1A] px-2 py-1 rounded">{tech}</span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-3xl font-bold mb-8 text-white">Education</h2>
+        <div className="space-y-6">
+          {education.map((edu) => (
+            <div key={edu.id} className="p-6 rounded-lg border border-[#333] bg-[#252525]">
+              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-2">
+                <h3 className="font-bold text-lg text-white">{edu.degree}</h3>
+                <span className="text-xs font-mono text-gray-400">{edu.period}</span>
+              </div>
+              <h4 className="text-blue-400 font-medium mb-3">{edu.school}</h4>
+              <p className="text-sm text-gray-400">{edu.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/HeroFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/HeroFrame.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function HeroFrame({ data }) {
+  const { personal } = data;
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-12 bg-gradient-to-br from-gray-900 to-black text-center relative overflow-hidden">
+      <div className="absolute inset-0 opacity-20 pointer-events-none" style={{ backgroundImage: 'radial-gradient(circle at center, #3b82f6 0%, transparent 70%)' }}></div>
+      <img src={personal.avatar} alt={personal.name} className="w-32 h-32 rounded-full mb-6 border-4 border-gray-800 shadow-2xl z-10 object-cover" />
+      <h1 className="text-5xl font-bold mb-4 z-10 text-white">{personal.name}</h1>
+      <h2 className="text-2xl text-blue-400 font-medium mb-6 z-10">{personal.title}</h2>
+      <p className="text-gray-400 max-w-lg z-10 leading-relaxed">
+        {personal.shortBio}
+      </p>
+      <div className="mt-8 flex gap-4 z-10">
+        <button className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors">
+          View Work
+        </button>
+        <button className="px-6 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded-md font-medium transition-colors">
+          Contact Me
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ProjectsFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ProjectsFrame.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ExternalLink, Github } from 'lucide-react';
+
+export default function ProjectsFrame({ data }) {
+  const { projects } = data;
+  
+  return (
+    <div className="h-full p-10 bg-[#1A1A1A] overflow-y-auto custom-scrollbar">
+      <h2 className="text-3xl font-bold mb-8 text-white">Selected Works</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {projects.map(project => (
+          <div key={project.id} className="bg-[#252525] rounded-xl overflow-hidden border border-[#333] hover:border-blue-500/50 transition-all duration-300 group">
+            <div className="h-48 overflow-hidden relative">
+              <div className="absolute inset-0 bg-blue-500/20 opacity-0 group-hover:opacity-100 transition-opacity z-10 mix-blend-overlay"></div>
+              <img src={project.image} alt={project.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+            </div>
+            <div className="p-6">
+              <div className="flex justify-between items-start mb-2">
+                <h3 className="text-xl font-bold text-white group-hover:text-blue-400 transition-colors">{project.title}</h3>
+                <div className="flex gap-2">
+                  {project.githubUrl && (
+                    <a href={project.githubUrl} target="_blank" rel="noreferrer" className="text-gray-400 hover:text-white transition-colors">
+                      <Github size={18} />
+                    </a>
+                  )}
+                  {project.liveUrl && (
+                    <a href={project.liveUrl} target="_blank" rel="noreferrer" className="text-gray-400 hover:text-white transition-colors">
+                      <ExternalLink size={18} />
+                    </a>
+                  )}
+                </div>
+              </div>
+              <p className="text-sm text-blue-500 mb-4 font-mono">{project.category}</p>
+              <p className="text-gray-400 text-sm mb-6 line-clamp-3">{project.description}</p>
+              <div className="flex flex-wrap gap-2">
+                {project.techStack.map(tech => (
+                  <span key={tech} className="text-xs px-2 py-1 bg-[#1A1A1A] text-gray-300 rounded border border-[#333]">
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ProjectsFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/ProjectsFrame.jsx
@@ -8,8 +8,8 @@ export default function ProjectsFrame({ data }) {
     <div className="h-full p-10 bg-[#1A1A1A] overflow-y-auto custom-scrollbar">
       <h2 className="text-3xl font-bold mb-8 text-white">Selected Works</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {projects.map(project => (
-          <div key={project.id} className="bg-[#252525] rounded-xl overflow-hidden border border-[#333] hover:border-blue-500/50 transition-all duration-300 group">
+        {projects && projects.map((project, i) => (
+          <div key={project.id || i} className="bg-[#252525] rounded-xl overflow-hidden border border-[#333] hover:border-blue-500/50 transition-all duration-300 group">
             <div className="h-48 overflow-hidden relative">
               <div className="absolute inset-0 bg-blue-500/20 opacity-0 group-hover:opacity-100 transition-opacity z-10 mix-blend-overlay"></div>
               <img src={project.image} alt={project.title} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/SkillsFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/SkillsFrame.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function SkillsFrame({ data }) {
+  const { skills } = data;
+  
+  // Group skills by category
+  const groupedSkills = skills.reduce((acc, skill) => {
+    if (!acc[skill.category]) acc[skill.category] = [];
+    acc[skill.category].push(skill);
+    return acc;
+  }, {});
+
+  return (
+    <div className="h-full p-10 bg-[#1A1A1A] overflow-y-auto custom-scrollbar">
+      <h2 className="text-3xl font-bold mb-8 text-white">Skills & Expertise</h2>
+      <div className="space-y-8">
+        {Object.entries(groupedSkills).map(([category, items]) => (
+          <div key={category}>
+            <h3 className="text-lg font-semibold text-gray-400 mb-4 tracking-wider uppercase">{category}</h3>
+            <div className="flex flex-wrap gap-3">
+              {items.map(skill => (
+                <div key={skill.name} className="px-4 py-2 bg-[#252525] border border-[#333] rounded-md flex items-center gap-3 hover:border-blue-500/50 transition-colors">
+                  <span className="text-white font-medium">{skill.name}</span>
+                  <span className="text-xs text-blue-400 font-mono">{skill.level}%</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/TestimonialsFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/TestimonialsFrame.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Quote } from 'lucide-react';
+
+export default function TestimonialsFrame({ data }) {
+  const { testimonials } = data;
+  
+  return (
+    <div className="h-full p-10 bg-[#1A1A1A] overflow-y-auto custom-scrollbar">
+      <h2 className="text-3xl font-bold mb-8 text-white">What People Say</h2>
+      <div className="space-y-6">
+        {testimonials.map((test) => (
+          <div key={test.id} className="p-6 rounded-xl border border-[#333] bg-[#252525] relative">
+            <Quote className="absolute top-6 right-6 text-[#333] opacity-50" size={40} />
+            <p className="text-gray-300 italic mb-6 relative z-10 text-lg leading-relaxed">
+              "{test.text}"
+            </p>
+            <div className="flex items-center gap-4">
+              <img src={test.avatar} alt={test.name} className="w-12 h-12 rounded-full object-cover border border-[#444]" />
+              <div>
+                <h4 className="font-bold text-white">{test.name}</h4>
+                <p className="text-xs text-blue-400">{test.role}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/frames/TestimonialsFrame.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/frames/TestimonialsFrame.jsx
@@ -8,9 +8,9 @@ export default function TestimonialsFrame({ data }) {
     <div className="h-full p-10 bg-[#1A1A1A] overflow-y-auto custom-scrollbar">
       <h2 className="text-3xl font-bold mb-8 text-white">What People Say</h2>
       <div className="space-y-6">
-        {testimonials.map((test) => (
-          <div key={test.id} className="p-6 rounded-xl border border-[#333] bg-[#252525] relative">
-            <Quote className="absolute top-6 right-6 text-[#333] opacity-50" size={40} />
+        {testimonials && testimonials.map((test, i) => (
+          <div key={test.id || i} className="p-6 rounded-xl border border-[#333] bg-[#252525] relative">
+            <Quote className="absolute top-6 right-6 text-[#333] opacity-50" size={48} />
             <p className="text-gray-300 italic mb-6 relative z-10 text-lg leading-relaxed">
               "{test.text}"
             </p>

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/index.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/index.jsx
@@ -1,29 +1,47 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import data from '../../../../data/dummy_data.json';
+import Toolbar from './Toolbar';
+import LeftSidebar from './LeftSidebar';
+import RightSidebar from './RightSidebar';
+import Canvas from './Canvas';
 
 /**
  * Figma Canvas Portfolio Template
  * Category: Famous UI Inspired
- * Description: Figma-like infinite canvas with draggable project frames. Toolbar at top, layers panel on left. Projects are design frames scattered on the canvas.
  */
 export default function FigmaCanvas() {
+  const [activeFrame, setActiveFrame] = useState('hero');
+  const canvasRef = useRef(null);
+
+  const handleFrameClick = (frameId) => {
+    setActiveFrame(frameId);
+    if (canvasRef.current) {
+      canvasRef.current.panToFrame(frameId);
+    }
+  };
+
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-8 font-sans">
-      <div className="max-w-3xl w-full text-center">
-        <h1 className="text-5xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
-          {data.personal.name}
-        </h1>
-        <p className="text-xl md:text-2xl text-gray-400 mb-8">{data.personal.title}</p>
-        <div className="p-8 border-2 border-dashed border-cyan-500/40 rounded-2xl bg-gray-900/50 backdrop-blur-sm">
-          <span className="inline-block px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-400 text-xs font-bold uppercase tracking-widest mb-4">
-            Famous UI Inspired
-          </span>
-          <h2 className="text-2xl font-bold text-gray-200 mb-3">Figma Canvas Template</h2>
-          <p className="text-gray-400 mb-6 leading-relaxed">
-            Figma-like infinite canvas with draggable project frames. Toolbar at top, layers panel on left. Projects are design frames scattered on the canvas.
-          </p>
-          <p className="text-cyan-400 font-semibold">Open an issue to contribute and build this template!</p>
-        </div>
+    <div className="h-full w-full flex flex-col bg-[#1E1E1E] text-white font-sans overflow-hidden">
+      <Toolbar userName={data.personal.name} />
+      
+      <div className="flex flex-1 overflow-hidden relative">
+        {/* Drawers for mobile could be added here later. Currently hidden on small screens */}
+        <LeftSidebar 
+          activeFrame={activeFrame} 
+          onFrameClick={handleFrameClick} 
+        />
+        
+        <Canvas 
+          ref={canvasRef}
+          data={data} 
+          activeFrame={activeFrame} 
+          onFrameClick={handleFrameClick}
+        />
+        
+        <RightSidebar 
+          activeFrame={activeFrame} 
+          data={data} 
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -9,6 +9,7 @@ import CulinaryAbout from "../components/portfolio/templates/Culinary_Restaurant
 import TechStartupHero from "../components/portfolio/templates/Tech_Startup/Hero";
 import GeometricShapesAbout from "../components/portfolio/templates/Geometric_Shapes/About";
 import Navbar from '../components/Navbar'
+import FigmaCanvas from "../components/portfolio/templates/Figma_Canvas";
 
 /* ─────────────────────────────────────────────────────────
    Custom FilterSelect
@@ -241,6 +242,18 @@ export default function TemplateGallery() {
       image: "/template-previews/Creative-Dashboard.png",
       createdAt: "2026-05-15",
     },
+    {
+      id: 4,
+      title: "Figma Canvas",
+      category: "Portfolio",
+      colorScheme: "Dark",
+      layout: "Grid",
+      author: "Jordan Mitchell",
+      views: 5400,
+      rating: 5.0,
+      image: "https://images.unsplash.com/photo-1611162617474-5b21e879e113?auto=format&fit=crop&q=80&w=600&h=400",
+      createdAt: "2026-05-26",
+    },
   ];
 
   const [category, setCategory] = useState("All");
@@ -412,6 +425,18 @@ export default function TemplateGallery() {
         </div>
         <div className="overflow-hidden rounded-2xl border border-cyan-500/20">
           <TechStartupHero />
+        </div>
+      </div>
+
+      <div className="mt-12">
+        <div className="mb-4 flex items-center gap-3 px-1">
+          <span className="rounded-full bg-blue-500/20 px-3 py-1 text-xs font-bold uppercase tracking-widest text-blue-400 border border-blue-500/30">
+            Preview
+          </span>
+          <h2 className="text-lg font-semibold text-foreground/70">Figma Canvas Theme — Complete Template</h2>
+        </div>
+        <div className="overflow-hidden rounded-2xl border border-border h-[800px] relative">
+          <FigmaCanvas />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## **User description**
## Description

This PR introduces the new **"Figma Canvas"** portfolio template as requested, inspired by the famous design tool interface. It also includes a critical layout fix for the DeployModal component.

### Changes Made

#### 🎨 New Template (Figma_Canvas)

- Created a modular architecture with `Toolbar`, `LeftSidebar` (Layers), `RightSidebar` (Properties Map), and a central `Canvas`.
- Implemented an infinite, draggable dotted canvas using **framer-motion** to scatter the various portfolio sections as fixed "Frames" across the screen.
- Implemented auto-panning when clicking on a layer in the Left Sidebar to jump directly to that section.
- Built individual stylized frames (**Hero, About, Skills, Projects, Experience, Testimonials, Contact**) that dynamically pull data from the global dummy data configuration.

#### 🖼️ Gallery Integration

- Registered the new **Figma Canvas** theme in `TemplateGallery.jsx` as a selectable template card.
- Embedded a live, fully interactive preview of the canvas at the bottom of the Template Gallery page.

#### 🛠️ Deploy Modal Fix

- Fixed a flexbox rendering bug in `DeployModal.jsx` where the header would be cut off on smaller screens.
- Added `max-h-[90vh]` with an internally scrollable body to ensure proper responsiveness.
- Removed the redundant **"Check connection"** button from the Cloudflare Pages card, improving layout and user experience.

### Testing Instructions

1. Navigate to `/templates` to view the Template Gallery.
2. Verify that the new **Figma Canvas** card is visible.
3. Scroll to the bottom of the page and interact with the embedded preview:
   - Drag to pan around the canvas.
   - Click layers in the sidebar to jump between sections.
4. Click **"Use This Theme"** on any template card.
5. Verify that the Deploy Modal header is fully visible and no longer clipped at the top of the viewport.

### Screenshot
<img width="1919" height="797" alt="image" src="https://github.com/user-attachments/assets/53ff6c04-d1fc-4e61-9e54-ae652e94fa43" />

<img width="1914" height="857" alt="image" src="https://github.com/user-attachments/assets/0362d5f7-f5fb-45cb-8386-49d266102dba" />

### Closes

Closes #2004


___

## **CodeAnt-AI Description**
**Add a new Figma Canvas portfolio template and fix the deploy modal on small screens**

### What Changed
- Added a new Figma-style portfolio template with a top toolbar, a layer list, a design panel, and a large draggable canvas
- Users can click a section in the layer list to jump to that part of the portfolio, and the active section is highlighted
- The template now shows distinct portfolio sections for the hero, about, skills, projects, experience, testimonials, and contact content
- The deploy modal now stays within the viewport on shorter screens and scrolls its content instead of clipping the header
- Removed the extra Cloudflare “Check connection” button from the deploy modal to simplify the layout

### Impact
`✅ Easier navigation through portfolio sections`
`✅ More polished portfolio preview experience`
`✅ Fewer clipped deploy dialogs on small screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Figma Canvas" interactive portfolio template with draggable frames, left navigation, right properties panel, toolbar, and built-in sections (Hero, About, Skills, Projects, Experience, Testimonials, Contact).
  * Template gallery now previews the Figma Canvas theme.

* **Bug Fixes**
  * Improved deploy modal layout to support in-dialog scrolling.
  * Removed the manual "Check connection" button for providers that don't require a token.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->