### PR TITLE
fix: export favicon generator as ES module

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "lint": "eslint src/",
-    "test": "node --test src/schemas/__tests__/schemas.test.js"
+    "test": "node --test src/schemas/__tests__/schemas.test.js src/utils/__tests__/faviconGenerator.test.js"
   },
   "dependencies": {
     "@google/generative-ai": "^0.21.0",

--- a/backend/src/utils/__tests__/faviconGenerator.test.js
+++ b/backend/src/utils/__tests__/faviconGenerator.test.js
@@ -1,0 +1,43 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { generateFavicon } from "../faviconGenerator.js";
+
+describe("faviconGenerator", () => {
+  test("exports generateFavicon as an ES module utility", () => {
+    assert.equal(typeof generateFavicon, "function");
+  });
+
+  test("generates an SVG favicon data URI from a name", () => {
+    const favicon = generateFavicon("John Doe");
+
+    assert.match(favicon.svg, /<svg[^>]+width="32"[^>]+height="32"/);
+    assert.match(favicon.svg, />JD<\/text>/);
+    assert.ok(favicon.dataUri.startsWith("data:image/svg+xml;base64,"));
+  });
+
+  test("uses U as a fallback initial for empty or whitespace-only names", () => {
+    assert.match(generateFavicon().svg, />U<\/text>/);
+    assert.match(generateFavicon("").svg, />U<\/text>/);
+    assert.match(generateFavicon("   ").svg, />U<\/text>/);
+  });
+
+  test("uses the first initial for a single-word name", () => {
+    assert.match(generateFavicon("Alice").svg, />A<\/text>/);
+  });
+
+  test("uses first and last initials for names with extra spacing", () => {
+    assert.match(generateFavicon("  Ada   Lovelace  Byron  ").svg, />AB<\/text>/);
+  });
+
+  test("escapes SVG-special characters in initials", () => {
+    const favicon = generateFavicon("<script Doe");
+
+    assert.match(favicon.svg, /&lt;D<\/text>/);
+    assert.doesNotMatch(favicon.svg, /><D<\/text>/);
+  });
+
+  test("generates deterministic output for the same name", () => {
+    assert.deepEqual(generateFavicon("Grace Hopper"), generateFavicon("Grace Hopper"));
+  });
+});

--- a/backend/src/utils/faviconGenerator.js
+++ b/backend/src/utils/faviconGenerator.js
@@ -26,8 +26,18 @@ function generateColor(name = "") {
   return `hsl(${hue}, 65%, 50%)`;
 }
 
+function escapeSvgText(value = "") {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
 function generateFavicon(name = "") {
   const initials = getInitials(name);
+  const escapedInitials = escapeSvgText(initials);
   const backgroundColor = generateColor(name);
 
   const svg = `
@@ -41,7 +51,7 @@ function generateFavicon(name = "") {
         font-family="Arial, sans-serif"
         font-size="${initials.length === 1 ? 14 : 12}"
         font-weight="bold"
-      >${initials}</text>
+      >${escapedInitials}</text>
     </svg>
   `.trim();
 
@@ -53,13 +63,4 @@ function generateFavicon(name = "") {
   };
 }
 
-/*
- Small verification test:
-
- console.log(generateFavicon("John Doe"))
- console.log(generateFavicon("Alice"))
-*/
-
-module.exports = {
-  generateFavicon,
-};
+export { generateFavicon };


### PR DESCRIPTION
## **User description**
## Description
Fixed `backend/src/utils/faviconGenerator.js` to use ES module export syntax instead of CommonJS `module.exports`. Added focused tests to verify `generateFavicon` can be imported successfully and handles edge cases.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #1726

## Testing
- [x] Unit tests pass
- [x] Tested Locally
- [x] New tests added

Tested with:
- `node --test src\utils\__tests__\faviconGenerator.test.js`
- `node --check src\utils\faviconGenerator.js`
- `node --check src\utils\__tests__\faviconGenerator.test.js`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Export the favicon generator as an ES module and keep generated icons safe**

### What Changed
- The favicon generator is now imported and exported in the same module style used by the rest of the backend, so it can be loaded without errors.
- Generated initials are now escaped before being placed into the SVG, preventing broken icons when names contain special characters.
- The test suite now covers import success, initials handling, empty-name fallback, spacing, escaping, and consistent output.

### Impact
`✅ Fewer favicon import failures`
`✅ Safer avatar icon rendering`
`✅ More reliable backend test coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed favicon generation to properly escape special characters that could interfere with SVG rendering.

* **Tests**
  * Added comprehensive test coverage for favicon generation, including edge cases and special character handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->