### PR TITLE
feat: Implement GitHub Profile portfolio template (#2001)

### DIFF
--- a/frontend/src/components/portfolio/templates/GitHub_Profile/index.jsx
+++ b/frontend/src/components/portfolio/templates/GitHub_Profile/index.jsx
@@ -1,30 +1,338 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { 
+  Users, MapPin, Link as LinkIcon, Mail, Star, 
+  Book, GitFork, Circle, Twitter, Linkedin, Github, 
+  Briefcase, MessageSquare, Smile, Code, BookOpen
+} from 'lucide-react';
 import data from '../../../../data/dummy_data.json';
 
-/**
- * GitHub Profile Portfolio Template
- * Category: Famous UI Inspired
- * Description: GitHub profile page clone with contribution graph heatmap, pinned repo cards, profile sidebar with stats. Dark/light mode toggle.
- */
 export default function GitHubProfile() {
+  const [activeTab, setActiveTab] = useState('overview');
+  
+  // Helper to get random language colors
+  const getLangColor = (lang) => {
+    const colors = {
+      'JavaScript': '#f1e05a',
+      'TypeScript': '#3178c6',
+      'React': '#61dafb',
+      'Node.js': '#339933',
+      'Python': '#3572A5',
+      'HTML': '#e34c26',
+      'CSS': '#563d7c',
+    };
+    return colors[lang] || '#8b949e';
+  };
+
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-8 font-sans">
-      <div className="max-w-3xl w-full text-center">
-        <h1 className="text-5xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
-          {data.personal.name}
-        </h1>
-        <p className="text-xl md:text-2xl text-gray-400 mb-8">{data.personal.title}</p>
-        <div className="p-8 border-2 border-dashed border-cyan-500/40 rounded-2xl bg-gray-900/50 backdrop-blur-sm">
-          <span className="inline-block px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-400 text-xs font-bold uppercase tracking-widest mb-4">
-            Famous UI Inspired
-          </span>
-          <h2 className="text-2xl font-bold text-gray-200 mb-3">GitHub Profile Template</h2>
-          <p className="text-gray-400 mb-6 leading-relaxed">
-            GitHub profile page clone with contribution graph heatmap, pinned repo cards, profile sidebar with stats. Dark/light mode toggle.
-          </p>
-          <p className="text-cyan-400 font-semibold">Open an issue to contribute and build this template!</p>
+    <div className="min-h-screen bg-[#0d1117] text-[#c9d1d9] font-sans selection:bg-[#58a6ff]/30 pb-12">
+      {/* Top Navbar (GitHub style) */}
+      <nav className="bg-[#161b22] px-4 py-3 flex items-center justify-between border-b border-[#30363d]">
+        <div className="flex items-center gap-4">
+          <Github className="w-8 h-8 text-white" />
+          <div className="hidden md:flex items-center rounded-md border border-[#30363d] bg-[#0d1117] px-3 py-1 w-64">
+            <span className="text-sm text-[#8b949e]">Search or jump to...</span>
+          </div>
+          <div className="hidden md:flex gap-4 text-sm font-semibold text-white ml-2">
+            <span className="cursor-pointer hover:text-gray-300">Pull requests</span>
+            <span className="cursor-pointer hover:text-gray-300">Issues</span>
+            <span className="cursor-pointer hover:text-gray-300">Codespaces</span>
+            <span className="cursor-pointer hover:text-gray-300">Marketplace</span>
+            <span className="cursor-pointer hover:text-gray-300">Explore</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <img src={data.personal.avatar} alt="Avatar" className="w-8 h-8 rounded-full border border-[#30363d]" />
+        </div>
+      </nav>
+
+      {/* Main Layout */}
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-8">
+        <div className="flex flex-col md:flex-row gap-8">
+          
+          {/* Left Sidebar - Profile */}
+          <motion.div 
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.5 }}
+            className="w-full md:w-1/4 flex flex-col"
+          >
+            <div className="relative">
+              <img 
+                src={data.personal.avatar} 
+                alt={data.personal.name} 
+                className="w-64 h-64 md:w-full md:h-auto rounded-full border border-[#30363d] mb-4 shadow-xl z-10 relative"
+              />
+              <div className="absolute bottom-12 right-12 md:bottom-8 md:right-8 bg-[#161b22] rounded-full p-2 border border-[#30363d] z-20 cursor-pointer hover:bg-[#30363d] transition-colors">
+                <Smile className="w-5 h-5 text-[#8b949e]" />
+              </div>
+            </div>
+            
+            <h1 className="text-2xl font-bold text-[#c9d1d9] leading-tight mt-2">{data.personal.name}</h1>
+            <h2 className="text-xl text-[#8b949e] font-light mb-4">{data.personal.title}</h2>
+            
+            <button className="w-full bg-[#21262d] border border-[#30363d] hover:bg-[#30363d] text-[#c9d1d9] font-medium py-1.5 px-3 rounded-md transition-colors mb-4 cursor-pointer">
+              Follow
+            </button>
+            
+            <p className="text-[#c9d1d9] text-base mb-4">{data.personal.bio}</p>
+            
+            <div className="flex items-center gap-1 text-[#8b949e] text-sm mb-4 cursor-pointer hover:text-[#58a6ff] transition-colors">
+              <Users className="w-4 h-4" />
+              <span className="font-bold text-[#c9d1d9]">2.4k</span> followers · 
+              <span className="font-bold text-[#c9d1d9]">14</span> following
+            </div>
+            
+            <ul className="text-sm text-[#c9d1d9] space-y-2 mb-6">
+              <li className="flex items-center gap-2">
+                <MapPin className="w-4 h-4 text-[#8b949e]" />
+                {data.personal.location}
+              </li>
+              <li className="flex items-center gap-2">
+                <Mail className="w-4 h-4 text-[#8b949e]" />
+                <a href={`mailto:${data.socials.email}`} className="hover:text-[#58a6ff] hover:underline">{data.socials.email}</a>
+              </li>
+              <li className="flex items-center gap-2">
+                <LinkIcon className="w-4 h-4 text-[#8b949e]" />
+                <a href={data.socials.github} className="hover:text-[#58a6ff] hover:underline">{data.personal.name.replace(/\s+/g, '').toLowerCase()}.com</a>
+              </li>
+              {data.socials.twitter && (
+                <li className="flex items-center gap-2">
+                  <Twitter className="w-4 h-4 text-[#8b949e]" />
+                  <a href={data.socials.twitter} className="hover:text-[#58a6ff] hover:underline">@{data.socials.twitter.split('/').pop()}</a>
+                </li>
+              )}
+            </ul>
+
+            <hr className="border-[#30363d] mb-4" />
+            
+            <h3 className="text-sm font-semibold text-[#c9d1d9] mb-2">Achievements</h3>
+            <div className="flex gap-2 mb-4">
+              <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-indigo-500 flex items-center justify-center cursor-pointer hover:scale-110 transition-transform">
+                <Star className="w-4 h-4 text-white" />
+              </div>
+              <div className="w-8 h-8 rounded-full bg-gradient-to-br from-green-500 to-emerald-500 flex items-center justify-center cursor-pointer hover:scale-110 transition-transform">
+                <Code className="w-4 h-4 text-white" />
+              </div>
+            </div>
+          </motion.div>
+
+          {/* Right Content Area */}
+          <div className="w-full md:w-3/4">
+            
+            {/* Tabs */}
+            <div className="flex overflow-x-auto border-b border-[#30363d] mb-6 text-sm font-medium hide-scrollbar">
+              {['Overview', 'Repositories', 'Projects', 'Packages', 'Stars'].map((tab) => (
+                <button 
+                  key={tab}
+                  onClick={() => setActiveTab(tab.toLowerCase())}
+                  className={`flex items-center gap-2 px-4 py-3 border-b-2 transition-colors whitespace-nowrap cursor-pointer ${
+                    activeTab === tab.toLowerCase() 
+                      ? 'border-[#f78166] text-[#c9d1d9]' 
+                      : 'border-transparent text-[#8b949e] hover:bg-[#161b22] hover:text-[#c9d1d9]'
+                  }`}
+                >
+                  {tab === 'Overview' && <BookOpen className="w-4 h-4" />}
+                  {tab === 'Repositories' && <Book className="w-4 h-4" />}
+                  {tab}
+                  {tab === 'Repositories' && <span className="bg-[#30363d] text-xs px-2 py-0.5 rounded-full ml-1">{data.projects.length}</span>}
+                </button>
+              ))}
+            </div>
+
+            <motion.div 
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+            >
+              
+              {/* README section */}
+              <div className="border border-[#30363d] rounded-md mb-6">
+                <div className="bg-[#161b22] px-4 py-2 border-b border-[#30363d] rounded-t-md text-xs text-[#8b949e] font-semibold flex items-center gap-2">
+                  <span>{data.personal.name.replace(/\s+/g, '').toLowerCase()}</span>
+                  <span className="text-[#30363d]">/</span>
+                  <span className="font-bold">README.md</span>
+                </div>
+                <div className="p-6 bg-[#0d1117] rounded-b-md">
+                  <h1 className="text-3xl font-bold border-b border-[#30363d] pb-2 mb-4 text-[#c9d1d9]">
+                    Hi there 👋, I'm {data.personal.name}
+                  </h1>
+                  <p className="text-[#8b949e] mb-4 text-base">
+                    {data.personal.bio} I'm currently working as a <strong>{data.personal.title}</strong>.
+                  </p>
+                  
+                  <h2 className="text-xl font-semibold border-b border-[#30363d] pb-2 mb-4 mt-8 text-[#c9d1d9]">
+                    🛠 Skills & Technologies
+                  </h2>
+                  <div className="flex flex-wrap gap-2 mb-4">
+                    {data.skills.map((skill, idx) => (
+                      <span key={idx} className="bg-[#161b22] border border-[#30363d] text-[#58a6ff] text-xs font-semibold px-3 py-1 rounded-full hover:bg-[#30363d] transition-colors cursor-pointer">
+                        {skill.name}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* Pinned Projects */}
+              <div className="mb-6">
+                <div className="flex items-center justify-between mb-2">
+                  <h2 className="text-base text-[#c9d1d9] font-normal">Pinned</h2>
+                  <span className="text-xs text-[#8b949e] hover:text-[#58a6ff] cursor-pointer">Customize your pins</span>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {data.projects.map((project, idx) => (
+                    <motion.div 
+                      key={idx}
+                      whileHover={{ scale: 1.02 }}
+                      className="border border-[#30363d] rounded-md p-4 bg-[#0d1117] flex flex-col justify-between"
+                    >
+                      <div>
+                        <div className="flex items-center gap-2 mb-2">
+                          <Book className="w-4 h-4 text-[#8b949e]" />
+                          <a href={project.githubUrl || project.liveUrl} className="text-[#58a6ff] font-semibold text-sm hover:underline font-mono">
+                            {project.title.toLowerCase().replace(/\s+/g, '-')}
+                          </a>
+                          <span className="border border-[#30363d] rounded-full px-2 py-0.5 text-xs text-[#8b949e] ml-auto">
+                            Public
+                          </span>
+                        </div>
+                        <p className="text-xs text-[#8b949e] mb-4 line-clamp-2">
+                          {project.description}
+                        </p>
+                      </div>
+                      
+                      <div className="flex items-center gap-4 text-xs text-[#8b949e]">
+                        {project.techStack && project.techStack[0] && (
+                          <div className="flex items-center gap-1">
+                            <span 
+                              className="w-3 h-3 rounded-full" 
+                              style={{ backgroundColor: getLangColor(project.techStack[0]) }}
+                            ></span>
+                            <span>{project.techStack[0]}</span>
+                          </div>
+                        )}
+                        <div className="flex items-center gap-1 hover:text-[#58a6ff] cursor-pointer">
+                          <Star className="w-3 h-3" />
+                          <span>{Math.floor(Math.random() * 100) + 10}</span>
+                        </div>
+                        <div className="flex items-center gap-1 hover:text-[#58a6ff] cursor-pointer">
+                          <GitFork className="w-3 h-3" />
+                          <span>{Math.floor(Math.random() * 50) + 5}</span>
+                        </div>
+                      </div>
+                    </motion.div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Experience Timeline */}
+              <div className="mb-6 mt-10">
+                <h2 className="text-base text-[#c9d1d9] font-normal mb-4">Experience</h2>
+                <div className="border border-[#30363d] rounded-md bg-[#0d1117] overflow-hidden">
+                  {data.experience.map((exp, idx) => (
+                    <div key={idx} className="flex gap-4 p-4 border-b border-[#30363d] last:border-0 hover:bg-[#161b22] transition-colors">
+                      <div className="flex flex-col items-center">
+                        <div className="w-8 h-8 rounded-full bg-[#21262d] flex items-center justify-center border border-[#30363d]">
+                          <Briefcase className="w-4 h-4 text-[#8b949e]" />
+                        </div>
+                        {idx !== data.experience.length - 1 && (
+                          <div className="w-0.5 h-full bg-[#30363d] mt-2"></div>
+                        )}
+                      </div>
+                      <div className="pb-4">
+                        <h3 className="text-[#c9d1d9] font-semibold text-sm">{exp.role}</h3>
+                        <div className="text-xs text-[#8b949e] mb-2">{exp.company} • {exp.period}</div>
+                        <p className="text-sm text-[#8b949e]">{exp.description}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Testimonials / Comments */}
+              <div className="mb-6 mt-10">
+                <h2 className="text-base text-[#c9d1d9] font-normal mb-4">Testimonials</h2>
+                <div className="space-y-4">
+                  {data.testimonials.map((test, idx) => (
+                    <div key={idx} className="flex gap-3">
+                      <img src={test.avatar} alt={test.name} className="w-10 h-10 rounded-full border border-[#30363d]" />
+                      <div className="border border-[#30363d] rounded-md flex-1 bg-[#0d1117]">
+                        <div className="bg-[#161b22] px-3 py-2 border-b border-[#30363d] rounded-t-md text-xs text-[#8b949e]">
+                          <span className="font-semibold text-[#c9d1d9]">{test.name}</span> 
+                          <span className="ml-1">({test.role})</span> commented
+                        </div>
+                        <div className="p-3 text-sm text-[#c9d1d9]">
+                          {test.text}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              
+              {/* Contribution Graph (Mock) */}
+              <div className="mb-12 mt-10">
+                <h2 className="text-base text-[#c9d1d9] font-normal mb-2">
+                  {Math.floor(Math.random() * 500) + 1000} contributions in the last year
+                </h2>
+                <div className="border border-[#30363d] rounded-md p-4 bg-[#0d1117] overflow-x-auto hide-scrollbar">
+                  <div className="flex gap-1 min-w-[700px]">
+                    {Array.from({ length: 52 }).map((_, weekIdx) => (
+                      <div key={weekIdx} className="flex flex-col gap-1">
+                        {Array.from({ length: 7 }).map((_, dayIdx) => {
+                          const levels = [
+                            'bg-[#161b22]', 
+                            'bg-[#0e4429]',
+                            'bg-[#006d32]',
+                            'bg-[#26a641]',
+                            'bg-[#39d353]'
+                          ];
+                          const randomLevel = Math.random() > 0.7 ? Math.floor(Math.random() * 4) + 1 : 0;
+                          return (
+                            <div key={dayIdx} className={`w-[10px] h-[10px] rounded-[2px] ${levels[randomLevel]}`}></div>
+                          );
+                        })}
+                      </div>
+                    ))}
+                  </div>
+                  <div className="flex items-center justify-between mt-2 text-xs text-[#8b949e]">
+                    <span>Learn how we count contributions</span>
+                    <div className="flex items-center gap-1">
+                      <span>Less</span>
+                      <div className="w-[10px] h-[10px] rounded-[2px] bg-[#161b22]"></div>
+                      <div className="w-[10px] h-[10px] rounded-[2px] bg-[#0e4429]"></div>
+                      <div className="w-[10px] h-[10px] rounded-[2px] bg-[#006d32]"></div>
+                      <div className="w-[10px] h-[10px] rounded-[2px] bg-[#26a641]"></div>
+                      <div className="w-[10px] h-[10px] rounded-[2px] bg-[#39d353]"></div>
+                      <span>More</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+            </motion.div>
+          </div>
         </div>
       </div>
+      
+      {/* Footer */}
+      <footer className="border-t border-[#30363d] mt-12 py-8 mb-[-3rem]">
+        <div className="max-w-[1280px] mx-auto px-4 flex flex-col md:flex-row items-center justify-center gap-4 text-xs text-[#8b949e]">
+          <div className="flex items-center gap-2">
+            <Github className="w-5 h-5 text-[#8b949e]" />
+            <span>© 2026 GitHub, Inc. Profile Theme by {data.personal.name}</span>
+          </div>
+          <div className="flex gap-4 flex-wrap justify-center mt-2 md:mt-0">
+            <span className="hover:text-[#58a6ff] cursor-pointer">Terms</span>
+            <span className="hover:text-[#58a6ff] cursor-pointer">Privacy</span>
+            <span className="hover:text-[#58a6ff] cursor-pointer">Security</span>
+            <span className="hover:text-[#58a6ff] cursor-pointer">Status</span>
+            <span className="hover:text-[#58a6ff] cursor-pointer">Docs</span>
+            <span className="hover:text-[#58a6ff] cursor-pointer">Contact</span>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #(issue number)

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [x] Attached Screenshots or Screen Recordings (showing before and after)
- *If your PR does not make any visual/UI changes, please write "N/A"*

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [ ] No new warnings generated

Resolves #2001 

### Description
This PR implements the **GitHub Profile** portfolio template from the Famous UI Inspired category. The template is a complete, single-page portfolio designed as a GitHub profile clone.

**Features included:**
- 🎨 Complete GitHub dark mode aesthetic (`#0d1117` bg, `#161b22` cards, etc.)
- 👤 **Hero/Profile Sidebar**: Avatar, bio, location, followers/following, and social links
- 📚 **Pinned Projects**: Project cards with tech stack language colors, stars, and forks
- 📖 **README/About Section**: A central markdown-styled section with a bio and skills
- 💼 **Experience Timeline**: Vertical timeline displaying past roles
- 💬 **Testimonials**: Styled like GitHub issue comments
- 🟩 **Contribution Graph**: A mockup contribution heat map graph
- 📱 Fully responsive on mobile, tablet, and desktop
- 🔄 Uses `lucide-react` for icons and `framer-motion` for subtle hover and entrance animations
- 🗃️ 100% data-driven from `dummy_data.json` with no hardcoded content

### Screenshots
*(Drag and drop your desktop and mobile screenshots here before submitting!)*

- [x] Desktop Screenshot

<img width="2776" height="1414" alt="Screenshot 2026-05-26 171929" src="https://github.com/user-attachments/assets/a44554eb-7530-4a1b-8ceb-1c9c5ac2dd91" />
<img width="2778" height="1417" alt="Screenshot 2026-05-26 171950" src="https://github.com/user-attachments/assets/1c950b20-d7bf-4537-89f8-9c213208abca" />
<img width="2760" height="1407" alt="Screenshot 2026-05-26 172019" src="https://github.com/user-attachments/assets/9fc15c3b-8c3d-4daf-af98-46fb92ca21be" />


- [x] Mobile Screenshot

<img width="831" height="1279" alt="Screenshot 2026-05-26 172733" src="https://github.com/user-attachments/assets/2f54b493-38c8-46e5-b224-7f1cc67412f4" />
<img width="818" height="1280" alt="Screenshot 2026-05-26 172749" src="https://github.com/user-attachments/assets/6d5a218b-7525-4766-aee2-244b6c04ac18" />
<img width="822" height="1257" alt="Screenshot 2026-05-26 172800" src="https://github.com/user-attachments/assets/aae28825-f930-4f54-9743-f1ecd3e1ef0e" />
<img width="823" height="1221" alt="Screenshot 2026-05-26 172810" src="https://github.com/user-attachments/assets/6c162556-376c-4713-abdb-0ea72d0350cf" />
<img width="828" height="1273" alt="Screenshot 2026-05-26 172830" src="https://github.com/user-attachments/assets/90c432dd-0288-4331-8643-e07da41e3e05" />
<img width="829" height="1194" alt="Screenshot 2026-05-26 172839" src="https://github.com/user-attachments/assets/19813c19-8df3-4ac2-823f-c8c76a7a2dbb" />
<img width="828" height="1271" alt="Screenshot 2026-05-26 172856" src="https://github.com/user-attachments/assets/495ae8c3-208c-4ad9-95dd-5c83cf59ca04" />
<img width="823" height="1012" alt="Screenshot 2026-05-26 172909" src="https://github.com/user-attachments/assets/44000305-7371-40a7-9a8d-a45f7f9c0b0e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned GitHub Profile template with a comprehensive GitHub-style layout featuring a profile sidebar with contact information, tabbed navigation, pinned projects grid, experience timeline, testimonials section, and contribution heatmap visualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->