### PR TITLE
Added empty portfolio state component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import SocialLinksEditor from './components/portfolio/SocialLinksEditor'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
 import { AuthProvider, useAuth } from './context/AuthContext'
@@ -145,6 +146,7 @@ function App() {
                 <Route path="messages" element={<FellowshipMessages />} />
                 <Route path="messages/:roomId" element={<FellowshipChat />} />
               </Route>
+              <Route path="/test" element={<SocialLinksEditor />} />
 
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/frontend/src/components/portfolio/EmptyPortfolioState.jsx
+++ b/frontend/src/components/portfolio/EmptyPortfolioState.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Globe, Sparkles } from "lucide-react";
+
+const EmptyPortfolioState = () => {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="flex items-center justify-center w-20 h-20 rounded-full bg-blue-100 mb-6">
+        <Globe className="w-10 h-10 text-blue-600" />
+      </div>
+
+      <h2 className="text-3xl font-bold mb-3">
+        No portfolios yet
+      </h2>
+
+      <p className="text-gray-500 max-w-md mb-8">
+        Create your first portfolio from your resume, GitHub, or LinkedIn.
+      </p>
+
+      <div className="flex gap-4">
+        <button className="px-5 py-2 bg-black text-white rounded-lg">
+          From Resume
+        </button>
+
+        <button className="px-5 py-2 border rounded-lg">
+          From GitHub
+        </button>
+
+        <button className="px-5 py-2 border rounded-lg">
+          From Scratch
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EmptyPortfolioState;

--- a/frontend/src/components/portfolio/SocialLinksEditor.jsx
+++ b/frontend/src/components/portfolio/SocialLinksEditor.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+const SocialLinksEditor = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">
+        Social Links Editor
+      </h1>
+
+      <div className="border rounded-lg p-4 mb-4">
+        <h2 className="font-semibold">GitHub</h2>
+
+        <input
+          type="text"
+          placeholder="Enter GitHub profile URL"
+          className="border p-2 rounded w-full mt-3"
+        />
+
+        <button className="mt-3 px-4 py-2 bg-blue-500 text-white rounded">
+          Save
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SocialLinksEditor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "career-pilot1",
+  "name": "career-pilot",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## **User description**
## Description
Added EmptyPortfolioState component for portfolio page empty state.

## Changes
- Added EmptyPortfolioState.jsx
- Added buttons for portfolio creation
- Used lucide-react icons
- Added clean responsive UI

## Related Issue
Closes #951


___

## **CodeAnt-AI Description**
Add a portfolio empty state and a simple social links editor page

### What Changed
- Added an empty portfolio screen that tells users there are no portfolios yet and offers three ways to start one: from a resume, GitHub, or from scratch
- Added a basic Social Links Editor page with a GitHub profile field and save button
- Made the Social Links Editor available as a new app route for quick access

### Impact
`✅ Clearer first-time portfolio setup`
`✅ Faster portfolio creation entry points`
`✅ Easier access to social link editing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a social links editor component for managing GitHub profile URLs with input field and save functionality.
  * Added an empty portfolio state interface with action buttons to create portfolios from resume, GitHub, or scratch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->