### PR TITLE
 improve integration test runner with summary table, timings… [ GSSOC'26 ]

### DIFF
--- a/backend/test.js
+++ b/backend/test.js
@@ -2,72 +2,107 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import mongoose from 'mongoose';
-import { getSystemPrompt, getVerbLists, enhanceResume } from './src/config/langchain.js';
+import { enhanceResume } from './src/config/langchain.js';
 import axios from 'axios';
 import { getQueueStats } from './src/services/jobAlertQueue.js';
 
+// ─── Result Store ─────────────────────────────────────────────────────────────
+
+const results = [];
+
+async function runTest(name, fn) {
+  console.log(`\n🔄 ${name}`);
+  const start = performance.now();
+  try {
+    const detail = await fn();
+    const ms = Math.round(performance.now() - start);
+    console.log(`✅ Passed (${ms}ms)${detail ? ' — ' + detail : ''}`);
+    results.push({ name, status: 'PASS', detail: detail ?? '', durationMs: ms });
+  } catch (err) {
+    const ms = Math.round(performance.now() - start);
+    const message = String(err.response?.data?.message ?? err.message ?? 'Unknown error');
+    console.error(`❌ Failed (${ms}ms) — ${message}`);
+    results.push({ name, status: 'FAIL', detail: message, durationMs: ms });
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
 async function runTests() {
-  console.log('--- INTEGRATION TESTS ---');
-  
-  try {
-    // 1. MONGODB
-    console.log('\n1. MONGODB CONNECTION');
-    await mongoose.connect(process.env.MONGODB_URI);
-    console.log('✅ MongoDB connected');
+  console.log('─'.repeat(68));
+  console.log(' INTEGRATION TESTS — ' + new Date().toLocaleString());
+  console.log('─'.repeat(68));
+
+  // 1. MONGODB
+  await runTest('MongoDB', async () => {
+    await mongoose.connect(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 5000 });
     await mongoose.disconnect();
-  } catch (err) {
-    console.error('❌ MongoDB Error:', err.message);
-  }
+    return 'Connection closed cleanly';
+  });
 
-  try {
-    // 2. REDIS
-    console.log('\n2. REDIS CONNECTION (BullMQ)');
-    const stats = await getQueueStats();
-    console.log('✅ Redis connected. Stats:', stats);
-  } catch (err) {
-    console.error('❌ Redis Error:', err.message);
+  // 2. REDIS
+  await runTest('Redis (BullMQ)', async () => {
+  const stats = await getQueueStats();
+  if (!stats.available) {
+    throw new Error(`Redis unavailable — ${stats.reason ?? 'no reason provided'}`);
   }
+  return `waiting=${stats.waiting} active=${stats.active} completed=${stats.completed}`;
+});
 
-  try {
-    // 3. AI / LANGCHAIN
-    console.log('\n3. AI SERVICES (Gemini)');
+  // 3. AI / LANGCHAIN
+  await runTest('AI Service (Gemini)', async () => {
     const mockResume = "Software Engineer with 2 years of experience. Developed React apps.";
     const result = await enhanceResume(mockResume, {
       jobRole: 'Frontend Developer',
       yearsOfExperience: '2',
       skills: ['React', 'JavaScript'],
     });
-    console.log('✅ AI Service Success.');
-    console.log(`Provider used: ${result.provider}`);
-    console.log(`Tokens used: ${JSON.stringify(result.tokensUsed)}`);
-    console.log('Snippet:', result.enhancedResume.substring(0, 100).replace(/\n/g, ' '));
-  } catch (err) {
-    console.error('❌ AI Service Error:', err.message);
-  }
+    return `provider=${result.provider} tokens=${JSON.stringify(result.tokensUsed)}`;
+  });
 
-  try {
-    // 4. RAPIDAPI
-    console.log('\n4. RAPIDAPI (JSearch)');
-    const options = {
+  // 4. RAPIDAPI
+  await runTest('RapidAPI (JSearch)', async () => {
+    const response = await axios.request({
       method: 'GET',
       url: `https://${process.env.RAPIDAPI_HOST}/search`,
-      params: {
-        query: 'developer',
-        page: '1',
-        num_pages: '1'
-      },
+      params: { query: 'developer', page: '1', num_pages: '1' },
       headers: {
         'X-RapidAPI-Key': process.env.RAPIDAPI_KEY,
-        'X-RapidAPI-Host': process.env.RAPIDAPI_HOST
-      }
-    };
-    const response = await axios.request(options);
-    console.log(`✅ RapidAPI Success. Found ${response.data?.data?.length} jobs.`);
-  } catch (err) {
-    console.error('❌ RapidAPI Error:', err.response?.data || err.message);
+        'X-RapidAPI-Host': process.env.RAPIDAPI_HOST,
+      },
+      timeout: 8000,
+    });
+    return `Found ${response.data?.data?.length ?? 0} jobs`;
+  });
+
+  // ─── Summary Table ───────────────────────────────────────────────────────────
+
+  const col = (str, w) => str.toString().padEnd(w);
+  const LINE = '─'.repeat(68);
+
+  console.log(`\n${LINE}`);
+  console.log(` ${col('Service', 22)} ${col('Status', 8)} ${col('Time', 8)} Detail`);
+  console.log(LINE);
+
+  for (const r of results) {
+    const icon = r.status === 'PASS' ? '✅' : '❌';
+    const detail = String(r.detail ?? '');
+    const trimmed = detail.length > 28 ? detail.slice(0, 25) + '...' : detail;
+    console.log(` ${col(r.name, 22)} ${icon} ${col(r.status, 5)} ${col(r.durationMs + 'ms', 8)} ${trimmed }`);
   }
 
-  process.exit(0);
+  const passed = results.filter(r => r.status === 'PASS').length;
+  const totalMs = results.reduce((sum, r) => sum + r.durationMs, 0);
+  const failed = results.filter(r => r.status === 'FAIL').length;
+
+  console.log(`${LINE}`);
+  console.log(` Result: ${passed}/${results.length} passed  |  Total: ${totalMs}ms`);
+  console.log(`${LINE}\n`);
+
+  process.exit(failed > 0 ? 1 : 0);
 }
 
-runTests();
+runTests().catch(err => {
+  console.error('\n❌ Fatal error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## **User description**
## Description
Refactored `test.js` integration test runner to remove repetitive try/catch blocks, add per-service response time tracking, print a summary table at the end, and fix exit code so CI pipelines correctly detect failures. Added timeouts to MongoDB and RapidAPI calls to prevent indefinite hanging.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2175 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Integration checks now report standardized PASS/FAIL results with timing per service.
  * Failure messages are clearer and aggregated into a summary table showing status, durations, and overall pass/fail counts.
  * Test run sets appropriate process exit codes for CI when any check fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show integration test results, timings, and failures more clearly**

### What Changed
- Each integration check now runs on its own and reports pass/fail status with the time it took
- A summary table is shown at the end, including service name, result, duration, and a short detail message
- MongoDB and RapidAPI calls now stop instead of hanging forever, and failed runs return a failing exit code for CI

### Impact
`✅ Clearer integration test output`
`✅ Fewer stuck test runs`
`✅ Reliable CI failure detection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
