### PR TITLE
React: Fix Mutable Ref Cleanup Warning in InterviewPrep.jsx #1692

### DIFF
--- a/frontend/src/pages/InterviewPrep.jsx
+++ b/frontend/src/pages/InterviewPrep.jsx
@@ -320,9 +320,13 @@ export default function InterviewPrep() {
 
   useEffect(() => {
     if (step === 'interview') initializeMedia();
+    
+    // Capture ref value locally
+    const synth = synthRef.current;
+    
     return () => {
       cleanupMedia();
-      if (synthRef.current) synthRef.current.cancel();
+      if (synth) synth.cancel();
     };
   }, [step]);
 


### PR DESCRIPTION
## **User description**
## Description

Fixed the mutable ref cleanup warning in `InterviewPrep.jsx` by capturing `synthRef.current` in a local constant inside `useEffect` and using that value during cleanup to avoid stale mutable ref access.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Other (describe)

## Related Issue

Fixes #1692

## Testing

* [x] Unit tests pass
* [x] Tested Locally
* [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)

N/A

## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [ ] Added comments where necessary
* [ ] Updated documentation
* [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Stop speech playback cleanup from triggering a ref warning in interview prep**

### What Changed
- Interview prep now cancels speech playback using the same speech engine instance that was active when the screen changed
- This avoids the cleanup warning that could appear when leaving or switching interview steps
- Speech and media cleanup still run when the interview screen closes

### Impact
`✅ Fewer interview prep console warnings`
`✅ More reliable speech cleanup when changing steps`
`✅ Smoother interview session transitions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
