### PR TITLE
fix: add socket authorization membership checks for realtime handlers

### DIFF
--- a/backend/src/controllers/communityFirebaseController.js
+++ b/backend/src/controllers/communityFirebaseController.js
@@ -232,6 +232,20 @@ export const getChannelMessages = async (req, res, next) => {
     const { limit = 50, before } = req.query;
     const limitNum = parseInt(limit);
 
+    // Verify channel exists and user has access
+    const channelDoc = await channelsRef.doc(channelId).get();
+    if (!channelDoc.exists) {
+      throw new ApiError(404, 'Channel not found');
+    }
+
+    const channel = channelDoc.data();
+    if (channel.type === 'private' && !channel.isDefault) {
+      const isMember = channel.members && channel.members.some(m => m.uid === req.user.uid);
+      if (!isMember) {
+        throw new ApiError(403, 'Not authorized to view messages in this channel');
+      }
+    }
+
     let query = messagesRef
       .where('channelId', '==', channelId)
       .where('isDeleted', '==', false)

--- a/backend/src/services/socketAuthz.js
+++ b/backend/src/services/socketAuthz.js
@@ -1,0 +1,60 @@
+import { db } from '../config/firebase.js';
+
+const conversationsRef = db.collection('conversations');
+const channelsRef = db.collection('channels');
+
+/**
+ * Verify the user is a participant in the given conversation.
+ * Throws an error if not found or not a member.
+ */
+export async function assertConversationMember(uid, conversationId) {
+  const convDoc = await conversationsRef.doc(conversationId).get();
+  if (!convDoc.exists) {
+    throw new Error('Conversation not found');
+  }
+  const conversation = convDoc.data();
+  if (!conversation.participantIds || !conversation.participantIds.includes(uid)) {
+    throw new Error('UNAUTHORIZED');
+  }
+  return { id: convDoc.id, ...conversation };
+}
+
+/**
+ * Verify the user is a member of the given channel.
+ * Throws an error if not found or not a member.
+ */
+export async function assertChannelMember(uid, channelId) {
+  const channelDoc = await channelsRef.doc(channelId).get();
+  if (!channelDoc.exists) {
+    throw new Error('Channel not found');
+  }
+  const channel = channelDoc.data();
+
+  // Public/default channels are open to all authenticated users
+  if (channel.type === 'public' || channel.isDefault) {
+    return { id: channelDoc.id, ...channel };
+  }
+
+  // Private channels require explicit membership
+  if (!channel.members || !channel.members.some(m => m.uid === uid)) {
+    throw new Error('UNAUTHORIZED');
+  }
+  return { id: channelDoc.id, ...channel };
+}
+
+/**
+ * Verify the user is a member of the given fellowship room.
+ * Fellowship rooms store members as a 'memberIds' array.
+ * Throws an error if not found or not a member.
+ */
+export async function assertFellowshipMember(uid, roomId) {
+  const roomDoc = await db.collection('fellowshipRooms').doc(roomId).get();
+  if (!roomDoc.exists) {
+    throw new Error('Fellowship room not found');
+  }
+  const room = roomDoc.data();
+  if (!room.memberIds || !room.memberIds.includes(uid)) {
+    throw new Error('UNAUTHORIZED');
+  }
+  return { id: roomDoc.id, ...room };
+}

--- a/backend/src/services/socketServiceFirebase.js
+++ b/backend/src/services/socketServiceFirebase.js
@@ -1,6 +1,7 @@
 import { db } from '../config/firebase.js';
 import { FieldValue } from 'firebase-admin/firestore';
 import { presenceService } from './presenceService.js';
+import { assertConversationMember, assertChannelMember, assertFellowshipMember } from './socketAuthz.js';
 
 // Collection references
 const channelsRef = db.collection('channels');
@@ -30,13 +31,14 @@ export const setupSocketHandlers = (io, socket) => {
   // Join a channel
   socket.on('join_channel', async (channelId) => {
     try {
-      const channelDoc = await channelsRef.doc(channelId).get();
-      if (!channelDoc.exists) {
-        socket.emit('error', { message: 'Channel not found' });
+      let channel;
+      try {
+        channel = await assertChannelMember(user.uid, channelId);
+      } catch (authErr) {
+        socket.emit('error', { message: authErr.message === 'UNAUTHORIZED' ? 'Not authorized to join this channel' : authErr.message });
         return;
       }
 
-      const channel = channelDoc.data();
       socket.join(`channel:${channelId}`);
       console.log(`${user.name} joined channel: ${channel.name}`);
 
@@ -94,6 +96,14 @@ export const setupSocketHandlers = (io, socket) => {
 
       if (!content || !content.trim()) {
         socket.emit('error', { message: 'Message content is required' });
+        return;
+      }
+
+      // Verify user is a member of this channel before sending
+      try {
+        await assertChannelMember(user.uid, channelId);
+      } catch (authErr) {
+        socket.emit('error', { message: authErr.message === 'UNAUTHORIZED' ? 'Not authorized to send messages in this channel' : authErr.message });
         return;
       }
 
@@ -366,13 +376,15 @@ export const setupSocketHandlers = (io, socket) => {
   // Send direct message
   socket.on('send_direct_message', async ({ conversationId, receiverId, content }) => {
     try {
-      const convDoc = await conversationsRef.doc(conversationId).get();
-      if (!convDoc.exists) {
-        socket.emit('error', { message: 'Conversation not found' });
+      // Verify the sender is actually a participant in this conversation
+      let conversation;
+      try {
+        conversation = await assertConversationMember(user.uid, conversationId);
+      } catch (authErr) {
+        socket.emit('error', { message: authErr.message === 'UNAUTHORIZED' ? 'Not authorized to send messages in this conversation' : authErr.message });
         return;
       }
 
-      const conversation = convDoc.data();
       const receiver = conversation.participants.find(p => p.uid === receiverId);
 
       const dmData = {
@@ -433,6 +445,14 @@ export const setupSocketHandlers = (io, socket) => {
   // Mark messages as read
   socket.on('mark_messages_read', async ({ conversationId }) => {
     try {
+      // Verify user belongs to this conversation before marking read
+      try {
+        await assertConversationMember(user.uid, conversationId);
+      } catch (authErr) {
+        socket.emit('error', { message: authErr.message === 'UNAUTHORIZED' ? 'Not authorized to access this conversation' : authErr.message });
+        return;
+      }
+
       // Get unread messages for this user
       const unreadSnapshot = await directMessagesRef
         .where('conversationId', '==', conversationId)
@@ -617,7 +637,13 @@ export const setupSocketHandlers = (io, socket) => {
 
   // ============ FELLOWSHIP CHAT EVENTS ============
 
-  socket.on('join_fellowship_chat', ({ roomId }) => {
+  socket.on('join_fellowship_chat', async ({ roomId }) => {
+    try {
+      await assertFellowshipMember(user.uid, roomId);
+    } catch (authErr) {
+      socket.emit('error', { message: authErr.message === 'UNAUTHORIZED' ? 'Not authorized to join this fellowship room' : authErr.message });
+      return;
+    }
     socket.join(`fellowship:${roomId}`);
     console.log(`${user.name} joined fellowship chat: ${roomId}`);
   });
@@ -626,7 +652,13 @@ export const setupSocketHandlers = (io, socket) => {
     socket.leave(`fellowship:${roomId}`);
   });
 
-  socket.on('fellowship_message', ({ roomId, message }) => {
+  socket.on('fellowship_message', async ({ roomId, message }) => {
+    try {
+      await assertFellowshipMember(user.uid, roomId);
+    } catch (authErr) {
+      socket.emit('error', { message: authErr.message === 'UNAUTHORIZED' ? 'Not authorized to send messages in this fellowship room' : authErr.message });
+      return;
+    }
     socket.to(`fellowship:${roomId}`).emit('fellowship_message', {
       roomId,
       message


### PR DESCRIPTION
## Description
Added server-side authorization checks to Socket.IO realtime handlers. Previously, authenticated users could access arbitrary conversations, private channels, and fellowship rooms by supplying any known ID. A new `socketAuthz.js` utility was added with reusable membership guard functions, and these guards were applied to all affected socket handlers and one REST route.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2146 


## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Access control for channels, conversations, and fellowship rooms now properly enforces membership verification.
  * Real-time message operations require valid authorization before proceeding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->