### PR TITLE
feat: implement responsive mobile navigation and layout rendering #465

### DIFF
--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import AppSidebar from "./AppSidebar";
+import MobileNav from "./MobileNav";
 import FAB from "./FAB";
 import NotificationCenter from "./NotificationCenter";
 import { cn } from "../lib/utils";
@@ -9,10 +10,12 @@ export default function AppLayout({ children, className }) {
 
     return (
         <div className={cn("flex h-screen bg-background overflow-hidden", className)}>
-            <AppSidebar />
+            <div className="hidden md:block">
+    <AppSidebar />
+</div>
 
             {/* The main tag below is what the FAB component listens to for scrolling */}
-            <main ref={mainRef} className="flex-1 overflow-y-auto relative">
+              <main ref={mainRef} className="flex-1 overflow-y-auto relative pb-24 md:pb-0">
                 {/* Top bar with notification bell */}
                 <div className="sticky top-0 z-40 flex justify-end items-center px-4 py-2 bg-background/80 backdrop-blur border-b border-border">
                     <NotificationCenter />
@@ -21,6 +24,7 @@ export default function AppLayout({ children, className }) {
 
                 <FAB scrollContainerRef={mainRef} />
             </main>
+            <MobileNav />
         </div>
     );
 }

--- a/frontend/src/components/MobileNav.jsx
+++ b/frontend/src/components/MobileNav.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import {
+    Bell,
+    CalendarDays,
+    Home,
+    Menu,
+    Search,
+    Settings,
+    UserCircle,
+    X,
+} from "lucide-react";
+import { cn } from "../lib/utils";
+
+const primaryTabs = [
+    { label: "Home", href: "/", icon: Home },
+    { label: "Search", href: "/search", icon: Search },
+    { label: "Calendar", href: "/calendar", icon: CalendarDays },
+    { label: "Alerts", href: "/notifications", icon: Bell },
+    { label: "Profile", href: "/profile", icon: UserCircle },
+];
+
+const secondaryLinks = [
+    { label: "Settings", href: "/settings", icon: Settings },
+];
+
+function getCurrentPath() {
+    if (typeof window === "undefined") return "";
+    return window.location.pathname;
+}
+
+function MobileNavItem({ item, activePath, onClick, drawerItem = false }) {
+    const Icon = item.icon;
+    const isActive = activePath === item.href;
+
+    return (
+        <a
+            href={item.href}
+            onClick={onClick}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+                "flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                isActive && "bg-accent text-accent-foreground",
+                drawerItem
+                    ? "flex-row justify-start gap-3 px-3 text-sm font-medium"
+                    : "flex-col gap-1 px-1 text-[11px] font-medium leading-none"
+            )}
+        >
+            <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+            <span className={cn(!drawerItem && "truncate")}>{item.label}</span>
+        </a>
+    );
+}
+
+export default function MobileNav({
+    tabs = primaryTabs,
+    menuLinks = secondaryLinks,
+    activePath = getCurrentPath(),
+}) {
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+    useEffect(() => {
+        if (!isMenuOpen) return undefined;
+
+        const handleKeyDown = (event) => {
+            if (event.key === "Escape") setIsMenuOpen(false);
+        };
+
+        document.body.style.overflow = "hidden";
+        window.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.body.style.overflow = "";
+            window.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [isMenuOpen]);
+
+    return (
+        <>
+            <nav
+                aria-label="Mobile navigation"
+                className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/95 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur md:hidden"
+            >
+                <div className="grid grid-cols-[44px_1fr] items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={() => setIsMenuOpen(true)}
+                        aria-label="Open menu"
+                        aria-expanded={isMenuOpen}
+                        className="flex h-11 w-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    >
+                        <Menu className="h-5 w-5" aria-hidden="true" />
+                    </button>
+
+                    <div className="grid grid-cols-5 gap-1">
+                        {tabs.slice(0, 5).map((item) => (
+                            <MobileNavItem
+                                key={item.href || item.label}
+                                item={item}
+                                activePath={activePath}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </nav>
+
+            {isMenuOpen && (
+                <div className="fixed inset-0 z-[60] md:hidden">
+                    <button
+                        type="button"
+                        aria-label="Close menu"
+                        onClick={() => setIsMenuOpen(false)}
+                        className="absolute inset-0 h-full w-full bg-foreground/40"
+                    />
+
+                    <aside
+                        aria-label="Secondary navigation"
+                        className="absolute inset-x-0 bottom-0 max-h-[82vh] overflow-y-auto border-t border-border bg-background px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-3 shadow-lg"
+                    >
+                        <div className="flex min-h-11 items-center justify-between">
+                            <h2 className="text-base font-semibold text-foreground">Menu</h2>
+                            <button
+                                type="button"
+                                onClick={() => setIsMenuOpen(false)}
+                                aria-label="Close menu"
+                                className="flex h-11 w-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                            >
+                                <X className="h-5 w-5" aria-hidden="true" />
+                            </button>
+                        </div>
+
+                        <div className="mt-2 grid gap-1">
+                            {menuLinks.map((item) => (
+                                <MobileNavItem
+                                    key={item.href || item.label}
+                                    item={item}
+                                    activePath={activePath}
+                                    drawerItem
+                                    onClick={() => setIsMenuOpen(false)}
+                                />
+                            ))}
+                        </div>
+                    </aside>
+                </div>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
## Description
Added mobile bottom tab navigation for the app layout.

Changes include:
- New `MobileNav` component with 5 primary tabs.
- Mobile-only bottom navigation bar.
- Hamburger menu for secondary navigation links.
- Sidebar hidden on mobile viewports.
- Added bottom padding to main content so the fixed mobile nav does not cover content.
- Touch-friendly tap targets with minimum 44px sizing.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #465 

## Testing
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] New tests added

Manual UI testing could not be completed because Firebase authentication is required to access the app.

## Screenshots (MANDATORY for UI/UX changes)
Screenshots could not be captured because the app requires Firebase authentication and I do not currently have access to a logged-in test account.

The changes were implemented in:
- `frontend/src/components/MobileNav.jsx`
- `frontend/src/components/AppLayout.jsx`

Expected UI changes:
- On mobile, the sidebar is hidden.
- A fixed bottom navigation bar with 5 tabs is shown.
- A hamburger menu opens secondary navigation links.
- Tap targets are at least 44px for mobile accessibility.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] Commented hard-to-understand areas
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced mobile bottom navigation with icon-based tab links and a collapsible menu drawer
  * Added full-screen overlay menu for secondary navigation options
  * Active navigation state highlighted based on current page

* **Improvements**
  * Layout automatically adapts between mobile and desktop views
  * Page scroll is managed when menu overlay is open

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->