### PR TITLE
feat: add reusable animated select component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,8 +4,6 @@
  */
 import React, { useState, useEffect, lazy, Suspense } from 'react';
 import StockTicker from "./components/portfolio/templates/Finance_Corporate/StockTicker";
-
-import React, { useState, useEffect } from 'react';
 import Deployments from './pages/Deployments'
 import TemplateGallery from "./pages/TemplateGallery";
 

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -10,4 +10,4 @@ export { default as Footer } from './Footer'
 export { default as GradientBorder, GlowCard } from './GradientBorder'
 export { AnimatedGradientText, AnimatedLetters, TypewriterText, FadeInText } from './AnimatedText'
 export { default as AnimatedCounter } from './AnimatedCounter'
-
+export { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './select'

--- a/frontend/src/components/ui/select.jsx
+++ b/frontend/src/components/ui/select.jsx
@@ -1,0 +1,176 @@
+import * as React from "react"
+import { ChevronDown, Check } from "lucide-react"
+import { motion, AnimatePresence } from "framer-motion"
+import { cn } from "@/lib/utils"
+
+const SelectContext = React.createContext(null)
+
+/**
+ * Main wrapper component for Custom Select Dropdown.
+ * Provides the interactive selection context to all subcomponents.
+ */
+export function Select({ children, value, onValueChange, defaultValue }) {
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [selectedValue, setSelectedValue] = React.useState(value || defaultValue || "")
+  const [options, setOptions] = React.useState({})
+  const containerRef = React.useRef(null)
+
+  // Sync selectedValue state with external value prop updates
+  React.useEffect(() => {
+    if (value !== undefined) {
+      setSelectedValue(value)
+    }
+  }, [value])
+
+  // Register option labels dynamically so trigger can display them based on current value
+  const registerOption = React.useCallback((val, label) => {
+    setOptions(prev => {
+      if (prev[val] === label) return prev
+      return { ...prev, [val]: label }
+    })
+  }, [])
+
+  // Deregister option labels on unmount to prevent memory leaks
+  const deregisterOption = React.useCallback((val) => {
+    setOptions(prev => {
+      if (!(val in prev)) return prev
+      const copy = { ...prev }
+      delete copy[val]
+      return copy
+    })
+  }, [])
+
+  // Close dropdown when clicking outside the component
+  React.useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  const handleSelect = React.useCallback((val) => {
+    setSelectedValue(val)
+    setIsOpen(false)
+    if (onValueChange) {
+      onValueChange(val)
+    }
+  }, [onValueChange])
+
+  const selectedLabel = options[selectedValue] || ""
+
+  return (
+    <SelectContext.Provider value={{ isOpen, setIsOpen, selectedValue, selectedLabel, registerOption, deregisterOption, handleSelect }}>
+      <div ref={containerRef} className="relative w-full">
+        {children}
+      </div>
+    </SelectContext.Provider>
+  )
+}
+
+/**
+ * The trigger button for opening and closing the Select dropdown.
+ */
+export const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => {
+  const { isOpen, setIsOpen, selectedLabel } = React.useContext(SelectContext)
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={() => setIsOpen(!isOpen)}
+      aria-expanded={isOpen}
+      className={cn(
+        "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 text-left transition-all duration-200 select-none",
+        isOpen && "ring-2 ring-ring ring-offset-2 border-primary/50",
+        className
+      )}
+      {...props}
+    >
+      {children || <span className="truncate">{selectedLabel}</span>}
+      <ChevronDown className={cn("h-4 w-4 opacity-50 transition-transform duration-200 ml-2 flex-shrink-0", isOpen && "rotate-180")} />
+    </button>
+  )
+})
+SelectTrigger.displayName = "SelectTrigger"
+
+/**
+ * Component to display the current selection or a placeholder.
+ */
+export const SelectValue = React.forwardRef(({ className, placeholder, ...props }, ref) => {
+  const { selectedValue, selectedLabel } = React.useContext(SelectContext)
+
+  return (
+    <span
+      ref={ref}
+      className={cn("block truncate", !selectedValue && "text-muted-foreground", className)}
+      {...props}
+    >
+      {selectedLabel || placeholder}
+    </span>
+  )
+})
+SelectValue.displayName = "SelectValue"
+
+/**
+ * The animated container showing the list of selectable options.
+ */
+export const SelectContent = React.forwardRef(({ className, children, ...props }, ref) => {
+  const { isOpen } = React.useContext(SelectContext)
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0, y: -10, scale: 0.97 }}
+          animate={{ opacity: 1, y: 4, scale: 1 }}
+          exit={{ opacity: 0, y: -10, scale: 0.97 }}
+          transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+          className="absolute z-50 min-w-[8rem] w-full overflow-hidden rounded-md border border-input bg-popover text-popover-foreground shadow-lg max-h-60 overflow-y-auto backdrop-blur-md bg-background/95"
+        >
+          <div ref={ref} className={cn("p-1 space-y-0.5", className)} {...props}>
+            {children}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+})
+SelectContent.displayName = "SelectContent"
+
+/**
+ * An individual option selectable within the dropdown.
+ */
+export const SelectItem = React.forwardRef(({ className, children, value, ...props }, ref) => {
+  const { selectedValue, registerOption, deregisterOption, handleSelect } = React.useContext(SelectContext)
+  const isSelected = selectedValue === value
+
+  const label = typeof children === "string" ? children : value
+
+  React.useEffect(() => {
+    registerOption(value, label)
+    return () => deregisterOption(value)
+  }, [value, label, registerOption, deregisterOption])
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={() => handleSelect(value)}
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-left transition-colors duration-150",
+        isSelected && "bg-accent text-accent-foreground font-medium",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2.5 flex h-3.5 w-3.5 items-center justify-center">
+        {isSelected && <Check className="h-3.5 w-3.5 text-primary" />}
+      </span>
+      <span className="truncate">{children}</span>
+    </button>
+  )
+})
+SelectItem.displayName = "SelectItem"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-<<<<<<< HEAD
   "name": "careerpilot",
   "private": true,
   "version": "1.0.0",
@@ -57,11 +56,5 @@
     "jsdom": "^29.1.1",
     "vite": "^7.2.4",
     "vitest": "^4.1.7"
-=======
-  "dependencies": {
-    "framer-motion": "^12.39.0",
-    "lucide-react": "^1.16.0",
-    "puppeteer-core": "^25.0.4"
->>>>>>> d9cec355c02ba7adf33119c9737350dda1bf2f81
   }
 }


### PR DESCRIPTION
## Description
- Implemented a highly reusable, fully customizable `Select` (dropdown) component in `frontend/src/components/ui/select.jsx` using `framer-motion` for smooth enter/exit transitions and active state outlines.
- Exported the components (`Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, `SelectItem`) in `frontend/src/components/ui/index.js` for easy modular imports.
- Resolved a duplicate hook/module import conflict in `frontend/src/App.jsx` (where React and useState were declared twice) to ensure a perfectly clean project compilation.
- Resolved Git conflict markers in the root `package.json`.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2230 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- Reusable UI component built for the component library. Tested locally using the Vite production build (`npm run build`), which now compiles successfully with zero warnings or errors.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Select dropdown component to the UI library with fully customizable subcomponents for trigger buttons, value display, dropdown content, and individual items. The component supports controlled and uncontrolled states with animated interactions.

* **Chores**
  * Resolved merge conflicts in package configuration and updated dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->