### PR TITLE
fix: prevent DropZone progress memory leaks and state pollution

### DIFF
--- a/frontend/src/components/DropZone.jsx
+++ b/frontend/src/components/DropZone.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, useRef, useEffect } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { Upload, FileText, X, CheckCircle, AlertCircle } from 'lucide-react'
 import toast from 'react-hot-toast'
@@ -13,18 +13,48 @@ export default function DropZone({
   const [previews, setPreviews] = useState([])
   const [uploadProgress, setUploadProgress] = useState({})
 
-  const simulateProgress = (fileName) => {
+  const intervalsRef = useRef({})
+
+  const simulateProgress = useCallback((fileName) => {
     let progress = 0
     setUploadProgress((prev) => ({ ...prev, [fileName]: 0 }))
+
+    if (intervalsRef.current[fileName]) {
+      clearInterval(intervalsRef.current[fileName])
+    }
+
     const interval = setInterval(() => {
       progress += Math.floor(Math.random() * 15) + 5
       if (progress >= 100) {
         progress = 100
         clearInterval(interval)
+        delete intervalsRef.current[fileName]
       }
-      setUploadProgress((prev) => ({ ...prev, [fileName]: progress }))
+      setUploadProgress((prev) => {
+        if (prev[fileName] === undefined) {
+          clearInterval(interval)
+          delete intervalsRef.current[fileName]
+          return prev
+        }
+        return { ...prev, [fileName]: progress }
+      })
     }, 150)
-  }
+
+    intervalsRef.current[fileName] = interval
+  }, [])
+
+  const removeFile = useCallback((fileName) => {
+    if (intervalsRef.current[fileName]) {
+      clearInterval(intervalsRef.current[fileName])
+      delete intervalsRef.current[fileName]
+    }
+    setPreviews((prev) => prev.filter((p) => p.name !== fileName))
+    setUploadProgress((prev) => {
+      const updated = { ...prev }
+      delete updated[fileName]
+      return updated
+    })
+  }, [])
 
   const onDrop = useCallback(
     (acceptedFiles, rejectedFiles) => {
@@ -60,17 +90,18 @@ export default function DropZone({
         onFileSelect(acceptedFiles[0])
       }
     },
-    [onFileSelect, maxSizeMB, maxSizeBytes, multiple]
+    [onFileSelect, maxSizeMB, maxSizeBytes, multiple, simulateProgress]
   )
 
-  const removeFile = (fileName) => {
-    setPreviews((prev) => prev.filter((p) => p.name !== fileName))
-    setUploadProgress((prev) => {
-      const updated = { ...prev }
-      delete updated[fileName]
-      return updated
-    })
-  }
+  useEffect(() => {
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const activeIntervals = intervalsRef.current
+      Object.keys(activeIntervals).forEach((fileName) => {
+        clearInterval(activeIntervals[fileName])
+      })
+    }
+  }, [])
 
   const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
     onDrop,


### PR DESCRIPTION
## Description
This pull request resolves a memory leak and state pollution bug in the `DropZone` component. Previously, the simulated file upload interval timers (`setInterval`) continued executing in the background after a file was removed or after the component unmounted (e.g., during page navigation). 

To fix this:
* Stored simulated progress interval IDs inside a React `useRef` object (`intervalsRef`).
* Cleared and deleted the corresponding interval immediately when a file is removed via `removeFile(fileName)`.
* Added a safety check inside the `setUploadProgress` callback: if the file key has been deleted, it halts and clears the interval.
* Implemented a `useEffect` cleanup hook to clear all remaining active intervals on component unmount.
* Wrapped helper handlers in `useCallback` to ensure reference stability.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2136

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
N/A *(This is a background logic fix for memory leak prevention, no visual UI components were altered)*

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload functionality by preventing timer memory leaks and optimizing cleanup processes during file operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->