### PR TITLE
docs: link isolated guides to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,23 @@ New contributors should read **[ARCHITECTURE.md](./ARCHITECTURE.md)** early, as 
 
 ---
 
+## 📖 Developer Guides & Extended Documentation
+
+To help you get familiar with the advanced subsystems of Career Pilot, we have provided detailed technical guides in the `docs` directory:
+
+* 🛠️ **[Environment Setup](./docs/environment-setup.md)**: Standard walkthrough for local environment variables, DB configurations, and cluster parameters.
+* 🤖 **[AI Features & Integration](./docs/ai-features.md)**: Deep-dive into Gemini prompt engineering, Harvard resume heuristics, and ATS scoring systems.
+* 📦 **[Portfolio Architecture](./docs/portfolio-architecture.md)**: Overview of the dynamic landing page renderer, metadata structures, and theme systems.
+* 🎨 **[Creating Portfolio Themes](./docs/creating-portfolio-themes.md)**: Step-by-step developer tutorial on creating custom portfolio aesthetics.
+* 🐙 **[GitHub Intelligence](./docs/github-intelligence.md)**: Inside look at how the system crawls repositories, parses metadata, and evaluates developer portfolios.
+* ⚡ **[Redis Lifecycle & Connection Tuning](./docs/redis-connection-lifecycle-issue.md)**: Advanced troubleshooting guide for Redis subscription channels and job queues.
+* 🌐 **[CDN & Assets Setup](./docs/cdn-setup.md)**: Cloudflare cache settings and optimal static asset delivery.
+* 🚀 **[Deployment Setup](./docs/deployment-setup.md)**: Production configurations for Vercel, Netlify, and server hosting.
+* 📘 **[User Guide](./docs/user-guide.md)**: Full-featured guide explaining product usage and workflow patterns.
+
+---
+
+
 ## 🔌 API Reference
 
 <details>


### PR DESCRIPTION
## Description
- Refactored the root `README.md` to link and summarize all 9 of the isolated guide files in the `docs/` directory.
- This provides direct discoverability for critical contributor onboarding topics such as Portfolio Architecture, AI Features, GitHub Intelligence integration, Redis tuning, and theme creation.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2213

## Testing
- [x] Tested Locally (checked markdown links in preview render)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [x] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive new Developer Guides & Extended Documentation section containing curated reference links to helpful resources covering development environment setup, AI feature integration, portfolio customization and architecture planning, GitHub intelligence capabilities, Redis optimization strategies, CDN and asset management, deployment procedures, and complete end-user implementation documentation to support faster developer onboarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->