### PR TITLE
fix(frontend): add React ErrorBoundary to prevent full app crashes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -87,7 +87,11 @@ function ProtectedRoute({ children }) {
     return <Navigate to="/login" replace />;
   }
 
-  return <AppLayout><ErrorBoundary>{children}</ErrorBoundary></AppLayout>;
+  return (
+    <ErrorBoundary>
+      <AppLayout>{children}</AppLayout>
+    </ErrorBoundary>
+  );
 }
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import { SocketProvider } from './context/SocketProvider';
 import { ThemeProvider } from './context/ThemeProvider';
 import AppLayout from './components/AppLayout';
 import Footer from './components/ui/Footer';
+import ErrorBoundary from './components/ErrorBoundary';
 
 import CommandPalette from './components/CommandPalette';
 import BackToTop from './components/BackToTop';
@@ -86,7 +87,7 @@ function ProtectedRoute({ children }) {
     return <Navigate to="/login" replace />;
   }
 
-  return <AppLayout>{children}</AppLayout>;
+  return <AppLayout><ErrorBoundary>{children}</ErrorBoundary></AppLayout>;
 }
 
 

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,120 @@
+import { Component } from 'react';
+
+/**
+ * ErrorBoundary catches unhandled JavaScript errors in any child component
+ * tree and displays a friendly fallback UI instead of crashing the entire app.
+ *
+ * Usage:
+ *   <ErrorBoundary>
+ *     <SomeFeaturePage />
+ *   </ErrorBoundary>
+ */
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render shows the fallback UI.
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Log error details for debugging / future monitoring integration (e.g. Sentry).
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    this.setState({ errorInfo });
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          style={{
+            minHeight: '100vh',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            gap: '1rem',
+            padding: '2rem',
+            background: 'var(--background, #0f0f0f)',
+            color: 'var(--foreground, #f5f5f5)',
+            textAlign: 'center',
+          }}
+        >
+          <div style={{ fontSize: '3rem' }}>⚠️</div>
+          <h2 style={{ fontSize: '1.5rem', fontWeight: 700, margin: 0 }}>
+            Something went wrong
+          </h2>
+          <p style={{ color: 'var(--muted-foreground, #888)', maxWidth: '480px', margin: 0 }}>
+            An unexpected error occurred. This is usually caused by a temporary
+            network or API issue. Your data has been preserved — try refreshing or
+            going back.
+          </p>
+
+          {/* Show error message in development only */}
+          {import.meta.env.DEV && this.state.error && (
+            <pre
+              style={{
+                background: 'var(--card, #1a1a1a)',
+                border: '1px solid var(--border, #333)',
+                borderRadius: '0.5rem',
+                padding: '1rem',
+                fontSize: '0.75rem',
+                textAlign: 'left',
+                maxWidth: '600px',
+                overflowX: 'auto',
+                color: '#ef4444',
+              }}
+            >
+              {this.state.error.toString()}
+            </pre>
+          )}
+
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+            <button
+              onClick={this.handleReset}
+              style={{
+                padding: '0.5rem 1.25rem',
+                borderRadius: '0.5rem',
+                border: 'none',
+                background: 'var(--primary, #6366f1)',
+                color: '#fff',
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+              }}
+            >
+              Try Again
+            </button>
+            <button
+              onClick={() => window.location.assign('/dashboard')}
+              style={{
+                padding: '0.5rem 1.25rem',
+                borderRadius: '0.5rem',
+                border: '1px solid var(--border, #333)',
+                background: 'transparent',
+                color: 'var(--foreground, #f5f5f5)',
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+              }}
+            >
+              Go to Dashboard
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
- Create frontend/src/components/ErrorBoundary.jsx with a class-based ErrorBoundary component to catch unhandled rendering errors
- Wrap the children in App.jsx's ProtectedRoute with ErrorBoundary so that major feature routes are resilient to crashes

## Description
Added a React `ErrorBoundary` component to prevent unhandled UI rendering errors from crashing the entire application and showing a blank white screen. 

Instead of wrapping each route individually, the `ErrorBoundary` is placed directly inside the `ProtectedRoute` wrapper component in `App.jsx`, ensuring that all authenticated major feature routes are automatically protected and resilient to crashes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2217

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [ ] Attached Screenshots or Screen Recordings (showing before and after)
- *If your PR does not make any visual/UI changes, please write "N/A"*
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Enhanced error handling** – When unexpected errors occur during app usage, a user-friendly fallback screen now appears with options to retry the action or navigate back to the dashboard, preventing blank page displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->