### PR TITLE
docs: fix incorrect repository URLs in CONTRIBUTION.md

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -78,14 +78,14 @@ Before contributing, ensure you have:
 2. **Clone your fork:**
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/ai-resume-builder.git
-cd ai-resume-builder
+git clone https://github.com/YOUR_USERNAME/career-pilot.git
+cd career-pilot
 ```
 
 1. **Add upstream remote:**
 
 ```bash
-git remote add upstream https://github.com/ORIGINAL_OWNER/ai-resume-builder.git
+git remote add upstream https://github.com/anurag3407/career-pilot.git
 ```
 
 1. **Keep your fork synced:**


### PR DESCRIPTION
## Description
The "Getting Started" section in `CONTRIBUTION.md` incorrectly referenced an older project name (`ai-resume-builder`) in the git clone and cd commands. This causes immediate errors for new contributors attempting to set up their local environment. 

- Updates the git clone URL and directory name to `career-pilot`.
- Replaces the placeholder `ORIGINAL_OWNER` in the upstream remote command with the correct upstream username (`anurag3407`), so the command can be copy-pasted directly by newcomers.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
N/A

## Testing
- [ ] Unit tests pass
- [ ] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [ ] Attached Screenshots or Screen Recordings (showing before and after)
- *If your PR does not make any visual/UI changes, please write "N/A"*
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [x] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution instructions to reference the correct repository name in setup guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->