### PR TITLE
fix: capture synthRef in InterviewPrep.jsx cleanup to prevent stale ref access

### DIFF
--- a/frontend/src/pages/InterviewPrep.jsx
+++ b/frontend/src/pages/InterviewPrep.jsx
@@ -320,9 +320,10 @@ export default function InterviewPrep() {
 
   useEffect(() => {
     if (step === 'interview') initializeMedia();
+    const synth = synthRef.current;
     return () => {
       cleanupMedia();
-      if (synthRef.current) synthRef.current.cancel();
+      if (synth) synth.cancel();
     };
   }, [step]);
 


### PR DESCRIPTION
Closes #2227.

**Fixes:**
- Captured `synthRef.current` in a local variable before the cleanup function runs to prevent React stale reference warnings and ensure `cancel()` is correctly invoked on the valid object instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code stability for interview preparation feature's speech synthesis cleanup logic.

---

*Note: This release contains internal improvements with no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->