### PR TITLE
feat: add Discord Server portfolio template

### DIFF
--- a/frontend/src/components/portfolio/templates/Discord_Server/ChannelSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChannelSidebar.jsx
@@ -16,7 +16,7 @@ const categories = ['INFORMATION', 'PORTFOLIO', 'COMMUNITY'];
 
 export default function ChannelSidebar({ activeChannel, setActiveChannel, name, title, avatar, forceShow = false }) {
   return (
-    <div className={`${forceShow ? 'flex' : 'hidden md:flex'} flex-col w-60 min-w-[240px] bg-[#2B2D31] overflow-hidden`}>
+    <div className={`${forceShow ? 'flex' : 'hidden md:flex'} flex-col w-60 min-w-[240px] bg-[#2B2D31] overflow-hidden select-none`}>
       {/* Server Header */}
       <div className="h-12 px-4 flex items-center justify-between border-b border-[#1F2023] shadow-md cursor-pointer hover:bg-[#35373C] transition-colors">
         <h2 className="text-[15px] font-semibold text-white truncate">{name}'s Portfolio</h2>

--- a/frontend/src/components/portfolio/templates/Discord_Server/ChannelSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChannelSidebar.jsx
@@ -27,10 +27,10 @@ export default function ChannelSidebar({ activeChannel, setActiveChannel, name, 
       <div className="flex-1 overflow-y-auto px-2 pt-4 space-y-4 scrollbar-thin">
         {categories.map((cat) => (
           <div key={cat}>
-            <button className="flex items-center gap-0.5 text-[11px] font-bold text-[#949BA4] tracking-wide uppercase hover:text-[#DBDEE1] px-1 mb-1 cursor-pointer">
+            <div className="flex items-center gap-0.5 text-[11px] font-bold text-[#949BA4] tracking-wide uppercase hover:text-[#DBDEE1] px-1 mb-1 cursor-pointer">
               <ChevronDown className="w-3 h-3" />
               {cat}
-            </button>
+            </div>
             {channels
               .filter((ch) => ch.category === cat)
               .map((ch) => (
@@ -56,10 +56,10 @@ export default function ChannelSidebar({ activeChannel, setActiveChannel, name, 
 
         {/* Voice Channel */}
         <div>
-          <button className="flex items-center gap-0.5 text-[11px] font-bold text-[#949BA4] tracking-wide uppercase hover:text-[#DBDEE1] px-1 mb-1 cursor-pointer">
+          <div className="flex items-center gap-0.5 text-[11px] font-bold text-[#949BA4] tracking-wide uppercase hover:text-[#DBDEE1] px-1 mb-1 cursor-pointer">
             <ChevronDown className="w-3 h-3" />
             VOICE CHANNELS
-          </button>
+          </div>
           <div className="flex items-center gap-1.5 px-2 py-1.5 rounded text-sm text-[#949BA4] hover:bg-[#35373C] hover:text-[#DBDEE1] cursor-pointer">
             <Volume2 className="w-4 h-4 shrink-0 opacity-70" />
             <span>Lounge</span>

--- a/frontend/src/components/portfolio/templates/Discord_Server/ChannelSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChannelSidebar.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Hash, ChevronDown, Mic, Headphones, Settings, Volume2, Users } from 'lucide-react';
+
+const channels = [
+  { id: 'welcome', label: 'welcome', category: 'INFORMATION' },
+  { id: 'about', label: 'about-me', category: 'INFORMATION' },
+  { id: 'skills', label: 'skills', category: 'PORTFOLIO' },
+  { id: 'projects', label: 'projects', category: 'PORTFOLIO' },
+  { id: 'experience', label: 'experience', category: 'PORTFOLIO' },
+  { id: 'testimonials', label: 'testimonials', category: 'COMMUNITY' },
+  { id: 'contact', label: 'contact', category: 'COMMUNITY' },
+];
+
+const categories = ['INFORMATION', 'PORTFOLIO', 'COMMUNITY'];
+
+export default function ChannelSidebar({ activeChannel, setActiveChannel, name, title, avatar, forceShow = false }) {
+  return (
+    <div className={`${forceShow ? 'flex' : 'hidden md:flex'} flex-col w-60 min-w-[240px] bg-[#2B2D31] overflow-hidden`}>
+      {/* Server Header */}
+      <div className="h-12 px-4 flex items-center justify-between border-b border-[#1F2023] shadow-md cursor-pointer hover:bg-[#35373C] transition-colors">
+        <h2 className="text-[15px] font-semibold text-white truncate">{name}'s Portfolio</h2>
+        <ChevronDown className="w-4 h-4 text-[#B5BAC1]" />
+      </div>
+
+      {/* Channel List */}
+      <div className="flex-1 overflow-y-auto px-2 pt-4 space-y-4 scrollbar-thin">
+        {categories.map((cat) => (
+          <div key={cat}>
+            <button className="flex items-center gap-0.5 text-[11px] font-bold text-[#949BA4] tracking-wide uppercase hover:text-[#DBDEE1] px-1 mb-1 cursor-pointer">
+              <ChevronDown className="w-3 h-3" />
+              {cat}
+            </button>
+            {channels
+              .filter((ch) => ch.category === cat)
+              .map((ch) => (
+                <motion.button
+                  key={ch.id}
+                  whileHover={{ x: 2 }}
+                  onClick={() => setActiveChannel(ch.id)}
+                  className={`w-full flex items-center gap-1.5 px-2 py-1.5 rounded text-sm cursor-pointer transition-colors mb-[1px] ${
+                    activeChannel === ch.id
+                      ? 'bg-[#404249] text-white font-medium'
+                      : 'text-[#949BA4] hover:bg-[#35373C] hover:text-[#DBDEE1]'
+                  }`}
+                >
+                  <Hash className="w-4 h-4 shrink-0 opacity-70" />
+                  <span className="truncate">{ch.label}</span>
+                  {ch.id === 'welcome' && (
+                    <span className="ml-auto bg-[#DA373C] text-white text-[10px] font-bold w-4 h-4 rounded-full flex items-center justify-center">!</span>
+                  )}
+                </motion.button>
+              ))}
+          </div>
+        ))}
+
+        {/* Voice Channel */}
+        <div>
+          <button className="flex items-center gap-0.5 text-[11px] font-bold text-[#949BA4] tracking-wide uppercase hover:text-[#DBDEE1] px-1 mb-1 cursor-pointer">
+            <ChevronDown className="w-3 h-3" />
+            VOICE CHANNELS
+          </button>
+          <div className="flex items-center gap-1.5 px-2 py-1.5 rounded text-sm text-[#949BA4] hover:bg-[#35373C] hover:text-[#DBDEE1] cursor-pointer">
+            <Volume2 className="w-4 h-4 shrink-0 opacity-70" />
+            <span>Lounge</span>
+            <Users className="w-3 h-3 ml-auto opacity-50" />
+          </div>
+        </div>
+      </div>
+
+      {/* User Panel */}
+      <div className="h-[52px] bg-[#232428] px-2 flex items-center gap-2">
+        <div className="relative">
+          <img src={avatar} alt={name} className="w-8 h-8 rounded-full object-cover" />
+          <div className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 bg-[#23A559] rounded-full border-[3px] border-[#232428]" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-white truncate leading-tight">{name.split(' ')[0]}</div>
+          <div className="text-[11px] text-[#949BA4] truncate leading-tight">Online</div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Mic className="w-4 h-4 text-[#B5BAC1] hover:text-white cursor-pointer" />
+          <Headphones className="w-4 h-4 text-[#B5BAC1] hover:text-white cursor-pointer" />
+          <Settings className="w-4 h-4 text-[#B5BAC1] hover:text-white cursor-pointer" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
@@ -3,7 +3,7 @@ import { Hash, Users, Pin, Search, Inbox, HelpCircle, Menu } from 'lucide-react'
 
 export default function ChatHeader({ channelName, onToggleMobile }) {
   return (
-    <div className="h-12 min-h-[48px] px-2 sm:px-4 flex items-center border-b border-[#1F2023] shadow-sm bg-[#313338]">
+    <div className="h-12 min-h-[48px] px-2 sm:px-4 flex items-center border-b border-[#1F2023] shadow-sm bg-[#313338] select-none">
       {/* Mobile hamburger */}
       <button onClick={onToggleMobile} className="md:hidden mr-2 text-[#B5BAC1] hover:text-white cursor-pointer">
         <Menu className="w-5 h-5" />

--- a/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
@@ -5,7 +5,7 @@ export default function ChatHeader({ channelName, onToggleMobile }) {
   return (
     <div className="h-12 min-h-[48px] px-2 sm:px-4 flex items-center border-b border-[#1F2023] shadow-sm bg-[#313338] select-none">
       {/* Mobile hamburger */}
-      <button onClick={onToggleMobile} className="md:hidden mr-2 text-[#B5BAC1] hover:text-white cursor-pointer">
+      <button onClick={onToggleMobile} aria-label="Toggle mobile menu" className="md:hidden mr-2 text-[#B5BAC1] hover:text-white cursor-pointer">
         <Menu className="w-5 h-5" />
       </button>
 

--- a/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Hash, Users, Pin, Search, Inbox, HelpCircle, Menu } from 'lucide-react';
+
+export default function ChatHeader({ channelName, onToggleMobile }) {
+  return (
+    <div className="h-12 min-h-[48px] px-2 sm:px-4 flex items-center border-b border-[#1F2023] shadow-sm bg-[#313338]">
+      {/* Mobile hamburger */}
+      <button onClick={onToggleMobile} className="md:hidden mr-2 text-[#B5BAC1] hover:text-white cursor-pointer">
+        <Menu className="w-5 h-5" />
+      </button>
+
+      <Hash className="w-5 h-5 text-[#80848E] mr-1.5 shrink-0" />
+      <h3 className="text-[15px] font-semibold text-white mr-2">{channelName}</h3>
+      <div className="hidden sm:block w-[1px] h-6 bg-[#3F4147] mx-2" />
+      <span className="hidden sm:block text-sm text-[#949BA4] truncate">
+        {channelName === 'welcome' && 'Welcome to the server! 🎉'}
+        {channelName === 'about-me' && 'Get to know me better'}
+        {channelName === 'skills' && 'Technologies & tools I work with'}
+        {channelName === 'projects' && 'Showcase of my work'}
+        {channelName === 'experience' && 'My professional journey'}
+        {channelName === 'testimonials' && 'What people say about me'}
+        {channelName === 'contact' && 'Get in touch!'}
+      </span>
+
+      <div className="ml-auto flex items-center gap-3 text-[#B5BAC1]">
+        <Pin className="w-5 h-5 hidden sm:block cursor-pointer hover:text-white" />
+        <Users className="w-5 h-5 hidden sm:block cursor-pointer hover:text-white" />
+        <div className="hidden lg:flex items-center bg-[#1E1F22] rounded px-1.5 py-1 text-xs text-[#949BA4] w-36">
+          Search
+          <Search className="w-3.5 h-3.5 ml-auto" />
+        </div>
+        <Inbox className="w-5 h-5 hidden sm:block cursor-pointer hover:text-white" />
+        <HelpCircle className="w-5 h-5 hidden sm:block cursor-pointer hover:text-white" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ContactContent.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ContactContent.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Github, Linkedin, Twitter, Mail, Send } from 'lucide-react';
+import { Message, Divider } from './MessageComponents';
+
+export function ContactContent({ data }) {
+  const p = data.personal;
+  const s = data.socials;
+
+  const links = [
+    { icon: Github, label: 'GitHub', url: s.github, color: '#DBDEE1' },
+    { icon: Linkedin, label: 'LinkedIn', url: s.linkedin, color: '#0A66C2' },
+    { icon: Twitter, label: 'Twitter', url: s.twitter, color: '#1DA1F2' },
+    { icon: Mail, label: 'Email', url: `mailto:${s.email}`, color: '#EB459E' },
+  ];
+
+  return (
+    <div className="py-4 space-y-1">
+      <Divider text="Get In Touch" />
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:50 AM"
+        isBot
+        index={0}
+      >
+        <p>📬 Want to connect with <span className="font-semibold text-white">{p.name}</span>? Here's how:</p>
+      </Message>
+
+      <Message avatar={p.avatar} name={p.name} timestamp="Today at 12:51 AM" index={1}>
+        <div className="max-w-[520px] mt-1 flex rounded overflow-hidden bg-[#2B2D31] border border-[#1E1F22]">
+          <div className="w-1 shrink-0 bg-[#5865F2]" />
+          <div className="p-4 flex-1 min-w-0">
+            <div className="text-sm font-semibold text-[#00AFF4] mb-3">🔗 Social Links</div>
+            <div className="space-y-2">
+              {links.map((link, i) => (
+                <a
+                  key={i}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-3 text-sm text-[#DBDEE1] hover:text-white py-1.5 px-2 rounded hover:bg-[#383A40] transition-colors group"
+                >
+                  <link.icon className="w-5 h-5 shrink-0" style={{ color: link.color }} />
+                  <span className="group-hover:underline">{link.label}</span>
+                  <span className="text-[#949BA4] text-xs ml-auto truncate hidden sm:inline">
+                    {link.url.replace('mailto:', '').replace('https://', '')}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Message>
+
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:52 AM"
+        isBot
+        index={2}
+      >
+        <p>Feel free to reach out! {p.name.split(' ')[0]} is always open to new opportunities and collaborations. 🤝</p>
+      </Message>
+
+      {/* Fake message input */}
+      <div className="px-4 pb-4 pt-6">
+        <div className="bg-[#383A40] rounded-lg flex items-center px-4 py-2.5">
+          <span className="text-[#6D6F78] text-sm flex-1">Message #{`contact`}</span>
+          <Send className="w-5 h-5 text-[#6D6F78]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ContactContent.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ContactContent.jsx
@@ -7,11 +7,11 @@ export function ContactContent({ data }) {
   const s = data.socials;
 
   const links = [
-    { icon: Github, label: 'GitHub', url: s.github, color: '#DBDEE1' },
-    { icon: Linkedin, label: 'LinkedIn', url: s.linkedin, color: '#0A66C2' },
-    { icon: Twitter, label: 'Twitter', url: s.twitter, color: '#1DA1F2' },
-    { icon: Mail, label: 'Email', url: `mailto:${s.email}`, color: '#EB459E' },
-  ];
+    s.github && { icon: Github, label: 'GitHub', url: s.github, color: '#DBDEE1' },
+    s.linkedin && { icon: Linkedin, label: 'LinkedIn', url: s.linkedin, color: '#0A66C2' },
+    s.twitter && { icon: Twitter, label: 'Twitter', url: s.twitter, color: '#1DA1F2' },
+    s.email && { icon: Mail, label: 'Email', url: `mailto:${s.email}`, color: '#EB459E' },
+  ].filter(Boolean);
 
   return (
     <div className="py-4 space-y-1">

--- a/frontend/src/components/portfolio/templates/Discord_Server/ExperienceTestimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ExperienceTestimonials.jsx
@@ -19,7 +19,7 @@ export function ExperienceContent({ data }) {
         <p>💼 <span className="font-semibold text-white">{p.name}</span>'s professional journey:</p>
       </Message>
 
-      {data.experience.map((exp, idx) => (
+      {(data.experience || []).map((exp, idx) => (
         <Message
           key={idx}
           avatar={p.avatar}
@@ -59,7 +59,7 @@ export function TestimonialsContent({ data }) {
         <p>💬 Here's what people have said about working with <span className="font-semibold text-white">{p.name}</span>:</p>
       </Message>
 
-      {data.testimonials.map((t, idx) => (
+      {(data.testimonials || []).map((t, idx) => (
         <Message
           key={idx}
           avatar={t.avatar}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ExperienceTestimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ExperienceTestimonials.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Briefcase } from 'lucide-react';
+import { Message, Divider } from './MessageComponents';
+
+export function ExperienceContent({ data }) {
+  const p = data.personal;
+  const timelineColors = ['#5865F2', '#23A559', '#F0B232', '#EB459E'];
+
+  return (
+    <div className="py-4 space-y-1">
+      <Divider text="Work Experience" />
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:30 AM"
+        isBot
+        index={0}
+      >
+        <p>💼 <span className="font-semibold text-white">{p.name}</span>'s professional journey:</p>
+      </Message>
+
+      {data.experience.map((exp, idx) => (
+        <Message
+          key={idx}
+          avatar={p.avatar}
+          name={p.name}
+          timestamp={`Today at 12:${31 + idx} AM`}
+          index={idx + 1}
+        >
+          <div className="max-w-[520px] mt-1 flex rounded overflow-hidden bg-[#2B2D31] border border-[#1E1F22]">
+            <div className="w-1 shrink-0" style={{ backgroundColor: timelineColors[idx % timelineColors.length] }} />
+            <div className="p-3 flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <Briefcase className="w-4 h-4" style={{ color: timelineColors[idx % timelineColors.length] }} />
+                <span className="text-sm font-semibold text-white">{exp.role}</span>
+              </div>
+              <div className="text-xs text-[#949BA4] mb-2">{exp.company} • {exp.period}</div>
+              <div className="text-sm text-[#DBDEE1]">{exp.description}</div>
+            </div>
+          </div>
+        </Message>
+      ))}
+    </div>
+  );
+}
+
+export function TestimonialsContent({ data }) {
+  const p = data.personal;
+  return (
+    <div className="py-4 space-y-1">
+      <Divider text="Testimonials" />
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:40 AM"
+        isBot
+        index={0}
+      >
+        <p>💬 Here's what people have said about working with <span className="font-semibold text-white">{p.name}</span>:</p>
+      </Message>
+
+      {data.testimonials.map((t, idx) => (
+        <Message
+          key={idx}
+          avatar={t.avatar}
+          name={t.name}
+          timestamp={`Today at 12:${41 + idx} AM`}
+          index={idx + 1}
+        >
+          <div className="text-sm text-[#DBDEE1] italic">"{t.text}"</div>
+          <div className="text-xs text-[#949BA4] mt-1">— {t.role}</div>
+        </Message>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/MessageComponents.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/MessageComponents.jsx
@@ -53,7 +53,7 @@ export function Embed({ color = '#5865F2', title, description, fields, image, fo
             ))}
           </div>
         )}
-        {image && <img src={image} alt="" className="w-full rounded mt-1 max-h-48 object-cover" />}
+        {image && <img src={image} alt={title || 'Embedded image'} className="w-full rounded mt-1 max-h-48 object-cover" />}
         {footer && <div className="text-[11px] text-[#949BA4] mt-2">{footer}</div>}
       </div>
     </div>

--- a/frontend/src/components/portfolio/templates/Discord_Server/MessageComponents.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/MessageComponents.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const msgAnim = {
+  hidden: { opacity: 0, y: 12 },
+  visible: (i) => ({ opacity: 1, y: 0, transition: { delay: i * 0.08, duration: 0.35 } }),
+};
+
+export function Message({ avatar, name, timestamp, children, isBot, index = 0 }) {
+  return (
+    <motion.div
+      custom={index}
+      initial="hidden"
+      animate="visible"
+      variants={msgAnim}
+      className="flex gap-4 px-4 py-1 hover:bg-[#2E3035] group transition-colors"
+    >
+      <img
+        src={avatar}
+        alt={name}
+        className="w-10 h-10 rounded-full object-cover mt-0.5 shrink-0 cursor-pointer hover:opacity-80"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`font-medium text-sm cursor-pointer hover:underline ${isBot ? 'text-[#5865F2]' : 'text-[#F2F3F5]'}`}>
+            {name}
+          </span>
+          {isBot && (
+            <span className="bg-[#5865F2] text-[10px] text-white font-bold px-1 py-[1px] rounded text-center leading-tight">BOT</span>
+          )}
+          <span className="text-[11px] text-[#949BA4]">{timestamp}</span>
+        </div>
+        <div className="text-sm text-[#DBDEE1] mt-0.5 leading-relaxed">{children}</div>
+      </div>
+    </motion.div>
+  );
+}
+
+export function Embed({ color = '#5865F2', title, description, fields, image, footer }) {
+  return (
+    <div className="max-w-[520px] mt-1 flex rounded overflow-hidden bg-[#2B2D31] border border-[#1E1F22]">
+      <div className="w-1 shrink-0" style={{ backgroundColor: color }} />
+      <div className="p-3 min-w-0 flex-1">
+        {title && <div className="text-sm font-semibold text-[#00AFF4] mb-1">{title}</div>}
+        {description && <div className="text-sm text-[#DBDEE1] mb-2">{description}</div>}
+        {fields && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-2">
+            {fields.map((f, i) => (
+              <div key={i}>
+                <div className="text-xs font-semibold text-[#B5BAC1]">{f.name}</div>
+                <div className="text-sm text-[#DBDEE1]">{f.value}</div>
+              </div>
+            ))}
+          </div>
+        )}
+        {image && <img src={image} alt="" className="w-full rounded mt-1 max-h-48 object-cover" />}
+        {footer && <div className="text-[11px] text-[#949BA4] mt-2">{footer}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function Divider({ text }) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 my-2">
+      <div className="flex-1 h-[1px] bg-[#3F4147]" />
+      <span className="text-[11px] font-semibold text-[#949BA4]">{text}</span>
+      <div className="flex-1 h-[1px] bg-[#3F4147]" />
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ProjectsContent.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ProjectsContent.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { ExternalLink, Github } from 'lucide-react';
+import { Message, Divider } from './MessageComponents';
+
+const embedColors = ['#5865F2', '#23A559', '#EB459E', '#F0B232', '#ED4245', '#57F287'];
+
+export function ProjectsContent({ data }) {
+  const p = data.personal;
+  return (
+    <div className="py-4 space-y-1">
+      <Divider text="Projects Showcase" />
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:20 AM"
+        isBot
+        index={0}
+      >
+        <p>🚀 Here are <span className="font-semibold text-white">{p.name}</span>'s featured projects:</p>
+      </Message>
+
+      {data.projects.map((project, idx) => (
+        <Message
+          key={idx}
+          avatar={p.avatar}
+          name={p.name}
+          timestamp={`Today at 12:${21 + idx} AM`}
+          index={idx + 1}
+        >
+          <div className="max-w-[520px] mt-1 flex rounded overflow-hidden bg-[#2B2D31] border border-[#1E1F22]">
+            <div className="w-1 shrink-0" style={{ backgroundColor: embedColors[idx % embedColors.length] }} />
+            <div className="p-3 flex-1 min-w-0">
+              <div className="text-sm font-semibold text-[#00AFF4] mb-1">{project.title}</div>
+              <div className="text-sm text-[#DBDEE1] mb-2">{project.description}</div>
+
+              <div className="flex flex-wrap gap-1 mb-2">
+                {project.techStack.map((tech, i) => (
+                  <span key={i} className="bg-[#1E1F22] text-[#B5BAC1] text-[11px] px-2 py-0.5 rounded-full">
+                    {tech}
+                  </span>
+                ))}
+              </div>
+
+              {project.image && (
+                <img src={project.image} alt={project.title} className="w-full rounded mt-1 max-h-48 object-cover" />
+              )}
+
+              <div className="flex gap-3 mt-2">
+                {project.liveUrl && (
+                  <a href={project.liveUrl} target="_blank" rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-[#00AFF4] hover:underline">
+                    <ExternalLink className="w-3 h-3" /> Live Demo
+                  </a>
+                )}
+                {project.githubUrl && (
+                  <a href={project.githubUrl} target="_blank" rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-[#00AFF4] hover:underline">
+                    <Github className="w-3 h-3" /> Source Code
+                  </a>
+                )}
+              </div>
+            </div>
+          </div>
+        </Message>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ProjectsContent.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ProjectsContent.jsx
@@ -19,7 +19,7 @@ export function ProjectsContent({ data }) {
         <p>🚀 Here are <span className="font-semibold text-white">{p.name}</span>'s featured projects:</p>
       </Message>
 
-      {data.projects.map((project, idx) => (
+      {(data.projects || []).map((project, idx) => (
         <Message
           key={idx}
           avatar={p.avatar}
@@ -34,7 +34,7 @@ export function ProjectsContent({ data }) {
               <div className="text-sm text-[#DBDEE1] mb-2">{project.description}</div>
 
               <div className="flex flex-wrap gap-1 mb-2">
-                {project.techStack.map((tech, i) => (
+                {(project.techStack || []).map((tech, i) => (
                   <span key={i} className="bg-[#1E1F22] text-[#B5BAC1] text-[11px] px-2 py-0.5 rounded-full">
                     {tech}
                   </span>

--- a/frontend/src/components/portfolio/templates/Discord_Server/ServerSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ServerSidebar.jsx
@@ -12,7 +12,7 @@ const serverIcons = [
 
 export default function ServerSidebar({ avatar, name, forceShow = false }) {
   return (
-    <div className={`${forceShow ? 'flex' : 'hidden md:flex'} flex-col items-center w-[72px] min-w-[72px] bg-[#1E1F22] py-3 gap-2 overflow-y-auto`}>
+    <div className={`${forceShow ? 'flex' : 'hidden md:flex'} flex-col items-center w-[72px] min-w-[72px] bg-[#1E1F22] py-3 gap-2 overflow-y-auto select-none`}>
       {/* Home Server Icon */}
       <motion.div
         whileHover={{ borderRadius: '35%' }}

--- a/frontend/src/components/portfolio/templates/Discord_Server/ServerSidebar.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ServerSidebar.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Gamepad2, Code2, Briefcase, Coffee, Music } from 'lucide-react';
+
+const serverIcons = [
+  { icon: Code2, color: 'from-indigo-500 to-purple-600', label: 'Dev' },
+  { icon: Briefcase, color: 'from-green-500 to-emerald-600', label: 'Work' },
+  { icon: Gamepad2, color: 'from-red-500 to-pink-600', label: 'Fun' },
+  { icon: Coffee, color: 'from-amber-500 to-orange-600', label: 'Chill' },
+  { icon: Music, color: 'from-cyan-500 to-blue-600', label: 'Music' },
+];
+
+export default function ServerSidebar({ avatar, name, forceShow = false }) {
+  return (
+    <div className={`${forceShow ? 'flex' : 'hidden md:flex'} flex-col items-center w-[72px] min-w-[72px] bg-[#1E1F22] py-3 gap-2 overflow-y-auto`}>
+      {/* Home Server Icon */}
+      <motion.div
+        whileHover={{ borderRadius: '35%' }}
+        className="w-12 h-12 rounded-[50%] overflow-hidden cursor-pointer mb-1 ring-2 ring-[#5865F2] transition-all duration-200"
+      >
+        <img src={avatar} alt={name} className="w-full h-full object-cover" />
+      </motion.div>
+
+      <div className="w-8 h-[2px] bg-[#35363C] rounded-full mb-1" />
+
+      {serverIcons.map((s, i) => (
+        <motion.div
+          key={i}
+          whileHover={{ borderRadius: '35%', scale: 1.05 }}
+          className={`w-12 h-12 rounded-[50%] bg-gradient-to-br ${s.color} flex items-center justify-center cursor-pointer transition-all duration-200`}
+          title={s.label}
+        >
+          <s.icon className="w-5 h-5 text-white" />
+        </motion.div>
+      ))}
+
+      {/* Add Server */}
+      <motion.div
+        whileHover={{ borderRadius: '35%', backgroundColor: '#3BA55D' }}
+        className="w-12 h-12 rounded-[50%] bg-[#313338] flex items-center justify-center cursor-pointer text-[#3BA55D] hover:text-white transition-all duration-200 mt-1"
+      >
+        <span className="text-2xl font-light">+</span>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/SkillsContent.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/SkillsContent.jsx
@@ -11,7 +11,7 @@ const categoryColors = {
 
 export function SkillsContent({ data }) {
   const p = data.personal;
-  const grouped = data.skills.reduce((acc, s) => {
+  const grouped = (data.skills || []).reduce((acc, s) => {
     acc[s.category] = acc[s.category] || [];
     acc[s.category].push(s);
     return acc;
@@ -54,7 +54,7 @@ export function SkillsContent({ data }) {
                     <div className="h-2 bg-[#1E1F22] rounded-full overflow-hidden">
                       <motion.div
                         initial={{ width: 0 }}
-                        animate={{ width: `${skill.level}%` }}
+                        animate={{ width: `${Math.min(100, Math.max(0, Number(skill.level) || 0))}%` }}
                         transition={{ duration: 1, delay: catIdx * 0.2 + i * 0.1 }}
                         className="h-full rounded-full"
                         style={{ backgroundColor: categoryColors[category] || '#5865F2' }}

--- a/frontend/src/components/portfolio/templates/Discord_Server/SkillsContent.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/SkillsContent.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Message, Divider } from './MessageComponents';
+
+const categoryColors = {
+  Frontend: '#5865F2',
+  Backend: '#23A559',
+  DevOps: '#F0B232',
+  Design: '#EB459E',
+};
+
+export function SkillsContent({ data }) {
+  const p = data.personal;
+  const grouped = data.skills.reduce((acc, s) => {
+    acc[s.category] = acc[s.category] || [];
+    acc[s.category].push(s);
+    return acc;
+  }, {});
+
+  return (
+    <div className="py-4 space-y-1">
+      <Divider text="Skills & Technologies" />
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:10 AM"
+        isBot
+        index={0}
+      >
+        <p>Here's a breakdown of <span className="font-semibold text-white">{p.name}</span>'s technical skills 🛠️</p>
+      </Message>
+
+      {Object.entries(grouped).map(([category, skills], catIdx) => (
+        <Message
+          key={category}
+          avatar={p.avatar}
+          name={p.name}
+          timestamp={`Today at 12:${11 + catIdx} AM`}
+          index={catIdx + 1}
+        >
+          <div className="max-w-[520px] mt-1 flex rounded overflow-hidden bg-[#2B2D31] border border-[#1E1F22]">
+            <div className="w-1 shrink-0" style={{ backgroundColor: categoryColors[category] || '#5865F2' }} />
+            <div className="p-3 flex-1 min-w-0">
+              <div className="text-sm font-semibold mb-3" style={{ color: categoryColors[category] || '#5865F2' }}>
+                {category === 'Frontend' && '🎨'} {category === 'Backend' && '⚙️'} {category === 'DevOps' && '🚀'} {category === 'Design' && '✏️'} {category}
+              </div>
+              <div className="space-y-2">
+                {skills.map((skill, i) => (
+                  <div key={i}>
+                    <div className="flex justify-between text-xs mb-1">
+                      <span className="text-[#DBDEE1] font-medium">{skill.name}</span>
+                      <span className="text-[#949BA4]">{skill.level}%</span>
+                    </div>
+                    <div className="h-2 bg-[#1E1F22] rounded-full overflow-hidden">
+                      <motion.div
+                        initial={{ width: 0 }}
+                        animate={{ width: `${skill.level}%` }}
+                        transition={{ duration: 1, delay: catIdx * 0.2 + i * 0.1 }}
+                        className="h-full rounded-full"
+                        style={{ backgroundColor: categoryColors[category] || '#5865F2' }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Message>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/WelcomeAbout.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/WelcomeAbout.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Sparkles, MapPin, Calendar, ArrowRight } from 'lucide-react';
+import { Message, Embed, Divider } from './MessageComponents';
+
+export function WelcomeContent({ data }) {
+  const p = data.personal;
+  const st = data.stats;
+  return (
+    <div className="py-4 space-y-1">
+      {/* Welcome banner */}
+      <div className="px-4 mb-6">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="bg-gradient-to-r from-[#5865F2] to-[#EB459E] rounded-lg p-6 sm:p-8 text-center"
+        >
+          <img src={p.avatar} alt={p.name} className="w-20 h-20 sm:w-24 sm:h-24 rounded-full mx-auto mb-4 border-4 border-white/20 object-cover" />
+          <h1 className="text-2xl sm:text-4xl font-bold text-white mb-2">{p.name}</h1>
+          <p className="text-white/80 text-base sm:text-lg mb-4">{p.title}</p>
+          <div className="flex flex-wrap justify-center gap-4 sm:gap-6 text-white/90 text-sm">
+            <div className="flex items-center gap-1"><MapPin className="w-4 h-4" />{p.location}</div>
+            <div className="flex items-center gap-1"><Calendar className="w-4 h-4" />{st.yearsExperience}+ Years</div>
+            <div className="flex items-center gap-1"><Sparkles className="w-4 h-4" />{st.projectsCompleted} Projects</div>
+          </div>
+        </motion.div>
+      </div>
+
+      <Divider text="Welcome to the server" />
+
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:00 AM"
+        isBot
+        index={0}
+      >
+        <div className="space-y-2">
+          <p>👋 Welcome to <span className="font-semibold text-white">{p.name}'s Portfolio Server</span>!</p>
+          <p>Feel free to explore the channels on the left to learn more:</p>
+          <div className="bg-[#2B2D31] rounded-lg p-3 mt-2 text-sm space-y-1 border-l-4 border-[#5865F2]">
+            <p><span className="text-[#00AFF4]">#about-me</span> — Learn about {p.name.split(' ')[0]}</p>
+            <p><span className="text-[#00AFF4]">#skills</span> — Tech stack & expertise</p>
+            <p><span className="text-[#00AFF4]">#projects</span> — Featured work & builds</p>
+            <p><span className="text-[#00AFF4]">#experience</span> — Career timeline</p>
+            <p><span className="text-[#00AFF4]">#testimonials</span> — What others say</p>
+            <p><span className="text-[#00AFF4]">#contact</span> — Get in touch</p>
+          </div>
+        </div>
+      </Message>
+
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:01 AM"
+        isBot
+        index={1}
+      >
+        <Embed
+          color="#23A559"
+          title="📊 Quick Stats"
+          fields={[
+            { name: '🗓 Experience', value: `${st.yearsExperience}+ years` },
+            { name: '🚀 Projects', value: `${st.projectsCompleted} completed` },
+            { name: '😊 Clients', value: `${st.happyClients} happy` },
+          ]}
+          footer="Last updated — Today"
+        />
+      </Message>
+    </div>
+  );
+}
+
+export function AboutContent({ data }) {
+  const p = data.personal;
+  return (
+    <div className="py-4 space-y-1">
+      <Divider text="About Me" />
+      <Message avatar={p.avatar} name={p.name} timestamp="Today at 12:05 AM" index={0}>
+        <p className="mb-3">{p.bio}</p>
+      </Message>
+      <Message avatar={p.avatar} name={p.name} timestamp="Today at 12:06 AM" index={1}>
+        <Embed
+          color="#EB459E"
+          title="✨ Profile Card"
+          description={p.tagline || 'Building the future, one line of code at a time.'}
+          fields={[
+            { name: '📍 Location', value: p.location },
+            { name: '💼 Role', value: p.title },
+            { name: '📧 Email', value: data.socials.email },
+          ]}
+          image={p.avatar}
+        />
+      </Message>
+      <Message
+        avatar="https://cdn.discordapp.com/embed/avatars/0.png"
+        name="PortfolioBot"
+        timestamp="Today at 12:07 AM"
+        isBot
+        index={2}
+      >
+        <p>Check out <span className="text-[#00AFF4]">#skills</span> to see {p.name.split(' ')[0]}'s tech stack! 🛠️</p>
+      </Message>
+    </div>
+  );
+}

--- a/frontend/src/components/portfolio/templates/Discord_Server/index.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/index.jsx
@@ -58,7 +58,7 @@ export default function DiscordServer() {
   };
 
   return (
-    <div className="h-screen w-full flex bg-[#313338] text-[#DBDEE1] font-sans overflow-hidden select-none">
+    <div className="h-screen w-full flex bg-[#313338] text-[#DBDEE1] font-sans overflow-hidden">
       {/* Server Sidebar - far left */}
       <ServerSidebar avatar={data.personal.avatar} name={data.personal.name} />
 

--- a/frontend/src/components/portfolio/templates/Discord_Server/index.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/index.jsx
@@ -1,29 +1,138 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import data from '../../../../data/dummy_data.json';
+import ServerSidebar from './ServerSidebar';
+import ChannelSidebar from './ChannelSidebar';
+import ChatHeader from './ChatHeader';
+import { WelcomeContent, AboutContent } from './WelcomeAbout';
+import { SkillsContent } from './SkillsContent';
+import { ProjectsContent } from './ProjectsContent';
+import { ExperienceContent, TestimonialsContent } from './ExperienceTestimonials';
+import { ContactContent } from './ContactContent';
 
 /**
  * Discord Server Portfolio Template
  * Category: Famous UI Inspired
- * Description: Discord server layout with sidebar channels for navigation, main content area styled as chat messages, user profile card in sidebar.
+ * Description: Discord server layout with sidebar channels for navigation,
+ * main content area styled as chat messages, user profile card in sidebar.
  */
+
+const channelLabels = {
+  welcome: 'welcome',
+  about: 'about-me',
+  skills: 'skills',
+  projects: 'projects',
+  experience: 'experience',
+  testimonials: 'testimonials',
+  contact: 'contact',
+};
+
 export default function DiscordServer() {
+  const [activeChannel, setActiveChannel] = useState('welcome');
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const renderContent = () => {
+    switch (activeChannel) {
+      case 'welcome':
+        return <WelcomeContent data={data} />;
+      case 'about':
+        return <AboutContent data={data} />;
+      case 'skills':
+        return <SkillsContent data={data} />;
+      case 'projects':
+        return <ProjectsContent data={data} />;
+      case 'experience':
+        return <ExperienceContent data={data} />;
+      case 'testimonials':
+        return <TestimonialsContent data={data} />;
+      case 'contact':
+        return <ContactContent data={data} />;
+      default:
+        return <WelcomeContent data={data} />;
+    }
+  };
+
+  const handleChannelChange = (ch) => {
+    setActiveChannel(ch);
+    setMobileMenuOpen(false);
+  };
+
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-8 font-sans">
-      <div className="max-w-3xl w-full text-center">
-        <h1 className="text-5xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
-          {data.personal.name}
-        </h1>
-        <p className="text-xl md:text-2xl text-gray-400 mb-8">{data.personal.title}</p>
-        <div className="p-8 border-2 border-dashed border-cyan-500/40 rounded-2xl bg-gray-900/50 backdrop-blur-sm">
-          <span className="inline-block px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-400 text-xs font-bold uppercase tracking-widest mb-4">
-            Famous UI Inspired
-          </span>
-          <h2 className="text-2xl font-bold text-gray-200 mb-3">Discord Server Template</h2>
-          <p className="text-gray-400 mb-6 leading-relaxed">
-            Discord server layout with sidebar channels for navigation, main content area styled as chat messages, user profile card in sidebar.
-          </p>
-          <p className="text-cyan-400 font-semibold">Open an issue to contribute and build this template!</p>
+    <div className="h-screen w-full flex bg-[#313338] text-[#DBDEE1] font-sans overflow-hidden select-none">
+      {/* Server Sidebar - far left */}
+      <ServerSidebar avatar={data.personal.avatar} name={data.personal.name} />
+
+      {/* Channel Sidebar */}
+      <ChannelSidebar
+        activeChannel={activeChannel}
+        setActiveChannel={handleChannelChange}
+        name={data.personal.name}
+        title={data.personal.title}
+        avatar={data.personal.avatar}
+      />
+
+      {/* Mobile Overlay */}
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.5 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setMobileMenuOpen(false)}
+              className="fixed inset-0 bg-black z-40 md:hidden"
+            />
+            <motion.div
+              initial={{ x: -300 }}
+              animate={{ x: 0 }}
+              exit={{ x: -300 }}
+              transition={{ type: 'spring', damping: 25, stiffness: 250 }}
+              className="fixed left-0 top-0 bottom-0 z-50 flex md:hidden"
+            >
+              <ServerSidebar avatar={data.personal.avatar} name={data.personal.name} forceShow />
+              <ChannelSidebar
+                activeChannel={activeChannel}
+                setActiveChannel={handleChannelChange}
+                name={data.personal.name}
+                title={data.personal.title}
+                avatar={data.personal.avatar}
+                forceShow
+              />
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+
+      {/* Main Chat Area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        <ChatHeader
+          channelName={channelLabels[activeChannel]}
+          onToggleMobile={() => setMobileMenuOpen(true)}
+        />
+        <div className="flex-1 overflow-y-auto scrollbar-thin">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={activeChannel}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              {renderContent()}
+            </motion.div>
+          </AnimatePresence>
         </div>
+
+        {/* Message Input Bar */}
+        {activeChannel !== 'contact' && (
+          <div className="px-4 pb-4 pt-2">
+            <div className="bg-[#383A40] rounded-lg flex items-center px-4 py-2.5">
+              <span className="text-[#6D6F78] text-sm flex-1">
+                Message #{channelLabels[activeChannel]}
+              </span>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Implemented the complete **Discord Server** portfolio template under the Famous UI Inspired category. Built as a fully responsive, single-page SPA mimicking the Discord app UI with fixed sidebars, a scrollable chat area, and a mobile sliding drawer. It maps all content dynamically from `dummy_data.json`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2003

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [x] Attached Screenshots or Screen Recordings (showing before and after)
<img width="750" height="1624" alt="discord-mobile-contact" src="https://github.com/user-attachments/assets/6d0ff23e-df93-45d4-ae7e-fa0b70152013" />
<img width="750" height="1624" alt="discord-mobile-testimonials" src="https://github.com/user-attachments/assets/d1317e19-ce68-4c96-a754-aeae911aa60c" />
<img width="750" height="1624" alt="discord-mobile-experience" src="https://github.com/user-attachments/assets/5de604a0-f1ea-4c41-a140-599015738706" />
<img width="750" height="1624" alt="discord-mobile-projects" src="https://github.com/user-attachments/assets/08e04b98-6884-465b-9544-7d56435f5c92" />
<img width="750" height="1624" alt="discord-mobile-skills" src="https://github.com/user-attachments/assets/20591e79-d474-4685-bc1e-71b4a40bb02b" />
<img width="750" height="1624" alt="discord-mobile-about" src="https://github.com/user-attachments/assets/728bbe92-3417-4b79-8866-eda52e0066d3" />
<img width="750" height="1624" alt="discord-mobile-welcome" src="https://github.com/user-attachments/assets/5b795713-dc6c-4882-96f1-2560e3bfc174" />
<img width="2880" height="1800" alt="discord-desktop-contact" src="https://github.com/user-attachments/assets/f87405fc-94a6-4b4a-a7e9-a5a0a12a1e2f" />
<img width="2880" height="1800" alt="discord-desktop-testimonials" src="https://github.com/user-attachments/assets/aa46f21d-57f4-47fb-9f06-c17244f3bf61" />
<img width="2880" height="1800" alt="discord-desktop-experience" src="https://github.com/user-attachments/assets/39dc75b8-c697-4461-acd3-3f887fa1fd94" />
<img width="2880" height="1800" alt="discord-desktop-projects" src="https://github.com/user-attachments/assets/c24d5112-6941-48c9-926c-f1820f2d1e7f" />
<img width="2880" height="1800" alt="discord-desktop-skills" src="https://github.com/user-attachments/assets/52c6feab-4faf-455b-b300-118452fe2c7a" />
<img width="2880" height="1800" alt="discord-desktop-about" src="https://github.com/user-attachments/assets/0de0b2a7-6eab-46a3-85a8-aac533f0dc13" />
<img width="2880" height="1800" alt="discord-desktop-welcome" src="https://github.com/user-attachments/assets/f72432eb-83d3-40b6-8d6a-c3f18089c3b7" />


https://github.com/user-attachments/assets/50b19094-7583-4f8c-b304-fe3ed783ca48


https://github.com/user-attachments/assets/0c654d23-f8d5-421c-91fe-4c925343efe8





## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Discord-style portfolio template with interactive server and channel sidebars
  * New sections: Welcome, About, Experience, Testimonials, Skills, Projects, Contact
  * Chat header, message/embed/divider components, and fake message input for contact
  * Animated progress bars, timeline-style experience entries, project cards with external links
  * Mobile-responsive overlay, hover/motion animations, and smooth transitions between channels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->