### PR TITLE
fix: bind Razorpay payments to proposal/escrow state (#2145)

### DIFF
--- a/backend/src/models/EscrowPayment.model.js
+++ b/backend/src/models/EscrowPayment.model.js
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose';
+
+const escrowPaymentSchema = new mongoose.Schema({
+    proposalId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Proposal',
+        required: true,
+        index: true
+    },
+    challengeId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Challenge',
+        required: true
+    },
+    payerId: {
+        type: String,
+        required: true
+    },
+    razorpayOrderId: {
+        type: String,
+        required: true,
+        unique: true,
+        index: true
+    },
+    razorpayPaymentId: {
+        type: String,
+        default: null
+    },
+    expectedAmount: {
+        type: Number,
+        required: true
+    },
+    status: {
+        type: String,
+        enum: ['pending', 'verified', 'released', 'failed'],
+        default: 'pending'
+    }
+}, { timestamps: true });
+
+export default mongoose.model('EscrowPayment', escrowPaymentSchema);

--- a/backend/src/routes/fellowships.js
+++ b/backend/src/routes/fellowships.js
@@ -458,6 +458,15 @@ router.put('/proposals/:id/status', verifyToken, asyncHandler(async (req, res) =
     if (!challenge || challenge.corporateId !== req.user.uid) {
         throw new ApiError(403, 'Only the challenge creator can update proposal status');
     }
+    if (status === 'accepted') {
+        const escrow = await EscrowPayment.findOne({
+        proposalId: req.params.id,
+        status: 'verified'
+        });
+        if (!escrow) {
+            throw new ApiError(422, 'Escrow payment must be verified before accepting a proposal');
+        }
+    }
 
     proposal.status = status;
     if (feedback) {
@@ -466,16 +475,6 @@ router.put('/proposals/:id/status', verifyToken, asyncHandler(async (req, res) =
     await proposal.save();
 
     let chatRoom = null;
-    if (status === 'accepted') {
-        const escrow = await EscrowPayment.findOne({
-            proposalId: req.params.id,
-            status: 'verified'
-        });
-        if (!escrow) {
-            throw new ApiError(422, 'Escrow payment must be verified before accepting a proposal');
-        }
-    }
-
     if (status === 'accepted') {
         challenge.status = 'in_progress';
         challenge.selectedProposalId = proposal._id;

--- a/backend/src/routes/fellowships.js
+++ b/backend/src/routes/fellowships.js
@@ -9,6 +9,7 @@ import Proposal from '../models/Proposal.model.js';
 import { FellowshipChatRoom, FellowshipMessage } from '../models/FellowshipChat.model.js';
 import { sendProposalApprovalEmail, sendVerificationEmail } from '../services/mailService.js';
 import { sanitizeMessageContent } from '../utils/sanitizeMessage.js';
+import EscrowPayment from '../models/EscrowPayment.model.js';
 
 const router = express.Router();
 
@@ -465,6 +466,16 @@ router.put('/proposals/:id/status', verifyToken, asyncHandler(async (req, res) =
     await proposal.save();
 
     let chatRoom = null;
+    if (status === 'accepted') {
+        const escrow = await EscrowPayment.findOne({
+            proposalId: req.params.id,
+            status: 'verified'
+        });
+        if (!escrow) {
+            throw new ApiError(422, 'Escrow payment must be verified before accepting a proposal');
+        }
+    }
+
     if (status === 'accepted') {
         challenge.status = 'in_progress';
         challenge.selectedProposalId = proposal._id;

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -10,6 +10,7 @@ import FellowshipProfile from '../models/FellowshipProfile.model.js';
 import { sendProposalApprovalEmail } from '../services/mailService.js';
 import { validate } from '../middleware/validate.js';
 import { createOrderSchema, verifyPaymentSchema } from '../schemas/payments.schema.js';
+import EscrowPayment from '../models/EscrowPayment.model.js';
 
 const router = express.Router();
 
@@ -61,6 +62,16 @@ router.post('/create-order', verifyToken, validate(createOrderSchema), asyncHand
         studentId: proposal.studentId,
         corporateId: challenge.corporateId
     });
+      // Persist order-to-proposal binding
+await EscrowPayment.create({
+    proposalId: proposal._id,
+    challengeId: challenge._id,
+    payerId: req.user.uid,
+    razorpayOrderId: order.id,
+    expectedAmount: Math.round(amount * 100),
+    status: 'pending'
+});
+    
 
     res.json({
         success: true,
@@ -99,6 +110,21 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
     if (!isValid) {
         throw new ApiError(400, 'Invalid payment signature');
     }
+        // Verify payment belongs to this proposal (binding check)
+    const escrow = await EscrowPayment.findOne({ razorpayOrderId: razorpay_order_id });
+    if (!escrow) {
+      throw new ApiError(400, 'Payment order not found on server');
+    }
+    if (escrow.proposalId.toString() !== proposalId) {
+      throw new ApiError(403, 'Payment does not belong to this proposal');
+    }
+    if (escrow.payerId !== req.user.uid) {
+      throw new ApiError(403, 'Payment payer mismatch');
+    }
+    if (escrow.expectedAmount !== Math.round(challenge?.price * 100)) {
+      throw new ApiError(400, 'Payment amount mismatch');
+    }
+        
 
     // Find proposal and challenge
     let proposal = await Proposal.findById(proposalId);
@@ -185,6 +211,11 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
         orderId: razorpay_order_id,
         paymentId: razorpay_payment_id,
         amount: challenge.price
+    });
+// Mark escrow as verified
+    await EscrowPayment.findByIdAndUpdate(escrow._id, {
+        status: 'verified',
+        razorpayPaymentId: razorpay_payment_id
     });
 
     res.json({

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -120,11 +120,7 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
     }
     if (escrow.payerId !== req.user.uid) {
       throw new ApiError(403, 'Payment payer mismatch');
-    }
-    if (escrow.expectedAmount !== Math.round(challenge?.price * 100)) {
-      throw new ApiError(400, 'Payment amount mismatch');
-    }
-        
+    }        
 
     // Find proposal and challenge
     let proposal = await Proposal.findById(proposalId);

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -141,6 +141,11 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
     if (proposal.status !== 'pending') {
         throw new ApiError(409, 'Proposal already processed');
     }
+    // Mark escrow as verified
+    await EscrowPayment.findByIdAndUpdate(escrow._id, {
+        status: 'verified',
+        razorpayPaymentId: razorpay_payment_id
+    });
 
     const updatedProposal = await Proposal.findOneAndUpdate(
         { _id: proposalId, status: 'pending' },
@@ -207,12 +212,7 @@ router.post('/verify-payment', verifyToken, validate(verifyPaymentSchema), async
         orderId: razorpay_order_id,
         paymentId: razorpay_payment_id,
         amount: challenge.price
-    });
-// Mark escrow as verified
-    await EscrowPayment.findByIdAndUpdate(escrow._id, {
-        status: 'verified',
-        razorpayPaymentId: razorpay_payment_id
-    });
+    }); 
 
     res.json({
         success: true,


### PR DESCRIPTION
## **User description**
## Problem
Razorpay payment verification only checked HMAC signature but did not 
verify that the payment belongs to the originating proposal/challenge.
Additionally, PUT /api/fellowship/proposals/:id/status could accept 
proposals without any verified escrow payment.

## Changes
- Added `EscrowPayment` model to persist order-to-proposal binding at order creation time
- In `verify-payment` route: validate that razorpay_order_id belongs to the requested proposalId
- In `fellowships.js`: gate proposal acceptance behind verified escrow check

## Fixes
Closes #2145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an escrow payment system with persisted escrow records and status tracking.
* **Bug Fixes / Behavior Changes**
  * Proposals cannot be accepted until associated escrow payments are verified.
  * Strengthened payment validation to ensure transactions match the proposal, payer, and expected amount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Bind proposal payments to the correct escrow before a proposal can be accepted

### What Changed
- Payment orders are now tied to a specific proposal and challenge when they are created
- Payment verification now checks that the order, payer, and amount match the proposal being paid for
- A proposal can only be marked as accepted after its escrow payment has been verified

### Impact
`✅ Fewer mismatched proposal payments`
`✅ Safer proposal acceptance`
`✅ Clearer payment rejection errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
