### PR TITLE
fix: lazy-load legal pages to prevent ad-blocker crash on startup

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,9 +52,9 @@ import FellowshipMessages from './pages/fellowship/FellowshipMessages';
 import FellowshipChat from './pages/fellowship/FellowshipChat';
 import SecuritySettings from './pages/SecuritySettings';
 import LinkedInCallback from './pages/LinkedInCallback';
-import PrivacyPolicy from './pages/PrivacyPolicy';
-import TermsOfService from './pages/TermsOfService';
-import CookiePolicy from './pages/CookiePolicy';
+const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
+const TermsOfService = lazy(() => import('./pages/TermsOfService'));
+const CookiePolicy = lazy(() => import('./pages/CookiePolicy'));
 import OpenRouterCallback from './pages/OpenRouterCallback';
 
 // Hub Imports
@@ -171,10 +171,10 @@ function AppRoutes() {
         <Route path="/auth/openrouter/callback" element={<OpenRouterCallback />} />
 
         {/* Legal Pages (Public) */}
-        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/privacy" element={<Suspense fallback={null}><PrivacyPolicy /></Suspense>} />
         <Route path="/about" element={<About />} />
-        <Route path="/terms" element={<TermsOfService />} />
-        <Route path="/cookies" element={<CookiePolicy />} />
+        <Route path="/terms" element={<Suspense fallback={null}><TermsOfService /></Suspense>} />
+        <Route path="/cookies" element={<Suspense fallback={null}><CookiePolicy /></Suspense>} />
 
         {/* Template Gallery Route (Registered at /templates) */}
         <Route path="/templates" element={<TemplateGallery />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -56,6 +56,7 @@ const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
 const TermsOfService = lazy(() => import('./pages/TermsOfService'));
 const CookiePolicy = lazy(() => import('./pages/CookiePolicy'));
 import OpenRouterCallback from './pages/OpenRouterCallback';
+import LegalPageErrorBoundary from './components/LegalPageErrorBoundary';
 
 // Hub Imports
 import ResumeHub from './pages/hubs/ResumeHub';
@@ -171,10 +172,10 @@ function AppRoutes() {
         <Route path="/auth/openrouter/callback" element={<OpenRouterCallback />} />
 
         {/* Legal Pages (Public) */}
-        <Route path="/privacy" element={<Suspense fallback={null}><PrivacyPolicy /></Suspense>} />
+        <Route path="/privacy" element={<LegalPageErrorBoundary><Suspense fallback={null}><PrivacyPolicy /></Suspense></LegalPageErrorBoundary>} />
         <Route path="/about" element={<About />} />
-        <Route path="/terms" element={<Suspense fallback={null}><TermsOfService /></Suspense>} />
-        <Route path="/cookies" element={<Suspense fallback={null}><CookiePolicy /></Suspense>} />
+        <Route path="/terms" element={<LegalPageErrorBoundary><Suspense fallback={null}><TermsOfService /></Suspense></LegalPageErrorBoundary>} />
+        <Route path="/cookies" element={<LegalPageErrorBoundary><Suspense fallback={null}><CookiePolicy /></Suspense></LegalPageErrorBoundary>} />
 
         {/* Template Gallery Route (Registered at /templates) */}
         <Route path="/templates" element={<TemplateGallery />} />

--- a/frontend/src/components/LegalPageErrorBoundary.jsx
+++ b/frontend/src/components/LegalPageErrorBoundary.jsx
@@ -1,0 +1,22 @@
+import { Component } from 'react';
+
+export default class LegalPageErrorBoundary extends Component {
+    state = { failed: false };
+
+    static getDerivedStateFromError() {
+        return { failed: true };
+    }
+
+    render() {
+        if (this.state.failed) {
+            return (
+                <div className="min-h-screen flex items-center justify-center bg-background">
+                    <p className="text-muted-foreground text-sm font-medium">
+                        This page could not be loaded. Please disable your ad-blocker and try again.
+                    </p>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}


### PR DESCRIPTION
## **User description**
## Description
  Converted `PrivacyPolicy`, `TermsOfService`, and `CookiePolicy` from eager imports to `React.lazy()` in `App.jsx`. Ad-blockers intercept
  these module requests at startup because the filenames match tracking-page filter lists, crashing the entire React module graph before
  anything renders. With lazy loading, these modules are only requested when the user navigates to the legal pages — so a blocked request
  only affects that specific page, not the whole app.

  ## Type of Change
  - [x] Bug fix

  ## Related Issue
  Fixes #2268

  ## Testing
  - [x] Tested Locally
  - [x] Unit tests pass

  ## Screenshots (MANDATORY for UI/UX changes)
  N/A — no visual or UI changes. This is a module loading fix.

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed my code
  - [x] Added comments where necessary
  - [x] Updated documentation
  - [x] No new warnings generated

  @anurag3407 please review the PR 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Legal pages (Privacy Policy, Terms of Service, Cookie Policy) now load on-demand to reduce initial bundle size.
* **Bug Fixes**
  * Added a full-screen fallback for legal pages that prompts users to disable ad-blockers and retry if the page fails to load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Prevent startup crashes caused by legal page requests being blocked**

### What Changed
- Legal pages now load only when a user opens them, instead of being loaded as soon as the app starts
- If an ad blocker blocks one of these pages, the rest of the app still loads normally
- Privacy, Terms, and Cookie pages continue to work when opened directly

### Impact
`✅ Fewer blank-screen startup crashes`
`✅ More reliable app loading with ad blockers`
`✅ Isolated failures on legal pages only`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
