### PR TITLE
feat: complete responsive obsidian vault template implementation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6651,7 +6651,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proj4": {
       "version": "2.20.8",
@@ -6813,14 +6814,6 @@
         "react": ">=16",
         "react-dom": ">=16"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "9.1.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,7 @@ const TermsOfService = lazy(() => import('./pages/TermsOfService'));
 const CookiePolicy = lazy(() => import('./pages/CookiePolicy'));
 import OpenRouterCallback from './pages/OpenRouterCallback';
 import LegalPageErrorBoundary from './components/LegalPageErrorBoundary';
+import RouteErrorBoundary from './components/RouteErrorBoundary';
 
 // Hub Imports
 import ResumeHub from './pages/hubs/ResumeHub';
@@ -178,7 +179,7 @@ function AppRoutes() {
         <Route path="/cookies" element={<LegalPageErrorBoundary><Suspense fallback={null}><CookiePolicy /></Suspense></LegalPageErrorBoundary>} />
 
         {/* Template Gallery Route (Registered at /templates) */}
-        <Route path="/templates" element={<TemplateGallery />} />
+        <Route path="/templates" element={<RouteErrorBoundary><TemplateGallery /></RouteErrorBoundary>} />
         <Route path="/templates/chatbot" element={<ChatbotPortfolio />} />
         <Route path="/templates/gamified-xp" element={<GamifiedXP />} />
         {/* Core Protected Routes */}

--- a/frontend/src/components/RouteErrorBoundary.jsx
+++ b/frontend/src/components/RouteErrorBoundary.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+class RouteErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error, errorInfo });
+    console.error('RouteErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-zinc-950 text-white p-8 flex flex-col items-center justify-center">
+          <div className="max-w-2xl w-full bg-zinc-900 border border-red-500/30 rounded-2xl p-8 shadow-2xl">
+            <h1 className="text-3xl font-bold text-red-400 mb-4">💥 Something went wrong</h1>
+            <p className="text-zinc-400 mb-6">The templates page crashed while rendering. Check the details below:</p>
+            
+            <div className="bg-zinc-950 rounded-xl p-4 mb-4 overflow-auto">
+              <h2 className="text-sm font-bold text-red-400 uppercase tracking-wider mb-2">Error</h2>
+              <pre className="text-red-300 text-sm font-mono whitespace-pre-wrap">{this.state.error?.toString()}</pre>
+            </div>
+            
+            <div className="bg-zinc-950 rounded-xl p-4 overflow-auto">
+              <h2 className="text-sm font-bold text-amber-400 uppercase tracking-wider mb-2">Component Stack</h2>
+              <pre className="text-amber-300 text-xs font-mono whitespace-pre-wrap">{this.state.errorInfo?.componentStack}</pre>
+            </div>
+
+            <button
+              onClick={() => window.location.reload()}
+              className="mt-6 px-6 py-3 bg-red-500 hover:bg-red-600 text-white rounded-xl font-semibold transition-colors"
+            >
+              Reload Page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default RouteErrorBoundary;

--- a/frontend/src/components/portfolio/templates/Liquid_Glass/index.jsx
+++ b/frontend/src/components/portfolio/templates/Liquid_Glass/index.jsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { GithubIcon, Linkedin, Twitter, Mail, ExternalLink, MapPin, Download, Star, Briefcase, User, Code2, MessageSquare, Phone, Globe } from "lucide-react";
+import { Github, Linkedin, Twitter, Mail, ExternalLink, MapPin, Download, Star, Briefcase, User, Code2, MessageSquare, Phone, Globe } from "lucide-react";
 import data from "../../../../data/dummy_data.json";
 
 // Glass card component reused throughout

--- a/frontend/src/components/portfolio/templates/Obsidian_Vault/index.jsx
+++ b/frontend/src/components/portfolio/templates/Obsidian_Vault/index.jsx
@@ -1,29 +1,588 @@
-import React from 'react';
+import React, { useRef, useEffect, useState } from 'react';
+import { motion, useScroll, useTransform } from 'framer-motion';
+import {
+  Github,
+  Linkedin,
+  Twitter,
+  Mail,
+  MapPin,
+  ExternalLink,
+  Code2,
+  Briefcase,
+  Star,
+  MessageSquare,
+  Send,
+  ChevronDown,
+  Link2,
+  FileText,
+  FolderOpen,
+  Network,
+  BookOpen,
+  Sparkles,
+} from 'lucide-react';
 import data from '../../../../data/dummy_data.json';
 
-/**
- * Obsidian Vault Portfolio Template
- * Category: Dark / Moody
- * Description: Obsidian.md-inspired dark knowledge vault. Linked notes visualization, graph view of connected projects, bidirectional links. Dark purple accents.
- */
+const fadeUp = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.6, ease: 'easeOut' } },
+};
+
+const stagger = {
+  visible: { transition: { staggerChildren: 0.1 } },
+};
+
+function GraphBackground() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    let animId;
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    const nodes = Array.from({ length: 40 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: (Math.random() - 0.5) * 0.3,
+      vy: (Math.random() - 0.5) * 0.3,
+      radius: Math.random() * 2 + 1,
+    }));
+
+    const animate = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      nodes.forEach((node) => {
+        node.x += node.vx;
+        node.y += node.vy;
+        if (node.x < 0 || node.x > canvas.width) node.vx *= -1;
+        if (node.y < 0 || node.y > canvas.height) node.vy *= -1;
+
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(168, 85, 247, 0.6)';
+        ctx.fill();
+      });
+
+      nodes.forEach((a, i) => {
+        nodes.slice(i + 1).forEach((b) => {
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < 120) {
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.strokeStyle = `rgba(168, 85, 247, ${0.15 * (1 - dist / 120)})`;
+            ctx.lineWidth = 0.5;
+            ctx.stroke();
+          }
+        });
+      });
+
+      animId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(animId);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full pointer-events-none opacity-60"
+    />
+  );
+}
+
+function VaultCard({ children, className = '', glow = false }) {
+  return (
+    <div
+      className={`relative rounded-xl border border-purple-500/20 bg-[#0d0d14]/80 backdrop-blur-sm ${
+        glow ? 'shadow-[0_0_30px_rgba(168,85,247,0.1)]' : ''
+      } ${className}`}
+    >
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-purple-500/40 to-transparent" />
+      {children}
+    </div>
+  );
+}
+
+function NoteLink({ children, icon: Icon }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded bg-purple-500/10 border border-purple-500/20 text-purple-300 text-xs font-mono">
+      {Icon && <Icon size={10} />}
+      {children}
+    </span>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="relative min-h-screen flex items-center justify-center px-6 py-24 overflow-hidden">
+      <GraphBackground />
+
+      <div className="absolute inset-0 bg-gradient-to-b from-purple-950/20 via-transparent to-[#0a0a0f]" />
+
+      <motion.div
+        className="relative z-10 max-w-4xl mx-auto text-center"
+        initial="hidden"
+        animate="visible"
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center justify-center gap-2 mb-6">
+          <span className="px-3 py-1 rounded-full bg-purple-500/10 border border-purple-500/30 text-purple-300 text-xs font-mono uppercase tracking-wider">
+            <Network size={12} className="inline mr-1.5" />
+            Knowledge Vault
+          </span>
+        </motion.div>
+
+        <motion.h1
+          variants={fadeUp}
+          className="text-5xl md:text-7xl lg:text-8xl font-bold mb-6 leading-tight"
+        >
+          <span className="text-white">{data.personal.name.split(' ')[0]}</span>{' '}
+          <span className="bg-gradient-to-r from-purple-400 via-violet-400 to-purple-500 bg-clip-text text-transparent">
+            {data.personal.name.split(' ').slice(1).join(' ')}
+          </span>
+        </motion.h1>
+
+        <motion.p variants={fadeUp} className="text-xl md:text-2xl text-gray-400 mb-4 font-light">
+          {data.personal.title}
+        </motion.p>
+
+        <motion.p variants={fadeUp} className="text-gray-500 mb-8 max-w-2xl mx-auto">
+          {data.personal.tagline}
+        </motion.p>
+
+        <motion.div variants={fadeUp} className="flex items-center justify-center gap-4 mb-12">
+          <NoteLink icon={MapPin}>{data.personal.location}</NoteLink>
+          <NoteLink icon={Briefcase}>{data.stats.yearsExperience}+ years</NoteLink>
+          <NoteLink icon={FolderOpen}>{data.stats.projectsCompleted} projects</NoteLink>
+        </motion.div>
+
+        <motion.div variants={fadeUp} className="flex flex-wrap items-center justify-center gap-4">
+          <a
+            href={`mailto:${data.socials.email}`}
+            className="px-6 py-3 rounded-lg bg-purple-600 hover:bg-purple-500 text-white font-medium transition-all hover:shadow-[0_0_20px_rgba(168,85,247,0.4)]"
+          >
+            <Mail size={16} className="inline mr-2" />
+            Get in Touch
+          </a>
+          <a
+            href={data.socials.github}
+            target="_blank"
+            rel="noreferrer"
+            className="px-6 py-3 rounded-lg border border-purple-500/30 hover:border-purple-500/60 text-purple-300 hover:text-white transition-all"
+          >
+            <Github size={16} className="inline mr-2" />
+            View Code
+          </a>
+        </motion.div>
+
+        <motion.div
+          variants={fadeUp}
+          className="mt-16 animate-bounce"
+        >
+          <ChevronDown size={24} className="text-purple-400/60 mx-auto" />
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}
+
+function About() {
+  return (
+    <section className="relative px-6 py-24">
+      <motion.div
+        className="max-w-5xl mx-auto"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center gap-3 mb-12">
+          <BookOpen size={20} className="text-purple-400" />
+          <h2 className="text-3xl font-bold text-white">About</h2>
+          <div className="flex-1 h-px bg-gradient-to-r from-purple-500/40 to-transparent" />
+        </motion.div>
+
+        <motion.div variants={fadeUp}>
+          <VaultCard className="p-8 md:p-10" glow>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              <div className="md:col-span-1 flex flex-col items-center md:items-start">
+                <div className="relative mb-4">
+                  <div className="absolute inset-0 rounded-full bg-purple-500/30 blur-xl" />
+                  <img
+                    src={data.personal.avatar}
+                    alt={data.personal.name}
+                    className="relative w-32 h-32 rounded-full object-cover border-2 border-purple-500/40"
+                  />
+                </div>
+                <h3 className="text-xl font-bold text-white mb-1">{data.personal.name}</h3>
+                <p className="text-purple-400 text-sm mb-3">{data.personal.title}</p>
+                <div className="flex items-center gap-1.5 text-gray-500 text-sm">
+                  <MapPin size={14} />
+                  {data.personal.location}
+                </div>
+              </div>
+
+              <div className="md:col-span-2">
+                <p className="text-gray-300 leading-relaxed text-lg mb-6">
+                  {data.personal.bio}
+                </p>
+
+                <div className="grid grid-cols-3 gap-4">
+                  {[
+                    { value: `${data.stats.yearsExperience}+`, label: 'Years', icon: Briefcase },
+                    { value: `${data.stats.projectsCompleted}+`, label: 'Projects', icon: FolderOpen },
+                    { value: `${data.stats.happyClients}+`, label: 'Clients', icon: Star },
+                  ].map(({ value, label, icon: Icon }) => (
+                    <div
+                      key={label}
+                      className="p-4 rounded-lg bg-purple-500/5 border border-purple-500/10 text-center"
+                    >
+                      <Icon size={18} className="text-purple-400 mx-auto mb-2" />
+                      <div className="text-2xl font-bold text-white">{value}</div>
+                      <div className="text-gray-500 text-xs uppercase tracking-wider">{label}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </VaultCard>
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}
+
+function Skills() {
+  const categories = [...new Set(data.skills.map((s) => s.category))];
+
+  return (
+    <section className="relative px-6 py-24">
+      <motion.div
+        className="max-w-5xl mx-auto"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center gap-3 mb-12">
+          <Code2 size={20} className="text-purple-400" />
+          <h2 className="text-3xl font-bold text-white">Skills</h2>
+          <div className="flex-1 h-px bg-gradient-to-r from-purple-500/40 to-transparent" />
+        </motion.div>
+
+        <motion.div
+          variants={stagger}
+          className="grid grid-cols-1 md:grid-cols-2 gap-6"
+        >
+          {categories.map((cat) => (
+            <motion.div key={cat} variants={fadeUp}>
+              <VaultCard className="p-6">
+                <h3 className="text-purple-400 text-xs font-mono uppercase tracking-widest mb-5">
+                  [[{cat}]]
+                </h3>
+                <div className="space-y-4">
+                  {data.skills
+                    .filter((s) => s.category === cat)
+                    .map((skill) => (
+                      <div key={skill.name}>
+                        <div className="flex justify-between items-center mb-1.5">
+                          <span className="text-gray-200 text-sm font-medium">{skill.name}</span>
+                          <span className="text-purple-400 text-xs font-mono">{skill.level}%</span>
+                        </div>
+                        <div className="h-1.5 rounded-full bg-purple-500/10 overflow-hidden">
+                          <motion.div
+                            className="h-full rounded-full bg-gradient-to-r from-purple-600 to-violet-500"
+                            initial={{ width: 0 }}
+                            whileInView={{ width: `${skill.level}%` }}
+                            transition={{ duration: 1, ease: 'easeOut' }}
+                            viewport={{ once: true }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              </VaultCard>
+            </motion.div>
+          ))}
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}
+
+function Projects() {
+  return (
+    <section className="relative px-6 py-24">
+      <motion.div
+        className="max-w-6xl mx-auto"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center gap-3 mb-12">
+          <FolderOpen size={20} className="text-purple-400" />
+          <h2 className="text-3xl font-bold text-white">Projects</h2>
+          <div className="flex-1 h-px bg-gradient-to-r from-purple-500/40 to-transparent" />
+        </motion.div>
+
+        <motion.div
+          variants={stagger}
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        >
+          {(data.projects || []).map((project, index) => (
+            <motion.div key={index} variants={fadeUp}>
+              <VaultCard className="overflow-hidden h-full flex flex-col group hover:border-purple-500/40 transition-all">
+                <div className="relative overflow-hidden">
+                  <img
+                    src={project.image}
+                    alt={project.title}
+                    className="w-full h-44 object-cover group-hover:scale-105 transition-transform duration-500"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-[#0d0d14] via-transparent to-transparent" />
+                  <div className="absolute top-3 right-3 flex gap-2">
+                    <a
+                      href={project.liveUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="p-2 rounded-lg bg-purple-500/20 border border-purple-500/30 text-purple-300 hover:bg-purple-500/40 transition-all"
+                    >
+                      <ExternalLink size={14} />
+                    </a>
+                    <a
+                      href={project.githubUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="p-2 rounded-lg bg-purple-500/20 border border-purple-500/30 text-purple-300 hover:bg-purple-500/40 transition-all"
+                    >
+                      <Github size={14} />
+                    </a>
+                  </div>
+                </div>
+
+                <div className="p-5 flex flex-col flex-1">
+                  <h3 className="text-white font-bold text-lg mb-2 flex items-center gap-2">
+                    <FileText size={14} className="text-purple-400" />
+                    {project.title}
+                  </h3>
+                  <p className="text-gray-400 text-sm leading-relaxed mb-4 flex-1">
+                    {project.description}
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {project.techStack.map((tech) => (
+                      <NoteLink key={tech}>{tech}</NoteLink>
+                    ))}
+                  </div>
+                </div>
+              </VaultCard>
+            </motion.div>
+          ))}
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}
+
+function Experience() {
+  return (
+    <section className="relative px-6 py-24">
+      <motion.div
+        className="max-w-4xl mx-auto"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center gap-3 mb-12">
+          <Briefcase size={20} className="text-purple-400" />
+          <h2 className="text-3xl font-bold text-white">Experience</h2>
+          <div className="flex-1 h-px bg-gradient-to-r from-purple-500/40 to-transparent" />
+        </motion.div>
+
+        <div className="relative">
+          <div className="absolute left-6 top-0 bottom-0 w-px bg-gradient-to-b from-purple-500/40 via-purple-500/20 to-transparent hidden md:block" />
+
+          <motion.div variants={stagger} className="space-y-8">
+            {(data.experience || []).map((exp, index) => (
+              <motion.div key={index} variants={fadeUp} className="md:pl-16 relative">
+                <div className="absolute left-4 top-6 w-4 h-4 rounded-full bg-purple-500 border-4 border-[#0a0a0f] hidden md:block shadow-[0_0_10px_rgba(168,85,247,0.5)]" />
+
+                <VaultCard className="p-6">
+                  <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
+                    <div>
+                      <h3 className="text-white font-bold text-lg">{exp.role}</h3>
+                      <p className="text-purple-400 text-sm font-mono">{exp.company}</p>
+                    </div>
+                    <span className="px-3 py-1 rounded-lg bg-purple-500/10 border border-purple-500/20 text-purple-300 text-xs font-mono whitespace-nowrap">
+                      {exp.period}
+                    </span>
+                  </div>
+                  <p className="text-gray-400 text-sm leading-relaxed">{exp.description}</p>
+                </VaultCard>
+              </motion.div>
+            ))}
+          </motion.div>
+        </div>
+      </motion.div>
+    </section>
+  );
+}
+
+function Testimonials() {
+  return (
+    <section className="relative px-6 py-24">
+      <motion.div
+        className="max-w-5xl mx-auto"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center gap-3 mb-12">
+          <MessageSquare size={20} className="text-purple-400" />
+          <h2 className="text-3xl font-bold text-white">Testimonials</h2>
+          <div className="flex-1 h-px bg-gradient-to-r from-purple-500/40 to-transparent" />
+        </motion.div>
+
+        <motion.div
+          variants={stagger}
+          className="grid grid-cols-1 md:grid-cols-2 gap-6"
+        >
+          {(data.testimonials || []).map((t, index) => (
+            <motion.div key={index} variants={fadeUp}>
+              <VaultCard className="p-6 h-full flex flex-col">
+                <Sparkles size={20} className="text-purple-400 mb-4" />
+                <p className="text-gray-300 text-sm leading-relaxed flex-1 mb-6 italic">
+                  "{t.text}"
+                </p>
+                <div className="flex items-center gap-3 pt-4 border-t border-purple-500/10">
+                  <img
+                    src={t.avatar}
+                    alt={t.name}
+                    className="w-10 h-10 rounded-full object-cover border border-purple-500/30"
+                  />
+                  <div>
+                    <div className="text-white font-semibold text-sm">{t.name}</div>
+                    <div className="text-purple-400 text-xs font-mono">{t.role}</div>
+                  </div>
+                </div>
+              </VaultCard>
+            </motion.div>
+          ))}
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}
+
+function Contact() {
+  return (
+    <section className="relative px-6 py-24">
+      <motion.div
+        className="max-w-3xl mx-auto text-center"
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={stagger}
+      >
+        <motion.div variants={fadeUp} className="flex items-center justify-center gap-3 mb-6">
+          <Send size={20} className="text-purple-400" />
+          <h2 className="text-3xl font-bold text-white">Contact</h2>
+        </motion.div>
+
+        <motion.p variants={fadeUp} className="text-gray-400 mb-10">
+          Have a project in mind? Let's connect and build something amazing together.
+        </motion.p>
+
+        <motion.div variants={fadeUp}>
+          <VaultCard className="p-8" glow>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+              <input
+                type="text"
+                placeholder="Your Name"
+                className="w-full px-4 py-3 rounded-lg bg-purple-500/5 border border-purple-500/20 text-white placeholder-gray-500 text-sm focus:outline-none focus:border-purple-500/50 transition-all"
+              />
+              <input
+                type="email"
+                placeholder="Your Email"
+                className="w-full px-4 py-3 rounded-lg bg-purple-500/5 border border-purple-500/20 text-white placeholder-gray-500 text-sm focus:outline-none focus:border-purple-500/50 transition-all"
+              />
+            </div>
+            <input
+              type="text"
+              placeholder="Subject"
+              className="w-full px-4 py-3 rounded-lg bg-purple-500/5 border border-purple-500/20 text-white placeholder-gray-500 text-sm focus:outline-none focus:border-purple-500/50 transition-all mb-4"
+            />
+            <textarea
+              rows={4}
+              placeholder="Your Message"
+              className="w-full px-4 py-3 rounded-lg bg-purple-500/5 border border-purple-500/20 text-white placeholder-gray-500 text-sm focus:outline-none focus:border-purple-500/50 transition-all mb-4 resize-none"
+            />
+            <button className="w-full py-3 rounded-lg bg-purple-600 hover:bg-purple-500 text-white font-medium transition-all hover:shadow-[0_0_20px_rgba(168,85,247,0.4)]">
+              <Send size={16} className="inline mr-2" />
+              Send Message
+            </button>
+          </VaultCard>
+        </motion.div>
+
+        <motion.div variants={fadeUp} className="flex justify-center gap-4 mt-10">
+          {[
+            { icon: Github, href: data.socials.github, label: 'GitHub' },
+            { icon: Linkedin, href: data.socials.linkedin, label: 'LinkedIn' },
+            { icon: Twitter, href: data.socials.twitter, label: 'Twitter' },
+            { icon: Mail, href: `mailto:${data.socials.email}`, label: 'Email' },
+          ].map(({ icon: Icon, href, label }) => (
+            <a
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={label}
+              className="w-12 h-12 flex items-center justify-center rounded-lg bg-purple-500/10 border border-purple-500/20 text-purple-300 hover:bg-purple-500/20 hover:border-purple-500/40 hover:text-white transition-all"
+            >
+              <Icon size={18} />
+            </a>
+          ))}
+        </motion.div>
+
+        <motion.p variants={fadeUp} className="text-gray-600 text-xs mt-10 font-mono">
+          © {new Date().getFullYear()} {data.personal.name}. All rights reserved.
+        </motion.p>
+      </motion.div>
+    </section>
+  );
+}
+
 export default function ObsidianVault() {
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-8 font-sans">
-      <div className="max-w-3xl w-full text-center">
-        <h1 className="text-5xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
-          {data.personal.name}
-        </h1>
-        <p className="text-xl md:text-2xl text-gray-400 mb-8">{data.personal.title}</p>
-        <div className="p-8 border-2 border-dashed border-cyan-500/40 rounded-2xl bg-gray-900/50 backdrop-blur-sm">
-          <span className="inline-block px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-400 text-xs font-bold uppercase tracking-widest mb-4">
-            Dark / Moody
-          </span>
-          <h2 className="text-2xl font-bold text-gray-200 mb-3">Obsidian Vault Template</h2>
-          <p className="text-gray-400 mb-6 leading-relaxed">
-            Obsidian.md-inspired dark knowledge vault. Linked notes visualization, graph view of connected projects, bidirectional links. Dark purple accents.
-          </p>
-          <p className="text-cyan-400 font-semibold">Open an issue to contribute and build this template!</p>
-        </div>
+    <div className="min-h-screen bg-[#0a0a0f] text-white font-sans relative overflow-x-hidden">
+      <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute top-0 left-1/4 w-[600px] h-[600px] rounded-full bg-purple-900/10 blur-[150px]" />
+        <div className="absolute bottom-0 right-1/4 w-[500px] h-[500px] rounded-full bg-violet-900/10 blur-[150px]" />
+      </div>
+
+      <div className="relative z-10">
+        <Hero />
+        <About />
+        <Skills />
+        <Projects />
+        <Experience />
+        <Testimonials />
+        <Contact />
       </div>
     </div>
   );

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -7,7 +7,6 @@ import { Moon, Sun, ChevronDown, Check, Eye, Star } from "lucide-react";
 import HolographicAbout from "../components/portfolio/templates/Holographic/About";
 import CulinaryAbout from "../components/portfolio/templates/Culinary_Restaurant/About";
 import TechStartupHero from "../components/portfolio/templates/Tech_Startup/Hero";
-import ArchitectureBlueprintHero from "../components/portfolio/templates/Architecture_Blueprint/Hero";
 import GeometricShapesAbout from "../components/portfolio/templates/Geometric_Shapes/About";
 import GeometricShapesHero from "../components/portfolio/templates/Geometric_Shapes/Hero";
 import LiquidGlass from "../components/portfolio/templates/Liquid_Glass/index";
@@ -18,7 +17,6 @@ import { X } from "lucide-react";
 // import ChooseAdventurePortfolio from "../components/portfolio/templates/Choose_Adventure/index";
 // import RetroProjects from "../components/portfolio/templates/2D_Retro_8bit/Projects";
 // import FantasyRPGProjects from "../components/portfolio/templates/Fantasy_RPG/Projects";
-import GraffitiHero from "../components/portfolio/templates/Graffiti_StreetArt/Hero";
 
 
 function FilterSelect({ value, onChange, options, className = "" }) {
@@ -134,7 +132,17 @@ function TemplateCard({ template, onUse }) {
             rest: { scale: 1, transition: { duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] } },
             hover: { scale: 1.08, transition: { type: "spring", stiffness: 200, damping: 25 } },
           }}
+          onError={(e) => {
+            e.target.style.display = 'none';
+            e.target.nextSibling.style.display = 'flex';
+          }}
         />
+        <div 
+          className="absolute inset-0 bg-gradient-to-br from-cyan-500/20 via-purple-500/20 to-pink-500/20 items-center justify-center"
+          style={{ display: 'none' }}
+        >
+          <span className="text-white/60 text-sm font-medium">{template.title}</span>
+        </div>
         <motion.div
           className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent pointer-events-none"
           variants={{ rest: { opacity: 0 }, hover: { opacity: 1 } }}
@@ -469,8 +477,12 @@ export default function TemplateGallery() {
       {/* <ChooseAdventurePortfolio /> */}
       {/* <RetroProjects /> */}
       {/* <FantasyRPGProjects /> */}
-      {/* <GraffitiHero /> */}
 
+      <TemplatePreviewModal
+        templateId={previewTemplateId}
+        isOpen={!!previewTemplateId}
+        onClose={() => setPreviewTemplateId(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 1. Blank Screen Fix — TemplateGallery.jsx
Root cause: Liquid_Glass/index.jsx imported GithubIcon from lucide-react but used <Github> (wrong name) in 4 places, causing a ReferenceError crash.
Fixes:
- Liquid_Glass/index.jsx:2 — Changed GithubIcon → Github in import
- TemplateGallery.jsx — Added missing <TemplatePreviewModal> render (was defined but never rendered in JSX — Preview button was dead)
- TemplateGallery.jsx — Removed unused imports (ArchitectureBlueprintHero, GraffitiHero)
- TemplateGallery.jsx — Added image onError fallback so missing template thumbnails show a gradient placeholder instead of blank space
- App.jsx — Wrapped /templates route with RouteErrorBoundary for future error visibility
- components/RouteErrorBoundary.jsx — New file, catches render crashes and displays the error/component stack

## 2. Obsidian Vault Template — Obsidian_Vault/index.jsx
New file — Replaced the 30-line placeholder with a complete 450+ line portfolio template.
All 7 required sections:
- Hero — Animated canvas graph visualization, gradient name, title, location/exp tags, CTA buttons
- About — Vault card with avatar, bio, stats grid (years/projects/clients)
- Skills — Skills grouped by category with animated purple gradient progress bars
- Projects — Card grid with hover scale, live/GitHub icon buttons, tech stack note-links
- Experience — Timeline with purple dot markers, period badges, company name
- Testimonials — Quote cards with avatar, role, italic testimonial text
- Contact — Form with inputs, social links row, copyright footer
Design: Dark vault (#0a0a0f), purple accents, vault cards with top glow border, graph background, [[category]] note-style headings, all data from dummy_data.json.

## 3. Build Verification
All changes compile successfully (npm run build passes without errors).

<img width="1908" height="944" alt="Screenshot 2026-05-29 005209" src="https://github.com/user-attachments/assets/a8aa699b-853b-464c-ad88-e1f4609c47e1" />
<img width="1909" height="943" alt="Screenshot 2026-05-29 005228" src="https://github.com/user-attachments/assets/988cef2a-b672-4582-88b1-51388909aac1" />
<img width="1912" height="939" alt="Screenshot 2026-05-29 005240" src="https://github.com/user-attachments/assets/bcd5bc57-6b3e-4ebb-9fc6-ab27cccbd21e" />
<img width="1908" height="942" alt="Screenshot 2026-05-29 005250" src="https://github.com/user-attachments/assets/c34054c0-c8c9-4f03-b45c-eab4513c29b6" />
<img width="1909" height="942" alt="Screenshot 2026-05-29 005301" src="https://github.com/user-attachments/assets/87b90863-9d7a-45e4-aecc-2f342e3fe78b" />
<img width="1910" height="939" alt="Screenshot 2026-05-29 005311" src="https://github.com/user-attachments/assets/d87f1082-7bf0-4582-be4c-f9c13fd2e55c" />
<img width="1908" height="941" alt="Screenshot 2026-05-29 005322" src="https://github.com/user-attachments/assets/c4100c06-3c00-4a18-964e-594396ade30c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Obsidian Vault template with animated sections and dynamic particle background
  * Added template preview modal to the gallery for enhanced exploration

* **Bug Fixes**
  * Implemented image fallback display in template gallery when preview images fail to load

* **Chores**
  * Added error boundary protection for template routes with automatic page reload option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->