### PR TITLE
fix: resolve JSX syntax errors causing Vite build failure

### DIFF
--- a/frontend/src/components/community/PostsFeed.jsx
+++ b/frontend/src/components/community/PostsFeed.jsx
@@ -466,7 +466,7 @@ const handleCreatePost = async (postData) => {
               })}
 
               {hasMore && (
-                <button
+                <motion.button
                   onClick={handleLoadMore}
                   className="w-full py-3 text-primary hover:text-primary/80 font-medium cursor-pointer"
                 >

--- a/frontend/src/components/portfolio/templates/Midnight_Gradient/index.jsx
+++ b/frontend/src/components/portfolio/templates/Midnight_Gradient/index.jsx
@@ -238,7 +238,7 @@ function About() {
             </p>
             <div className="flex items-center gap-2.5 text-gray-400 text-sm">
               <MapPin size={16} className="text-cyan-400" />
-              <span>Based in {data.personal.location}
+              <span>Based in {data.personal.location}</span>
             </div>
           </GlowingCard>
 

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -482,7 +482,7 @@ export default function TemplateGallery() {
         <div className="overflow-hidden rounded-2xl border border-border">
           <MidnightGradient />
         </div>
-        <div/>
+        </div>
       {/* Playing Cards Theme */}
       <div className="mt-12">
         <div className="mb-4 flex items-center gap-3 px-1">
@@ -532,6 +532,6 @@ export default function TemplateGallery() {
         onClose={() => setPreviewTemplateId(null)}
       />
       </div>
-    </div>
+    
   );
 }

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -17,6 +17,7 @@ import MidnightGradient from "../components/portfolio/templates/Midnight_Gradien
 import PlayingCardsPortfolio from "../components/portfolio/templates/Playing_Cards";
 import Navbar from '../components/Navbar'
 import { X } from "lucide-react";
+import CherryBlossom from "../components/portfolio/templates/Cherry_Blossom/index";
 // import Hero from "../components/portfolio/templates/Holographic/Hero";
 // import ChooseAdventurePortfolio from "../components/portfolio/templates/Choose_Adventure/index";
 // import RetroProjects from "../components/portfolio/templates/2D_Retro_8bit/Projects";
@@ -480,7 +481,8 @@ export default function TemplateGallery() {
         </div>
         <div className="overflow-hidden rounded-2xl border border-border">
           <MidnightGradient />
-
+        </div>
+        <div/>
       {/* Playing Cards Theme */}
       <div className="mt-12">
         <div className="mb-4 flex items-center gap-3 px-1">
@@ -529,6 +531,7 @@ export default function TemplateGallery() {
         isOpen={!!previewTemplateId}
         onClose={() => setPreviewTemplateId(null)}
       />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description
Repairs three JSX syntax errors that were causing Vite to throw 
pre-transform errors on startup, preventing the entire frontend 
from loading.

## Type of Change
- [x] Bug fix


## Related Issue
Fixes #2412 

## Testing

- [x] Tested Locally

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Cherry Blossom portfolio template to the gallery

* **Bug Fixes**
  * Fixed markup in the Midnight Gradient About section to correct rendering
  * Resolved layout/container issues in the template gallery so previews and modals render correctly

* **Style**
  * Upgraded the "Load more posts" control to a smoother animated button

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->