### PR TITLE
UI/tabs component

### DIFF
--- a/frontend/src/components/Tabs.jsx
+++ b/frontend/src/components/Tabs.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+import { cn } from '../lib/utils'
+
+const MotionSpan = motion.span
+
+function renderIcon(icon, isActive) {
+  if (!icon) return null
+
+  if (React.isValidElement(icon)) {
+    return React.cloneElement(icon, {
+      className: cn('h-4 w-4 shrink-0', icon.props.className),
+      'aria-hidden': true,
+    })
+  }
+
+  const Icon = icon
+  return <Icon className="h-4 w-4 shrink-0" aria-hidden="true" data-active={isActive} />
+}
+
+export default function Tabs({ tabs = [], activeTab, onChange }) {
+  return (
+    <div className="w-full overflow-x-auto border-b border-border">
+      <div className="flex min-w-max items-center" role="tablist">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTab
+
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`${tab.id}-panel`}
+              onClick={() => onChange?.(tab.id)}
+              className={cn(
+                'relative flex h-11 items-center gap-2 whitespace-nowrap px-4 text-sm font-medium transition-colors',
+                'text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                isActive && 'text-foreground'
+              )}
+            >
+              {renderIcon(tab.icon, isActive)}
+              <span>{tab.label}</span>
+              {isActive && (
+                <MotionSpan
+                  layoutId="tabs-active-indicator"
+                  className="absolute inset-x-0 bottom-[-1px] h-0.5 rounded-full bg-primary"
+                  transition={{ type: 'spring', stiffness: 420, damping: 32 }}
+                />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description
Added a reusable `Tabs` component for shared tab navigation across areas like the portfolio editor, GitHub dashboard, and other UI sections. The component supports icon + text tabs, controlled active state, horizontal scrolling on smaller screens, and an animated active bottom indicator.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #760 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [ ] Attached Screenshots or Screen Recordings (showing before and after)

Not attached yet. The component has been created but is not currently rendered on any page, so there is no visible before/after screen in the app UI yet.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced GitHub Dashboard with activity metrics including current streak and repository stars
  * Added match score badges to job listings showing compatibility with your resume

* **Bug Fixes**
  * Improved profile and stats loading resilience—failures no longer break the entire page
  * Fixed template gallery layout structure

* **UI Components**
  * Added new Tabs and Select dropdown components for enhanced interface interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->