### PR TITLE
fix: cancel interview speech synthesis on cleanup

### DIFF
--- a/frontend/src/pages/InterviewPrep.jsx
+++ b/frontend/src/pages/InterviewPrep.jsx
@@ -322,10 +322,11 @@ export default function InterviewPrep() {
   }, []);
 
   useEffect(() => {
+    const synth = synthRef.current;
     if (step === 'interview') initializeMedia();
     return () => {
       cleanupMedia();
-      if (synthRef.current) synthRef.current.cancel();
+      if (synth) synth.cancel();
     };
   }, [step]);
 


### PR DESCRIPTION
## Summary
- Capture the speech synthesis reference inside the InterviewPrep cleanup effect
- Cancel the captured synthesizer during cleanup to avoid stale ref access

## Verification
- npm run build

Closes #2227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio cleanup behavior when navigating between interview prep steps to ensure smooth speech playback transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->