### PR TITLE
fix(dashboard): avoid unsafe return in finally

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -144,9 +144,9 @@ export default function Dashboard() {
       setFetchError('Failed to load your dashboard. Please try again.')
       toast.error('Failed to load dashboard data')
     } finally {
-      if (!canUpdate()) return
-
-      setLoading(false)
+      if (canUpdate()) {
+        setLoading(false)
+      }
     }
   }
 
@@ -595,4 +595,3 @@ export default function Dashboard() {
     </div>
   )
 }
-


### PR DESCRIPTION
## What
Fixes #2457 by removing the unsafe `return` from the `Dashboard.jsx` `finally` block. The dashboard still avoids setting state after unmount, but it no longer uses control flow that can suppress async errors or trigger `no-unsafe-finally`.

## How
Changed the `finally` block from `if (!canUpdate()) return; setLoading(false);` to a positive guard: `if (canUpdate()) { setLoading(false); }`.

## Testing
- `cd frontend && npm exec -- eslint src/pages/Dashboard.jsx` passes with 0 errors; only existing warnings remain.
- `cd frontend && npm ci` completed successfully with 0 vulnerabilities.
- `cd frontend && npm run build` passes.
- `cd backend && npm test` passes: 96 tests.
- `git diff --check` passes.

## Risks / Notes
No UI change; screenshots: N/A. Full `cd frontend && npm run lint` still fails on unrelated existing lint errors in other files; this PR removes the Dashboard `no-unsafe-finally` error it targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing unnecessary loading state updates that could occur after component unmount or stale requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->