### PR TITLE
fix(frontend): remove unused cabe typo dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "@tabler/icons-react": "^3.36.1",
     "@tailwindcss/vite": "^4.1.18",
     "@xyflow/react": "^12.10.2",
-    "cabe": "^1.0.1",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
Remove the unused `cabe` typo package from `frontend/package.json`; `cobe` remains the 3D globe dependency.

## Related issue
Fixes #2352