### PR TITLE
[Bug]: Frontend build fails due to syntax errors in LinkedInCallback and portfolio template components

### DIFF
--- a/frontend/src/pages/LinkedInCallback.jsx
+++ b/frontend/src/pages/LinkedInCallback.jsx
@@ -46,15 +46,16 @@ export default function LinkedInCallback() {
             try {
                 setStatus('Completing sign-in...')
 
-                const apiBase = import.meta.env.VITE_API_URL || '/api'
-                const resp = await fetch(`${apiBase}/auth/linkedin/token?code=${encodeURIComponent(code)}`)
-                if (!resp.ok) {
-                    const body = await resp.json().catch(() => ({}))
-                    throw new Error(body.error || 'Token exchange failed')
-                }
-                const { token, isNew } = await resp.json()
+                // Exchange the one-time code for the Firebase custom token (never exposed in URL)
+                const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:5001'
+                const exchangeRes = await fetch(`${apiUrl}/api/auth/linkedin/token/${code}`)
+                const exchangeData = await exchangeRes.json()
 
-                await signInWithCustomToken(auth, token)
+                if (!exchangeRes.ok || !exchangeData.token) {
+                    throw new Error(exchangeData.error || 'Failed to retrieve token')
+                }
+
+                await signInWithCustomToken(auth, exchangeData.token)
                 
                 // Fetch two-factor status to prevent 2FA bypass
                 const tfaStatus = await twoFactorApi.getStatus()
@@ -73,7 +74,7 @@ export default function LinkedInCallback() {
         }
 
         handleCallback()
-    }, [searchParams, navigate]) // Added dependencies
+    }, [])
 
     const handleTotpSubmit = async (e) => {
         e.preventDefault()


### PR DESCRIPTION
Fix #2254

Changes:
- Remove duplicate API call and premature signInWithCustomToken in LinkedInCallback.jsx
- Fix duplicate const buildPostData declaration causing SyntaxError in PostEditor.jsx

Files fixed:
- frontend/src/pages/LinkedInCallback.jsx
- src/components/community/PostEditor.jsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LinkedIn OAuth authentication with improved token validation and explicit error handling
  * Strengthened the OAuth callback flow to ensure tokens are properly validated before sign-in
  * Improved reliability and error resilience of the LinkedIn login process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->