### PR TITLE
fix: remove redundant 'cabe' typo dependency from package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "@tabler/icons-react": "^3.36.1",
     "@tailwindcss/vite": "^4.1.18",
     "@xyflow/react": "^12.10.2",
-    "cabe": "^1.0.1",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Fixes #2352

Removes the redundant \cabe\ dependency which is a typo of \cobe\ (both were listed). \cobe\ is the correct 3D globe library; \cabe\ adds unnecessary bloat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend dependency management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->