### PR TITLE
feat(portfolio): implement ZenQuote section for Minimalist White theme

### DIFF
--- a/frontend/src/components/portfolio/templates/Minimalist_White/ZenQuote.jsx
+++ b/frontend/src/components/portfolio/templates/Minimalist_White/ZenQuote.jsx
@@ -1,10 +1,33 @@
 import React from 'react';
+import { motion } from 'framer-motion';
+import { Quote } from 'lucide-react';
 
 export default function ZenQuote() {
   return (
-    <div className="w-full min-h-[400px] flex items-center justify-center border-2 border-dashed border-gray-300 rounded-xl p-8">
-      <h2 className="text-2xl font-bold text-gray-500">Minimalist_White Theme - ZenQuote Section</h2>
-      <p className="mt-4 text-gray-400">Implementation pending. Open an issue to contribute!</p>
-    </div>
+    <section className="w-full py-24 md:py-32 bg-white flex items-center justify-center px-6">
+      <motion.div 
+        initial={{ opacity: 0, y: 30 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-50px" }}
+        transition={{ duration: 1, ease: "easeOut" }}
+        className="max-w-4xl mx-auto flex flex-col items-center text-center space-y-10"
+      >
+        {/* Subtle, thin quotation mark */}
+        <Quote size={48} strokeWidth={1} className="text-slate-200" />
+        
+        {/* The Quote */}
+        <h2 className="text-3xl md:text-5xl lg:text-6xl font-light text-slate-800 leading-snug md:leading-tight tracking-tight">
+          "Simplicity is the ultimate sophistication."
+        </h2>
+        
+        {/* The Author & Separator */}
+        <div className="flex flex-col items-center gap-6 mt-4">
+          <div className="w-12 h-[1px] bg-slate-300"></div>
+          <p className="text-xs md:text-sm uppercase tracking-[0.3em] text-slate-400 font-medium">
+            Leonardo da Vinci
+          </p>
+        </div>
+      </motion.div>
+    </section>
   );
 }

--- a/frontend/src/components/portfolio/templates/Minimalist_White/ZenQuote.jsx
+++ b/frontend/src/components/portfolio/templates/Minimalist_White/ZenQuote.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
 import { motion } from 'framer-motion';
 import { Quote } from 'lucide-react';
 
-export default function ZenQuote() {
+export default function ZenQuote({ 
+  quote = "Simplicity is the ultimate sophistication.", 
+  author = "Leonardo da Vinci" 
+}) {
   return (
     <section className="w-full py-24 md:py-32 bg-white flex items-center justify-center px-6">
       <motion.div 
@@ -12,20 +14,20 @@ export default function ZenQuote() {
         transition={{ duration: 1, ease: "easeOut" }}
         className="max-w-4xl mx-auto flex flex-col items-center text-center space-y-10"
       >
-        {/* Subtle, thin quotation mark */}
-        <Quote size={48} strokeWidth={1} className="text-slate-200" />
+        {/* Subtle, thin quotation mark (hidden from screen readers) */}
+        <Quote size={48} strokeWidth={1} className="text-slate-200" aria-hidden="true" />
         
         {/* The Quote */}
-        <h2 className="text-3xl md:text-5xl lg:text-6xl font-light text-slate-800 leading-snug md:leading-tight tracking-tight">
-          "Simplicity is the ultimate sophistication."
-        </h2>
+        <blockquote className="text-3xl md:text-5xl lg:text-6xl font-light text-slate-800 leading-snug md:leading-tight tracking-tight">
+          "{quote}"
+        </blockquote>
         
         {/* The Author & Separator */}
         <div className="flex flex-col items-center gap-6 mt-4">
           <div className="w-12 h-[1px] bg-slate-300"></div>
-          <p className="text-xs md:text-sm uppercase tracking-[0.3em] text-slate-400 font-medium">
-            Leonardo da Vinci
-          </p>
+          <cite className="text-xs md:text-sm uppercase tracking-[0.3em] text-slate-400 font-medium not-italic">
+            {author}
+          </cite>
         </div>
       </motion.div>
     </section>


### PR DESCRIPTION
## Description
Implemented the "ZenQuote" section for the Minimalist White portfolio template. The component is built strictly using React, Tailwind CSS, `lucide-react` (for the Quote icon), and `framer-motion` (for a smooth fade-in reveal). The design strictly adheres to the minimalist aesthetic with extensive whitespace, ultra-light elegant typography, and a subtle separator.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #1335 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
<img width="1919" height="732" alt="image" src="https://github.com/user-attachments/assets/f1d723ca-708a-49b3-abce-c18a47dd1cbb" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portfolio quote sections transformed into animated, centered quote blocks with smooth entrance animation and refined visual styling.
  * Decorative quote icon, author attribution, and clean separators improve readability.
  * Quote text and author can now be customized (with sensible defaults) for each portfolio.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->