### PR TITLE
feat: Add GitHub Profile inspired portfolio theme

### DIFF
--- a/frontend/src/components/portfolio/templates/GitHubProfileTheme.css
+++ b/frontend/src/components/portfolio/templates/GitHubProfileTheme.css
@@ -1,0 +1,191 @@
+/* ── LAYOUT ── */
+.github-profile-theme {
+  display: flex;
+  gap: 24px;
+  background-color: #0d1117;
+  color: #c9d1d9;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+    Arial, sans-serif;
+  min-height: 100vh;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+/* ── SIDEBAR ── */
+.gp-sidebar {
+  width: 260px;
+  flex-shrink: 0;
+}
+
+.gp-avatar {
+  width: 100%;
+  border-radius: 50%;
+  border: 2px solid #30363d;
+  margin-bottom: 16px;
+}
+
+.gp-name {
+  font-size: 24px;
+  font-weight: 600;
+  color: #f0f6fc;
+  margin: 0 0 4px;
+}
+
+.gp-username {
+  font-size: 18px;
+  color: #8b949e;
+  margin: 0 0 12px;
+}
+
+.gp-bio {
+  font-size: 14px;
+  color: #c9d1d9;
+  margin: 0 0 8px;
+}
+
+.gp-location {
+  font-size: 13px;
+  color: #8b949e;
+  margin: 0 0 16px;
+}
+
+/* Skills */
+.gp-skills h3 {
+  font-size: 14px;
+  color: #f0f6fc;
+  margin: 0 0 8px;
+  border-top: 1px solid #30363d;
+  padding-top: 12px;
+}
+
+.gp-skills-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.gp-skill-badge {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 20px;
+  padding: 2px 10px;
+  font-size: 12px;
+  color: #58a6ff;
+}
+
+/* ── MAIN ── */
+.gp-main {
+  flex: 1;
+}
+
+.gp-section {
+  margin-bottom: 32px;
+}
+
+.gp-section h2 {
+  font-size: 16px;
+  color: #f0f6fc;
+  border-bottom: 1px solid #30363d;
+  padding-bottom: 8px;
+  margin-bottom: 16px;
+}
+
+/* ── CONTRIBUTION GRAPH ── */
+.gp-contribution-graph {
+  display: flex;
+  gap: 3px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.gp-week {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.gp-day {
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+}
+
+.level-0 { background-color: #161b22; }
+.level-1 { background-color: #0e4429; }
+.level-2 { background-color: #006d32; }
+.level-3 { background-color: #26a641; }
+.level-4 { background-color: #39d353; }
+
+.gp-graph-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: #8b949e;
+}
+
+/* ── PINNED REPOS ── */
+.gp-pinned-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.gp-repo-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gp-repo-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gp-repo-name {
+  color: #58a6ff;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.gp-repo-name:hover {
+  text-decoration: underline;
+}
+
+.gp-repo-desc {
+  font-size: 12px;
+  color: #8b949e;
+  flex: 1;
+  margin: 0;
+}
+
+.gp-repo-footer {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: #8b949e;
+}
+
+.gp-repo-lang {
+  color: #f0f6fc;
+}
+
+/* ── RESPONSIVE ── */
+@media (max-width: 768px) {
+  .github-profile-theme {
+    flex-direction: column;
+  }
+  .gp-sidebar {
+    width: 100%;
+  }
+  .gp-pinned-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/portfolio/templates/GitHubProfileTheme.jsx
+++ b/frontend/src/components/portfolio/templates/GitHubProfileTheme.jsx
@@ -1,0 +1,171 @@
+import React from "react";
+
+const GitHubProfileTheme = ({ portfolioData }) => {
+  const {
+    name = "Your Name",
+    username = "github-username",
+    bio = "Full Stack Developer | Open Source Enthusiast",
+    avatar = "https://github.com/identicons/default.png",
+    location = "India",
+    projects = [],
+    skills = [],
+    experience = [],
+  } = portfolioData || {};
+
+  const contributionLevels = [
+    "bg-[#161b22]",
+    "bg-[#0e4429]",
+    "bg-[#006d32]",
+    "bg-[#26a641]",
+    "bg-[#39d353]",
+  ];
+
+  return (
+    <div className="min-h-screen bg-[#0d1117] text-[#c9d1d9] font-sans p-6">
+
+      {/* ── MAIN LAYOUT ── */}
+      <div className="max-w-6xl mx-auto flex gap-6 flex-col md:flex-row">
+
+        {/* ── LEFT SIDEBAR ── */}
+        <div className="w-full md:w-64 flex-shrink-0">
+
+          {/* Avatar */}
+          <img
+            src={avatar}
+            alt={name}
+            className="w-full rounded-full border-2 border-[#30363d] mb-4"
+          />
+
+          {/* Name & Username */}
+          <h1 className="text-2xl font-semibold text-[#f0f6fc]">{name}</h1>
+          <p className="text-lg text-[#8b949e] mb-3">@{username}</p>
+
+          {/* Bio */}
+          <p className="text-sm text-[#c9d1d9] mb-3">{bio}</p>
+
+          {/* Location */}
+          {location && (
+            <p className="text-sm text-[#8b949e] mb-4">📍 {location}</p>
+          )}
+
+          {/* Skills */}
+          {skills.length > 0 && (
+            <div className="border-t border-[#30363d] pt-4">
+              <h3 className="text-sm font-semibold text-[#f0f6fc] mb-2">
+                Skills
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {skills.map((skill, i) => (
+                  <span
+                    key={i}
+                    className="bg-[#161b22] border border-[#30363d] rounded-full px-3 py-1 text-xs text-[#58a6ff]"
+                  >
+                    {skill}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Experience */}
+          {experience.length > 0 && (
+            <div className="border-t border-[#30363d] pt-4 mt-4">
+              <h3 className="text-sm font-semibold text-[#f0f6fc] mb-2">
+                Experience
+              </h3>
+              {experience.map((exp, i) => (
+                <div key={i} className="mb-3">
+                  <p className="text-sm font-medium text-[#f0f6fc]">
+                    {exp.role}
+                  </p>
+                  <p className="text-xs text-[#8b949e]">{exp.company}</p>
+                  <p className="text-xs text-[#8b949e]">{exp.duration}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── RIGHT MAIN CONTENT ── */}
+        <div className="flex-1">
+
+          {/* ── CONTRIBUTION GRAPH ── */}
+          <div className="mb-8">
+            <h2 className="text-base font-semibold text-[#f0f6fc] border-b border-[#30363d] pb-2 mb-4">
+              Contribution Activity
+            </h2>
+            <div className="flex gap-[3px] overflow-x-auto pb-2">
+              {Array(52)
+                .fill(null)
+                .map((_, week) => (
+                  <div key={week} className="flex flex-col gap-[3px]">
+                    {Array(7)
+                      .fill(null)
+                      .map((_, day) => {
+                        const level = Math.floor(Math.random() * 5);
+                        return (
+                          <div
+                            key={day}
+                            className={`w-[11px] h-[11px] rounded-sm ${contributionLevels[level]}`}
+                            title={`${level} contributions`}
+                          />
+                        );
+                      })}
+                  </div>
+                ))}
+            </div>
+            {/* Legend */}
+            <div className="flex items-center gap-1 mt-2 text-xs text-[#8b949e]">
+              <span>Less</span>
+              {contributionLevels.map((cls, i) => (
+                <div
+                  key={i}
+                  className={`w-[11px] h-[11px] rounded-sm ${cls}`}
+                />
+              ))}
+              <span>More</span>
+            </div>
+          </div>
+
+          {/* ── PINNED PROJECTS ── */}
+          <div className="mb-8">
+            <h2 className="text-base font-semibold text-[#f0f6fc] border-b border-[#30363d] pb-2 mb-4">
+              Pinned Projects
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {projects.slice(0, 6).map((project, i) => (
+                <div
+                  key={i}
+                  className="bg-[#161b22] border border-[#30363d] rounded-md p-4 flex flex-col gap-2 hover:border-[#58a6ff] transition-colors"
+                >
+                  <div className="flex items-center gap-2">
+                    <span>📁</span>
+                    <a
+                      href={project.link || "#"}
+                      className="text-[#58a6ff] text-sm font-semibold hover:underline"
+                    >
+                      {project.name || "Project Name"}
+                    </a>
+                  </div>
+                  <p className="text-xs text-[#8b949e] flex-1">
+                    {project.description || "No description provided."}
+                  </p>
+                  <div className="flex gap-4 text-xs text-[#8b949e]">
+                    <span className="text-[#f0f6fc]">
+                      ● {project.language || "JavaScript"}
+                    </span>
+                    <span>⭐ {project.stars || 0}</span>
+                    <span>🍴 {project.forks || 0}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GitHubProfileTheme;


### PR DESCRIPTION
## Description
Added GitHub Profile inspired portfolio theme 
for the Career Pilot portfolio builder.

## Changes Made
- Created GitHubProfileTheme.jsx in templates folder
- Created GitHubProfileTheme.css for styling
- GitHub dark UI using Tailwind CSS
- Sidebar with avatar, name, bio, skills, experience
- Contribution graph with color levels (like real GitHub)
- Pinned projects section with repo cards
- Fully responsive (mobile + desktop)

## Issue
Closes #2495

## Screenshots
<img width="513" height="1143" alt="files" src="https://github.com/user-attachments/assets/e4d51b64-fc5a-4c2a-86ca-61a1e7696848" />
<img width="1600" height="957" alt="Template gallery" src="https://github.com/user-attachments/assets/922bcf7d-5411-4081-86da-ce471f0e9306" />

## Checklist
- [x] Code is in templates folder only
- [x] No other files modified
- [x] Responsive design added
- [x] Tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a GitHub-style portfolio theme with profile display (avatar, name, username, bio, location)
  * Added contribution activity visualization showing contributions over time with activity levels
  * Added pinned projects showcase with repository details (description, language, stars, forks)
  * Included responsive design that adapts to mobile screens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->