### PR TITLE
fix: fail closed when portfolio versioning DB is down (#2319)

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -63,8 +63,26 @@ const assertValidPortfolioSlug = (slug) => {
   }
 };
 
-// In-memory fallback for testing without a database
+// In-memory fallback was historically used when MongoDB was disconnected.
+// This can silently drop data or cause split-brain behavior across instances, so it is now opt-in.
 const inMemoryStore = new Map();
+
+const isMongoConnected = () => mongoose.connection.readyState === 1;
+
+const allowInMemoryPortfolioVersioning = () => {
+  const enabled = String(process.env.ALLOW_PORTFOLIO_INMEMORY_VERSIONING || '').toLowerCase() === 'true';
+  const nonProd = process.env.NODE_ENV !== 'production';
+  return enabled && nonProd;
+};
+
+const assertPortfolioVersioningPersistenceAvailable = () => {
+  if (isMongoConnected()) return;
+  if (allowInMemoryPortfolioVersioning()) return;
+  throw new ApiError(
+    503,
+    'Portfolio versioning is temporarily unavailable because the database connection is down. Please try again later.',
+  );
+};
 
 // Helper to reconstruct full state from versions
 const reconstructVersion = async (portfolioId, targetVersionNumber, isConnected) => {
@@ -399,7 +417,8 @@ router.post('/:id/save', verifyToken, asyncHandler(async (req, res) => {
     throw new ApiError(400, 'Content is required for saving.');
   }
 
-  const isConnected = mongoose.connection.readyState === 1;
+  assertPortfolioVersioningPersistenceAvailable();
+  const isConnected = isMongoConnected();
   let latestVersion;
 
   if (isConnected) {
@@ -501,7 +520,8 @@ router.get('/:id/versions', verifyToken, asyncHandler(async (req, res) => {
     throw new ApiError(403, 'Unauthorized access to version history.');
   }
 
-  const isConnected = mongoose.connection.readyState === 1;
+  assertPortfolioVersioningPersistenceAvailable();
+  const isConnected = isMongoConnected();
 
   let versions;
   if (isConnected) {
@@ -533,7 +553,8 @@ router.post('/:id/restore/:versionId', verifyToken, asyncHandler(async (req, res
     throw new ApiError(403, 'Unauthorized access to restore this portfolio.');
   }
 
-  const isConnected = mongoose.connection.readyState === 1;
+  assertPortfolioVersioningPersistenceAvailable();
+  const isConnected = isMongoConnected();
 
   let versionToRestore;
   if (isConnected) {


### PR DESCRIPTION
## Description
Fail-closed when portfolio versioning persistence is unavailable (MongoDB disconnected), instead of silently falling back to an in-memory store. The in-memory fallback is now opt-in for non-production environments.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2319

## Testing
- [x] Unit tests pass (`cd backend && npm test`)
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
Not needed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portfolio versioning operations (save, view history, restore) now properly fail with clear error messaging when database connectivity is unavailable, instead of operating inconsistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anurag3407/career-pilot/pull/2522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->