### PR TITLE
feat: implement semantic footer for portfolio starter template

### DIFF
--- a/backend/src/templates/portfolio/_starter/index.html
+++ b/backend/src/templates/portfolio/_starter/index.html
@@ -91,9 +91,8 @@
        FOOTER SECTION
        ====================== -->
   <footer>
-    <p>Built with career-pilot</p>
     <div class="footer-container">
-      <p>&copy; <script>document.write(new Date().getFullYear())</script> {{portfolio.owner.name}}. All rights reserved.</p>
+      <p>&copy; <span id="current-year"></span> {{portfolio.owner.name}}. All rights reserved.</p>
       
       <div class="footer-socials">
         {{#if portfolio.owner.github}}
@@ -113,5 +112,8 @@
 
   </footer>
 
+  <script>
+    document.getElementById('current-year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/backend/src/templates/portfolio/_starter/index.html
+++ b/backend/src/templates/portfolio/_starter/index.html
@@ -91,8 +91,26 @@
        FOOTER SECTION
        ====================== -->
   <footer>
-    <!-- TODO: Add your footer content here -->
     <p>Built with career-pilot</p>
+    <div class="footer-container">
+      <p>&copy; <script>document.write(new Date().getFullYear())</script> {{portfolio.owner.name}}. All rights reserved.</p>
+      
+      <div class="footer-socials">
+        {{#if portfolio.owner.github}}
+          <a href="{{portfolio.owner.github}}" target="_blank" rel="noopener noreferrer">GitHub</a>
+        {{/if}}
+        {{#if portfolio.owner.linkedin}}
+          <a href="{{portfolio.owner.linkedin}}" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        {{/if}}
+        {{#if portfolio.owner.twitter}}
+          <a href="{{portfolio.owner.twitter}}" target="_blank" rel="noopener noreferrer">Twitter</a>
+        {{/if}}
+      </div>
+      <p class="built-with">
+        Built with <a href="#" target="_blank" rel="noopener noreferrer"><strong>Career-Pilot</strong></a>
+      </p>
+    </div>
+
   </footer>
 
 </body>

--- a/backend/src/templates/portfolio/_starter/index.html
+++ b/backend/src/templates/portfolio/_starter/index.html
@@ -107,7 +107,7 @@
         {{/if}}
       </div>
       <p class="built-with">
-        Built with <a href="#" target="_blank" rel="noopener noreferrer"><strong>Career-Pilot</strong></a>
+        Built with <a href="{{portfolio.owner.github}}" target="_blank" rel="noopener noreferrer"><strong>Career-Pilot</strong></a>
       </p>
     </div>
 


### PR DESCRIPTION
## Description
Updated the `_starter` template's footer to include a dynamic and comprehensive layout. Replaced the generic placeholder with a fully functional `footer-container` that automatically handles copyright dates, social media links, and branding.

Key additions:
- Added a dynamic copyright year using inline JavaScript `new Date().getFullYear()`.
- Automatically injects the portfolio owner's name (`{{portfolio.owner.name}}`) into the copyright notice.
- Added conditional Handlebars rendering (`{{#if}}`) for social links (GitHub, LinkedIn, Twitter), ensuring they only appear if the user has provided those URLs.
- Included a "Built with Career-Pilot" branding section.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2539 
## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
N/A – Backend starter template change. The `_starter` template is not directly exposed in the frontend UI.
*(Note: Since this updates the backend Handlebars `_starter` template boilerplate, visual changes depend on how future themes style this new HTML structure.)*

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced portfolio footer with a structured design replacing the placeholder
  * Dynamically displays the current copyright year and portfolio owner attribution
  * Optional social links (GitHub, LinkedIn, Twitter) now appear when configured in your profile
  * Updated Career-Pilot attribution link with improved security and external-link behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->