### PR TITLE
fix: remove debug console.log calls from production code

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -36,7 +36,6 @@ export default function Navbar() {
 
   useEffect(() => {
     const handleScroll = () => {
-      console.log(window.scrollY);
       setScrolled(window.scrollY>20)
     }
 

--- a/frontend/src/components/portfolio/templates/Netflix_Browse/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Netflix_Browse/Contact.jsx
@@ -21,7 +21,7 @@ export default function Contact({ personal, socials }) {
     setForm({ name: "", email: "", message: "" });
 
   } catch (error) {
-    console.log(error);
+    console.error(error);
 
   } finally {
     setLoading(false);


### PR DESCRIPTION
Fixed debug console.log statements left in production code.

**Changes:**
- Removed console.log(window.scrollY) from Navbar.jsx scroll event handler (debug leftover)
- Replaced console.log(error) with console.error(error) in Netflix_Browse/Contact.jsx for proper error logging

These debug statements were found during routine code review. — Sent via @AmSach bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal maintenance improvements to code quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->