### PR TITLE
fix: add missing alt attributes to image tags

### DIFF
--- a/frontend/src/components/portfolio/templates/Gradient_Mesh_Art/components/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Gradient_Mesh_Art/components/Testimonials.jsx
@@ -72,7 +72,7 @@ export default function Testimonials() {
                 <img
                   src={t.avatar}
                   className="w-12 h-12 rounded-full border border-white/10"
-                />
+                 alt="profile avatar"/>
 
                 <div>
                   <h4 className="font-semibold text-white">{t.name}</h4>

--- a/frontend/src/components/portfolio/templates/Gradient_Mesh_Art/components/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Gradient_Mesh_Art/components/Testimonials.jsx
@@ -72,7 +72,7 @@ export default function Testimonials() {
                 <img
                   src={t.avatar}
                   className="w-12 h-12 rounded-full border border-white/10"
-                 alt="profile avatar"/>
+                 alt={t.name ? `${t.name} profile photo` : "Profile avatar"}/>
 
                 <div>
                   <h4 className="font-semibold text-white">{t.name}</h4>

--- a/frontend/src/components/portfolio/templates/Northern_Fjords/index.jsx
+++ b/frontend/src/components/portfolio/templates/Northern_Fjords/index.jsx
@@ -54,7 +54,7 @@ export default function NorthernFjords() {
         <div className="grid md:grid-cols-3 gap-6">
           {data.projects.map((project, i) => (
             <div key={i} className="bg-white/5 rounded-xl overflow-hidden">
-              <img src={project.image} className="h-40 w-full object-cover" />
+              <img src={project.image} className="h-40 w-full object-cover"  alt=""/>
               <div className="p-4">
                 <h3 className="font-bold">{project.title}</h3>
                 <p className="text-gray-400 text-sm mt-2">


### PR DESCRIPTION
This PR adds missing \lt\ attributes to image tags across multiple files to improve accessibility for screen readers. Closes #2303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by adding descriptive, dynamic alt text to testimonial avatar images (uses the testimonial name when available, otherwise a fallback).
  * Standardized project thumbnail alt attributes by setting them explicitly to an empty value to prevent misleading or redundant screen reader content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->