### PR TITLE
feat: Add Line Art Portfolio Template  #1915

### DIFF
--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/About.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/About.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { User } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn, WireframeCorners } from './shared';
+
+const AboutSection = () => {
+  const { bio, avatar } = data.personal;
+  const { yearsExperience, projectsCompleted, happyClients } = data.stats;
+
+  return (
+    <section id="about" className="py-12">
+      <FadeIn>
+        <div className="flex items-center gap-4 mb-16">
+          <User size={20} strokeWidth={1} className="text-zinc-400" />
+          <h3 className="text-xl font-light uppercase tracking-widest">About</h3>
+          <div className="flex-1 border-t border-zinc-200 ml-4"></div>
+        </div>
+      </FadeIn>
+
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-16 items-center">
+        <FadeIn delay={0.1} className="md:col-span-5 relative">
+          <div className="relative p-4 border border-zinc-200 aspect-square flex items-center justify-center">
+            <WireframeCorners />
+            <div className="absolute top-2 left-2 text-[10px] text-zinc-400 font-mono">IMG_SRC</div>
+            <div className="absolute bottom-2 right-2 text-[10px] text-zinc-400 font-mono">1:1 RATIO</div>
+
+            <div className="w-full h-full border border-zinc-100 p-2">
+              <img src={avatar} alt="Avatar" className="w-full h-full object-cover grayscale opacity-90 hover:opacity-100 hover:grayscale-0 transition-all duration-700" />
+            </div>
+          </div>
+        </FadeIn>
+
+        <div className="md:col-span-7 flex flex-col justify-center">
+          <FadeIn delay={0.2}>
+            <p className="text-lg md:text-xl text-zinc-500 leading-loose font-light mb-16">{bio}</p>
+          </FadeIn>
+
+          <div className="grid grid-cols-3 gap-8 border-t border-zinc-200 pt-8 relative">
+            <WireframeCorners />
+            <FadeIn delay={0.3}>
+              <div className="text-4xl font-light text-zinc-900 mb-2">{yearsExperience}</div>
+              <div className="text-[10px] uppercase tracking-[0.15em] text-zinc-400">Years Exp</div>
+            </FadeIn>
+            <FadeIn delay={0.4} className="border-l border-zinc-200 pl-8">
+              <div className="text-4xl font-light text-zinc-900 mb-2">{projectsCompleted}</div>
+              <div className="text-[10px] uppercase tracking-[0.15em] text-zinc-400">Projects</div>
+            </FadeIn>
+            <FadeIn delay={0.5} className="border-l border-zinc-200 pl-8">
+              <div className="text-4xl font-light text-zinc-900 mb-2">{happyClients}</div>
+              <div className="text-[10px] uppercase tracking-[0.15em] text-zinc-400">Clients</div>
+            </FadeIn>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AboutSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Contact.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Mail, ArrowUpRight, Github, Linkedin, Twitter } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn, WireframeCorners } from './shared';
+
+const ContactSection = () => {
+  const { email, github, linkedin, twitter } = data.socials;
+
+  return (
+    <section id="contact" className="py-24">
+      <FadeIn>
+        <div className="border border-zinc-200 p-12 md:p-24 text-center relative group">
+          <WireframeCorners />
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-16 h-16 border bg-white border-zinc-200 flex items-center justify-center transform rotate-45">
+            <Mail size={20} strokeWidth={1} className="-rotate-45 text-zinc-400" />
+          </div>
+
+          <h3 className="text-4xl md:text-5xl font-extralight text-zinc-900 mb-8 mt-4">Start a project</h3>
+          <p className="text-zinc-400 font-light mb-12 max-w-md mx-auto leading-relaxed">Available for new opportunities. Send a message to discuss your next technical or creative endeavor.</p>
+
+          <a href={`mailto:${email}`} className="inline-flex items-center gap-3 border border-zinc-900 px-8 py-4 text-zinc-900 hover:bg-zinc-900 hover:text-white transition-all duration-300 text-xs tracking-[0.2em] uppercase">
+            Say Hello <ArrowUpRight size={14} strokeWidth={1} />
+          </a>
+
+          <div className="flex justify-center gap-8 mt-24">
+            {github && (<a href={github} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-900 transition-colors"><Github size={20} strokeWidth={1} /></a>)}
+            {linkedin && (<a href={linkedin} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-900 transition-colors"><Linkedin size={20} strokeWidth={1} /></a>)}
+            {twitter && (<a href={twitter} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-900 transition-colors"><Twitter size={20} strokeWidth={1} /></a>)}
+          </div>
+        </div>
+      </FadeIn>
+    </section>
+  );
+};
+
+export default ContactSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Experience.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Experience.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn } from './shared';
+
+const ExperienceSection = () => {
+  return (
+    <section id="experience" className="py-12">
+      <FadeIn>
+        <div className="flex items-center gap-4 mb-16">
+          <Calendar size={20} strokeWidth={1} className="text-zinc-400" />
+          <h3 className="text-xl font-light uppercase tracking-widest">History</h3>
+          <div className="flex-1 border-t border-zinc-200 ml-4"></div>
+        </div>
+      </FadeIn>
+
+      <div className="relative border-l border-zinc-200 ml-2 md:ml-4 space-y-16 pb-4">
+        {data.experience.map((job, index) => (
+          <FadeIn key={index} delay={index * 0.1} className="relative pl-8 md:pl-16">
+            <div className="absolute -left-[5px] top-2 flex items-center justify-center">
+              <span className="w-2.5 h-2.5 bg-white border border-zinc-900 rounded-none transform rotate-45" />
+              <div className="absolute w-8 h-px bg-zinc-200 left-full"></div>
+            </div>
+
+            <div className="flex flex-col md:flex-row md:items-baseline md:justify-between mb-4">
+              <h4 className="text-2xl font-light text-zinc-900">{job.role}</h4>
+              <span className="text-[11px] tracking-[0.1em] text-zinc-400 mt-2 md:mt-0 font-mono border border-zinc-200 px-3 py-1">{job.period}</span>
+            </div>
+            <div className="text-zinc-900 uppercase tracking-widest text-xs mb-6 font-medium">{job.company}</div>
+            <p className="text-zinc-500 font-light leading-relaxed max-w-3xl">{job.description}</p>
+          </FadeIn>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ExperienceSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Hero.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ArrowUpRight, MapPin } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn, WireframeCorners, AbstractLineArt } from './shared';
+
+const HeroSection = () => {
+  const { name, title, location } = data.personal;
+
+  return (
+    <section className="min-h-screen flex flex-col justify-center pt-20 relative">
+      <div className="absolute top-1/2 right-10 -translate-y-1/2 pointer-events-none hidden lg:block">
+        <AbstractLineArt />
+      </div>
+
+      <FadeIn>
+        <div className="inline-flex items-center gap-2 border border-zinc-200 px-4 py-1.5 text-[10px] uppercase tracking-widest text-zinc-500 mb-8 relative">
+          <WireframeCorners />
+          <MapPin size={12} strokeWidth={1} />
+          {location}
+        </div>
+      </FadeIn>
+
+      <FadeIn delay={0.1}>
+        <h1 className="text-6xl md:text-8xl font-extralight tracking-tighter text-zinc-900 mb-4">{name}</h1>
+      </FadeIn>
+
+      <FadeIn delay={0.2}>
+        <h2 className="text-2xl md:text-4xl text-zinc-400 font-light tracking-wide max-w-2xl">{title}</h2>
+      </FadeIn>
+
+      <FadeIn delay={0.3} className="flex gap-6 mt-16">
+        <a href="#projects" className="group relative px-8 py-3 border border-zinc-900 text-zinc-900 text-xs tracking-[0.2em] uppercase hover:bg-zinc-50 transition-colors">
+          <WireframeCorners />
+          <span className="flex items-center gap-2">View Projects <ArrowUpRight size={14} strokeWidth={1} className="group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" /></span>
+        </a>
+      </FadeIn>
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Projects.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Briefcase, ExternalLink, Github } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn, WireframeCorners } from './shared';
+
+const ProjectsSection = () => {
+  return (
+    <section id="projects" className="py-12">
+      <FadeIn>
+        <div className="flex items-center gap-4 mb-16">
+          <Briefcase size={20} strokeWidth={1} className="text-zinc-400" />
+          <h3 className="text-xl font-light uppercase tracking-widest">Selected Works</h3>
+          <div className="flex-1 border-t border-zinc-200 ml-4"></div>
+        </div>
+      </FadeIn>
+
+      <div className="space-y-24">
+        {data.projects.map((project, index) => (
+          <FadeIn key={index} delay={index * 0.1}>
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-8 items-center group">
+              <div className={`md:col-span-7 relative p-4 border border-zinc-200 ${index % 2 !== 0 ? 'md:order-last' : ''}`}>
+                <WireframeCorners />
+                <div className="flex justify-between items-center mb-2 px-1">
+                  <span className="text-[10px] font-mono text-zinc-400">FILE_{index + 1}.PNG</span>
+                  <span className="text-[10px] font-mono text-zinc-400">RENDER</span>
+                </div>
+
+                <div className="relative overflow-hidden border border-zinc-100 aspect-[4/3] bg-zinc-50 p-2">
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-500 z-10 pointer-events-none">
+                    <div className="w-full h-px bg-white/50 absolute"></div>
+                    <div className="h-full w-px bg-white/50 absolute"></div>
+                    <div className="border border-white/50 w-1/2 h-1/2 absolute"></div>
+                  </div>
+
+                  <img src={project.image} alt={project.title} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-700" />
+                </div>
+              </div>
+
+              <div className={`md:col-span-5 flex flex-col ${index % 2 !== 0 ? 'md:items-end md:text-right' : ''}`}>
+                <div className="text-[10px] tracking-[0.2em] uppercase text-zinc-400 mb-4 font-mono">Project // {String(index + 1).padStart(2, '0')}</div>
+                <h4 className="text-3xl font-light text-zinc-900 mb-6">{project.title}</h4>
+                <p className="text-zinc-500 font-light leading-relaxed mb-8">{project.description}</p>
+
+                <div className={`flex flex-wrap gap-x-4 gap-y-2 mb-8 ${index % 2 !== 0 ? 'md:justify-end' : ''}`}>
+                  {project.techStack.map((tech, idx) => (
+                    <span key={idx} className="text-[11px] tracking-widest uppercase text-zinc-400 border border-zinc-200 px-2 py-1">{tech}</span>
+                  ))}
+                </div>
+
+                <div className="flex gap-4">
+                  {project.githubUrl && (
+                    <a href={project.githubUrl} target="_blank" rel="noreferrer" className="p-3 border border-zinc-200 hover:border-zinc-900 text-zinc-400 hover:text-zinc-900 transition-colors">
+                      <Github size={18} strokeWidth={1} />
+                    </a>
+                  )}
+                  {project.liveUrl && (
+                    <a href={project.liveUrl} target="_blank" rel="noreferrer" className="p-3 border border-zinc-200 hover:border-zinc-900 text-zinc-400 hover:text-zinc-900 transition-colors">
+                      <ExternalLink size={18} strokeWidth={1} />
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ProjectsSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Skills.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Skills.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Code } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn } from './shared';
+
+const SkillsSection = () => {
+  return (
+    <section id="skills" className="py-12">
+      <FadeIn>
+        <div className="flex items-center gap-4 mb-16">
+          <Code size={20} strokeWidth={1} className="text-zinc-400" />
+          <h3 className="text-xl font-light uppercase tracking-widest">Expertise</h3>
+          <div className="flex-1 border-t border-zinc-200 ml-4"></div>
+        </div>
+      </FadeIn>
+
+      <div className="flex flex-wrap gap-4">
+        {data.skills.map((skill, index) => (
+          <FadeIn key={index} delay={index * 0.05}>
+            <div className="relative border border-zinc-200 px-6 py-3 hover:border-zinc-500 transition-colors duration-300 flex items-center gap-4 group cursor-crosshair">
+              <div className="absolute -top-[5px] -left-[5px] text-zinc-300 opacity-0 group-hover:opacity-100">+</div>
+              <div className="absolute -bottom-[5px] -right-[5px] text-zinc-300 opacity-0 group-hover:opacity-100">+</div>
+              <span className="text-sm font-light text-zinc-700">{skill.name}</span>
+              <div className="w-px h-3 bg-zinc-200"></div>
+              <span className="text-[10px] text-zinc-400 uppercase tracking-widest font-mono">{skill.category}</span>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SkillsSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/Testimonials.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Quote } from 'lucide-react';
+import data from '../../../../data/dummy_data.json';
+import { FadeIn } from './shared';
+
+const TestimonialsSection = () => {
+  return (
+    <section id="testimonials" className="py-12">
+      <FadeIn>
+        <div className="flex items-center gap-4 mb-16">
+          <Quote size={20} strokeWidth={1} className="text-zinc-400" />
+          <h3 className="text-xl font-light uppercase tracking-widest">Feedback</h3>
+          <div className="flex-1 border-t border-zinc-200 ml-4"></div>
+        </div>
+      </FadeIn>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        {data.testimonials.map((testimonial, index) => (
+          <FadeIn key={index} delay={index * 0.1}>
+            <div className="border border-zinc-200 p-10 h-full flex flex-col relative group hover:border-zinc-400 transition-colors duration-300">
+              <Quote size={32} strokeWidth={0.5} className="text-zinc-200 mb-8" />
+              <p className="text-zinc-500 font-light italic mb-12 flex-grow leading-loose">"{testimonial.text}"</p>
+              <div className="flex items-center gap-4">
+                <div className="p-1 border border-zinc-200">
+                  <img src={testimonial.avatar} alt={testimonial.name} className="w-10 h-10 object-cover grayscale" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-zinc-900 tracking-wide">{testimonial.name}</div>
+                  <div className="text-[10px] uppercase tracking-widest text-zinc-400 mt-1">{testimonial.role}</div>
+                </div>
+              </div>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default TestimonialsSection;

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/index.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/index.jsx
@@ -1,30 +1,40 @@
 import React from 'react';
 import data from '../../../../data/dummy_data.json';
+import HeroSection from './Hero';
+import AboutSection from './About';
+import SkillsSection from './Skills';
+import ProjectsSection from './Projects';
+import ExperienceSection from './Experience';
+import TestimonialsSection from './Testimonials';
+import ContactSection from './Contact';
+import { LineDivider } from './shared';
 
-/**
- * Line Art Portfolio Portfolio Template
- * Category: Minimal / Clean
- * Description: Minimal line art illustrations throughout. Single-weight stroke icons, thin borders, wireframe-style project previews. Clean and delicate.
- */
 export default function LineArtPortfolio() {
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-8 font-sans">
-      <div className="max-w-3xl w-full text-center">
-        <h1 className="text-5xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
-          {data.personal.name}
-        </h1>
-        <p className="text-xl md:text-2xl text-gray-400 mb-8">{data.personal.title}</p>
-        <div className="p-8 border-2 border-dashed border-cyan-500/40 rounded-2xl bg-gray-900/50 backdrop-blur-sm">
-          <span className="inline-block px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-400 text-xs font-bold uppercase tracking-widest mb-4">
-            Minimal / Clean
-          </span>
-          <h2 className="text-2xl font-bold text-gray-200 mb-3">Line Art Portfolio Template</h2>
-          <p className="text-gray-400 mb-6 leading-relaxed">
-            Minimal line art illustrations throughout. Single-weight stroke icons, thin borders, wireframe-style project previews. Clean and delicate.
-          </p>
-          <p className="text-cyan-400 font-semibold">Open an issue to contribute and build this template!</p>
-        </div>
-      </div>
+    <div className="min-h-screen bg-[#fafafa] text-zinc-900 font-sans selection:bg-zinc-200 selection:text-zinc-900 relative">
+      <div className="fixed inset-0 z-0 pointer-events-none" style={{
+        backgroundImage: `linear-gradient(to right, #00000008 1px, transparent 1px), linear-gradient(to bottom, #00000008 1px, transparent 1px)`,
+        backgroundSize: '40px 40px'
+      }}></div>
+
+      <main className="max-w-5xl mx-auto px-6 md:px-12 relative z-10 pb-12 bg-[#fafafa]/80 backdrop-blur-sm border-x border-zinc-200/50 min-h-screen">
+        <HeroSection />
+        <LineDivider />
+        <AboutSection />
+        <LineDivider />
+        <SkillsSection />
+        <LineDivider />
+        <ProjectsSection />
+        <LineDivider />
+        <ExperienceSection />
+        <LineDivider />
+        <TestimonialsSection />
+        <ContactSection />
+
+        <footer className="text-center pb-8 pt-12 text-[10px] uppercase font-mono text-zinc-400 tracking-[0.2em]">
+          © {new Date().getFullYear()} {data.personal.name} // SYS.ONLINE
+        </footer>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/shared.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/shared.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Plus } from 'lucide-react';
+
+export const FadeIn = ({ children, delay = 0, className = "" }) => (
+  <motion.div
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true, margin: "-50px" }}
+    transition={{ duration: 0.6, delay, ease: "easeOut" }}
+    className={className}
+  >
+    {children}
+  </motion.div>
+);
+
+export const LineDivider = () => (
+  <motion.hr
+    initial={{ scaleX: 0 }}
+    whileInView={{ scaleX: 1 }}
+    viewport={{ once: true }}
+    transition={{ duration: 1, ease: "easeInOut" }}
+    className="border-t border-zinc-200 origin-left my-16 md:my-24 w-full"
+  />
+);
+
+export const WireframeCorners = () => (
+  <>
+    <Plus size={16} strokeWidth={1} className="absolute -top-2 -left-2 text-zinc-300" />
+    <Plus size={16} strokeWidth={1} className="absolute -top-2 -right-2 text-zinc-300" />
+    <Plus size={16} strokeWidth={1} className="absolute -bottom-2 -left-2 text-zinc-300" />
+    <Plus size={16} strokeWidth={1} className="absolute -bottom-2 -right-2 text-zinc-300" />
+  </>
+);
+
+export const AbstractLineArt = () => (
+  <svg viewBox="0 0 200 200" className="w-64 h-64 mx-auto opacity-30" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 100 C 50 10, 150 10, 190 100 C 150 190, 50 190, 10 100 Z" fill="none" stroke="currentColor" strokeWidth="1" className="text-zinc-900" />
+    <path d="M100 10 L 100 190 M 10 100 L 190 100" fill="none" stroke="currentColor" strokeWidth="0.5" strokeDasharray="4 4" className="text-zinc-400" />
+    <circle cx="100" cy="100" r="40" fill="none" stroke="currentColor" strokeWidth="1" className="text-zinc-900" />
+  </svg>
+);
+
+export default {};

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/shared.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/shared.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { motion } from 'framer-motion';
 import { Plus } from 'lucide-react';
 
 export const FadeIn = ({ children, delay = 0, className = "" }) => (

--- a/frontend/src/components/portfolio/templates/Line_Art_Portfolio/shared.jsx
+++ b/frontend/src/components/portfolio/templates/Line_Art_Portfolio/shared.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import { Plus } from 'lucide-react';
 
 export const FadeIn = ({ children, delay = 0, className = "" }) => (

--- a/frontend/src/components/portfolio/templates/OLED_Black/About.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/About.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { User } from 'lucide-react';
+import { fadeUp, staggerContainer, SectionHeading } from './shared';
+
+const About = ({ personal }) => (
+  <section className="relative py-24">
+    <SectionHeading title="Identity" icon={User} />
+    <div className="grid grid-cols-1 items-center gap-12 md:grid-cols-12">
+      <motion.div
+        variants={fadeUp}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        className="group relative md:col-span-5"
+      >
+        <div className="absolute inset-0 rounded-full bg-cyan-400/20 opacity-0 blur-xl transition-opacity duration-700 group-hover:opacity-100" />
+        <img
+          src={personal.avatar}
+          alt={personal.name}
+          className="relative z-10 aspect-square w-full rounded-sm border border-gray-800 object-cover grayscale transition-all duration-700 hover:grayscale-0"
+        />
+        <div className="absolute -left-2 -top-2 z-20 h-6 w-6 border-l-2 border-t-2 border-cyan-400" />
+        <div className="absolute -bottom-2 -right-2 z-20 h-6 w-6 border-b-2 border-r-2 border-cyan-400" />
+      </motion.div>
+
+      <motion.div
+        variants={staggerContainer}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        className="space-y-6 text-lg leading-relaxed text-gray-300 font-light md:col-span-7"
+      >
+        <motion.p variants={fadeUp}>{personal.bio}</motion.p>
+      </motion.div>
+    </div>
+  </section>
+);
+
+export default About;

--- a/frontend/src/components/portfolio/templates/OLED_Black/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Contact.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Mail } from 'lucide-react';
+import { fadeUp } from './shared';
+
+const Contact = ({ socials }) => (
+  <section className="relative mt-20 overflow-hidden border-t border-gray-900 py-32">
+    <motion.div variants={fadeUp} initial="hidden" whileInView="visible" viewport={{ once: true }} className="relative z-10 text-center">
+      <h2 className="mb-6 text-5xl font-black tracking-tighter text-white md:text-7xl">
+        INITIATE <span className="bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-blue-600">HANDSHAKE</span>
+      </h2>
+      <p className="mx-auto mb-12 max-w-xl text-lg font-light text-gray-400 md:text-xl">
+        Currently open for new opportunities. Whether you have a question or just want to say hi, my inbox is always open.
+      </p>
+
+      <motion.a
+        href={`mailto:${socials.email}`}
+        whileHover={{ scale: 1.05, boxShadow: '0 0 20px rgba(34, 211, 238, 0.4)' }}
+        whileTap={{ scale: 0.95 }}
+        className="inline-flex items-center gap-3 border border-cyan-400 bg-black px-8 py-4 font-mono text-sm uppercase tracking-widest text-cyan-400 transition-all duration-300 hover:bg-cyan-400 hover:text-black"
+      >
+        <Mail size={18} />
+        Ping User
+      </motion.a>
+    </motion.div>
+  </section>
+);
+
+export default Contact;

--- a/frontend/src/components/portfolio/templates/OLED_Black/Experience.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Experience.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Briefcase } from 'lucide-react';
+import { fadeUp, drawLine, SectionHeading } from './shared';
+
+const Experience = ({ experience }) => (
+  <section className="relative py-24">
+    <SectionHeading title="Log" icon={Briefcase} />
+    <div className="relative pl-8 md:pl-0">
+      <motion.div
+        variants={drawLine}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        className="absolute left-[15px] top-0 w-px origin-top -translate-x-1/2 bg-gradient-to-b from-cyan-400 via-cyan-900 to-transparent md:left-1/2"
+      />
+
+      <div className="space-y-16">
+        {experience.map((exp, index) => (
+          <motion.div
+            key={index}
+            variants={fadeUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: '-50px' }}
+            className={`relative flex w-full flex-col items-start md:flex-row md:justify-between ${index % 2 === 0 ? 'md:flex-row-reverse' : ''}`}
+          >
+            <motion.div
+              whileHover={{ scale: 1.5, backgroundColor: '#22d3ee', boxShadow: '0 0 15px #22d3ee' }}
+              className="absolute left-[-29px] z-10 mt-1.5 h-4 w-4 cursor-pointer rounded-full border-2 border-cyan-400 bg-black transition-colors duration-300 md:left-1/2 md:-translate-x-1/2"
+            />
+
+            <div className={`md:w-[45%] ${index % 2 === 0 ? 'md:text-left' : 'md:text-right'}`}>
+              <div className="group border border-gray-800 bg-black/50 p-6 transition-all duration-300 hover:border-cyan-500/30 hover:bg-cyan-950/10">
+                <span className="mb-2 block font-mono text-sm tracking-widest text-cyan-400">{exp.period}</span>
+                <h4 className="mb-1 text-xl font-bold text-white transition-colors group-hover:text-cyan-300">{exp.role}</h4>
+                <h5 className="mb-4 text-md text-gray-500">{exp.company}</h5>
+                <p className="text-sm leading-relaxed text-gray-400 font-light md:text-base">{exp.description}</p>
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default Experience;

--- a/frontend/src/components/portfolio/templates/OLED_Black/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Hero.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Github, Linkedin, Twitter, Mail } from 'lucide-react';
+import { fadeUp, staggerContainer, SocialLink } from './shared';
+
+const Hero = ({ personal, stats, socials }) => (
+  <section className="relative flex min-h-screen flex-col justify-center overflow-hidden pb-12 pt-20">
+    <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden opacity-[0.15]">
+      <motion.div
+        animate={{ backgroundPosition: ['0px 0px', '40px 40px'] }}
+        transition={{ repeat: Infinity, duration: 3, ease: 'linear' }}
+        className="absolute inset-0"
+        style={{
+          backgroundImage: 'linear-gradient(to right, #22d3ee 1px, transparent 1px), linear-gradient(to bottom, #22d3ee 1px, transparent 1px)',
+          backgroundSize: '40px 40px',
+          WebkitMaskImage: 'radial-gradient(ellipse at 50% 50%, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 60%)',
+          maskImage: 'radial-gradient(ellipse at 50% 50%, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 60%)',
+        }}
+      />
+    </div>
+
+    <motion.div
+      animate={{ scale: [1, 1.2, 1], opacity: [0.03, 0.06, 0.03] }}
+      transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
+      className="pointer-events-none absolute left-1/4 top-1/4 z-0 h-[40vw] w-[40vw] rounded-full bg-cyan-500/10 blur-[120px]"
+    />
+
+    <motion.div variants={staggerContainer} initial="hidden" animate="visible" className="z-10 relative">
+      <motion.div variants={fadeUp} className="mb-6 flex items-center gap-3">
+        <span className="h-px w-12 bg-cyan-400" />
+        <span className="text-cyan-400 font-mono text-sm uppercase tracking-widest">System Online // Welcome</span>
+      </motion.div>
+
+      <motion.h1 variants={fadeUp} className="mb-4 text-6xl font-black leading-tight tracking-tighter md:text-8xl">
+        {personal.name.split(' ').map((word, index) => (
+          <span key={index} className="block w-fit pb-2">
+            <motion.span
+              animate={{ backgroundPosition: ['0% 50%', '200% 50%'] }}
+              transition={{ repeat: Infinity, duration: 3.5, ease: 'linear', delay: index * 0.3 }}
+              style={{
+                backgroundImage: 'linear-gradient(90deg, #ffffff 0%, #ffffff 40%, #22d3ee 50%, #ffffff 60%, #ffffff 100%)',
+                backgroundSize: '200% auto',
+              }}
+              className="block bg-clip-text text-transparent"
+            >
+              {word}
+            </motion.span>
+          </span>
+        ))}
+      </motion.h1>
+
+      <motion.p variants={fadeUp} className="mb-12 max-w-2xl border-l-2 border-cyan-500/30 bg-gradient-to-r from-black via-black to-transparent pl-6 text-xl font-light text-gray-400 md:text-2xl">
+        {personal.title} based in {personal.location}.
+      </motion.p>
+
+      <motion.div variants={fadeUp} className="mb-16 flex flex-wrap gap-8 md:gap-16">
+        {[
+          { label: 'Years Exp.', value: stats.yearsExperience },
+          { label: 'Projects', value: stats.projectsCompleted },
+          { label: 'Clients', value: stats.happyClients },
+        ].map((stat, index) => (
+          <div key={index} className="group relative flex flex-col">
+            <span className="mb-1 text-4xl font-bold text-white transition-colors duration-300 group-hover:text-cyan-400">
+              {stat.value}<span className="text-cyan-400 transition-colors duration-300 group-hover:text-white">+</span>
+            </span>
+            <span className="text-xs font-mono uppercase tracking-wider text-gray-500">{stat.label}</span>
+          </div>
+        ))}
+      </motion.div>
+
+      <motion.div variants={fadeUp} className="flex gap-6">
+        {socials.github && <SocialLink href={socials.github} icon={<Github />} />}
+        {socials.linkedin && <SocialLink href={socials.linkedin} icon={<Linkedin />} />}
+        {socials.twitter && <SocialLink href={socials.twitter} icon={<Twitter />} />}
+        {socials.email && <SocialLink href={`mailto:${socials.email}`} icon={<Mail />} />}
+      </motion.div>
+    </motion.div>
+  </section>
+);
+
+export default Hero;

--- a/frontend/src/components/portfolio/templates/OLED_Black/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Projects.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { ExternalLink, Github, Code } from 'lucide-react';
+import { fadeUp, SectionHeading } from './shared';
+
+const ProjectCard = ({ project, index }) => (
+  <motion.div
+    variants={fadeUp}
+    initial="hidden"
+    whileInView="visible"
+    viewport={{ once: true }}
+    transition={{ delay: index * 0.1 }}
+    whileHover="hover"
+    className="group relative block w-full overflow-hidden border border-gray-800 bg-black"
+  >
+    <motion.div
+      variants={{ hover: { opacity: 1 } }}
+      initial={{ opacity: 0 }}
+      className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-t from-cyan-950/40 to-transparent transition-opacity duration-500"
+    />
+
+    <div className="relative h-64 overflow-hidden border-b border-gray-800">
+      <motion.img
+        variants={{ hover: { scale: 1.05 } }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        src={project.image}
+        alt={project.title}
+        className="h-full w-full object-cover opacity-60 transition-opacity duration-500 group-hover:opacity-100"
+      />
+    </div>
+
+    <div className="relative z-10 p-8">
+      <div className="mb-4 flex items-start justify-between">
+        <h3 className="text-2xl font-semibold text-white transition-colors group-hover:text-cyan-400">{project.title}</h3>
+        <div className="flex gap-3 text-gray-500">
+          {project.githubUrl && (
+            <a href={project.githubUrl} className="transition-colors hover:text-cyan-400 hover:drop-shadow-[0_0_5px_rgba(34,211,238,0.8)]">
+              <Github size={20} />
+            </a>
+          )}
+          {project.liveUrl && (
+            <a href={project.liveUrl} className="transition-colors hover:text-cyan-400 hover:drop-shadow-[0_0_5px_rgba(34,211,238,0.8)]">
+              <ExternalLink size={20} />
+            </a>
+          )}
+        </div>
+      </div>
+      <p className="mb-6 line-clamp-2 font-light text-gray-400">{project.description}</p>
+      <div className="flex flex-wrap gap-2">
+        {project.techStack.map((tech, techIndex) => (
+          <span key={techIndex} className="border border-cyan-900/50 bg-cyan-950/30 px-2 py-1 font-mono text-xs text-cyan-400/70">
+            {tech}
+          </span>
+        ))}
+      </div>
+    </div>
+  </motion.div>
+);
+
+const Projects = ({ projects }) => (
+  <section className="py-24">
+    <SectionHeading title="Deployment" icon={Code} />
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+      {projects.map((project, index) => (
+        <ProjectCard key={index} project={project} index={index} />
+      ))}
+    </div>
+  </section>
+);
+
+export default Projects;

--- a/frontend/src/components/portfolio/templates/OLED_Black/Skills.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Skills.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Terminal } from 'lucide-react';
+import { fadeUp, staggerContainer, SectionHeading } from './shared';
+
+const Skills = ({ skills }) => (
+  <section className="py-24">
+    <SectionHeading title="Capabilities" icon={Terminal} />
+    <motion.div variants={staggerContainer} initial="hidden" whileInView="visible" viewport={{ once: true }} className="flex flex-wrap gap-4">
+      {skills.map((skill, index) => (
+        <motion.div
+          key={index}
+          variants={fadeUp}
+          whileHover={{
+            scale: 1.05,
+            backgroundColor: 'rgba(34, 211, 238, 0.1)',
+            borderColor: 'rgba(34, 211, 238, 0.5)',
+            boxShadow: '0 0 15px rgba(34, 211, 238, 0.2)',
+          }}
+          className="flex cursor-default items-center gap-3 rounded-none border border-gray-800 bg-black px-5 py-3 text-gray-300 transition-all"
+        >
+          <span className="font-mono text-xs text-cyan-400 opacity-70">{String(index + 1).padStart(2, '0')}</span>
+          <span className="font-medium tracking-wide">{skill.name}</span>
+        </motion.div>
+      ))}
+    </motion.div>
+  </section>
+);
+
+export default Skills;

--- a/frontend/src/components/portfolio/templates/OLED_Black/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Testimonials.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { MessageSquare } from 'lucide-react';
+import { SectionHeading } from './shared';
+
+const Testimonials = ({ testimonials }) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setActiveIndex((previousIndex) => (previousIndex + 1) % testimonials.length);
+    }, 6000);
+
+    return () => clearInterval(timer);
+  }, [testimonials.length]);
+
+  return (
+    <section className="py-24">
+      <SectionHeading title="Telemetry" icon={MessageSquare} />
+      <div className="relative flex min-h-[300px] items-center overflow-hidden border border-gray-800 bg-gradient-to-br from-black to-zinc-950 p-8 md:p-12">
+        <div
+          className="absolute inset-0 opacity-[0.03]"
+          style={{
+            backgroundImage: 'linear-gradient(to right, #22d3ee 1px, transparent 1px), linear-gradient(to bottom, #22d3ee 1px, transparent 1px)',
+            backgroundSize: '20px 20px',
+          }}
+        />
+
+        <span className="absolute left-6 top-4 z-0 font-serif text-6xl text-gray-800 opacity-50">"</span>
+
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={activeIndex}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.5 }}
+            className="w-full"
+          >
+            <p className="relative z-10 mb-8 text-xl font-light italic leading-relaxed text-gray-300 md:text-3xl">
+              {testimonials[activeIndex].text}
+            </p>
+            <div className="relative z-10 flex items-center gap-4">
+              <img
+                src={testimonials[activeIndex].avatar}
+                alt={testimonials[activeIndex].name}
+                className="h-12 w-12 rounded-full border border-cyan-500/30 grayscale"
+              />
+              <div>
+                <h4 className="font-medium text-white">{testimonials[activeIndex].name}</h4>
+                <p className="font-mono text-sm text-cyan-400/70">{testimonials[activeIndex].role}</p>
+              </div>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+
+        <div className="absolute bottom-6 right-8 z-10 flex gap-2">
+          {testimonials.map((_, index) => (
+            <button
+              key={index}
+              onClick={() => setActiveIndex(index)}
+              className={`h-1 transition-all duration-300 ${activeIndex === index ? 'w-8 bg-cyan-400' : 'w-2 bg-gray-700 hover:bg-gray-500'}`}
+              aria-label={`Go to testimonial ${index + 1}`}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Testimonials;

--- a/frontend/src/components/portfolio/templates/OLED_Black/index.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/index.jsx
@@ -1,30 +1,40 @@
 import React from 'react';
 import data from '../../../../data/dummy_data.json';
+import Hero from './Hero';
+import About from './About';
+import Skills from './Skills';
+import Projects from './Projects';
+import Experience from './Experience';
+import Testimonials from './Testimonials';
+import Contact from './Contact';
 
-/**
- * OLED Black Portfolio Template
- * Category: Dark / Moody
- * Description: Pure #000000 OLED black background for true blacks on OLED screens. White text, minimal UI. Single accent color (cyan or electric blue).
- */
-export default function OLEDBlack() {
+export default function OLED_Black_Portfolio() {
+  const { personal, socials, skills, projects, experience, testimonials, stats } = data;
+
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-8 font-sans">
-      <div className="max-w-3xl w-full text-center">
-        <h1 className="text-5xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
-          {data.personal.name}
-        </h1>
-        <p className="text-xl md:text-2xl text-gray-400 mb-8">{data.personal.title}</p>
-        <div className="p-8 border-2 border-dashed border-cyan-500/40 rounded-2xl bg-gray-900/50 backdrop-blur-sm">
-          <span className="inline-block px-3 py-1 rounded-full bg-cyan-500/20 text-cyan-400 text-xs font-bold uppercase tracking-widest mb-4">
-            Dark / Moody
-          </span>
-          <h2 className="text-2xl font-bold text-gray-200 mb-3">OLED Black Template</h2>
-          <p className="text-gray-400 mb-6 leading-relaxed">
-            Pure #000000 OLED black background for true blacks on OLED screens. White text, minimal UI. Single accent color (cyan or electric blue).
-          </p>
-          <p className="text-cyan-400 font-semibold">Open an issue to contribute and build this template!</p>
-        </div>
-      </div>
+    <div className="min-h-screen bg-black text-gray-200 selection:bg-cyan-500/30 selection:text-cyan-200 font-sans">
+      <style dangerouslySetInnerHTML={{__html: `
+        ::-webkit-scrollbar { width: 8px; }
+        ::-webkit-scrollbar-track { background: #000000; }
+        ::-webkit-scrollbar-thumb { background: #1f2937; }
+        ::-webkit-scrollbar-thumb:hover { background: #22d3ee; }
+      `}} />
+
+      <main className="max-w-6xl mx-auto px-6 md:px-12 relative z-10">
+        <Hero personal={personal} stats={stats} socials={socials} />
+        <About personal={personal} />
+        <Skills skills={skills} />
+        <Projects projects={projects} />
+        <Experience experience={experience} />
+        <Testimonials testimonials={testimonials} />
+        <Contact socials={socials} />
+      </main>
+
+      <footer className="border-t border-gray-900 py-8 text-center bg-black relative z-10">
+        <p className="text-gray-600 font-mono text-xs uppercase tracking-widest">
+          © {new Date().getFullYear()} {personal.name}. System Built.
+        </p>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/components/portfolio/templates/OLED_Black/shared.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/shared.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export const fadeUp = {
+  hidden: { opacity: 0, y: 40 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.8, ease: [0.22, 1, 0.36, 1] } },
+};
+
+export const staggerContainer = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { staggerChildren: 0.15 } },
+};
+
+export const drawLine = {
+  hidden: { height: 0 },
+  visible: { height: '100%', transition: { duration: 1.5, ease: 'easeInOut' } },
+};
+
+export const SectionHeading = ({ title, icon: Icon }) => (
+  <motion.div
+    variants={fadeUp}
+    initial="hidden"
+    whileInView="visible"
+    viewport={{ once: true, margin: '-100px' }}
+    className="mb-12 flex items-center gap-4"
+  >
+    <div className="rounded-full border border-cyan-500/20 bg-cyan-950/30 p-3 text-cyan-400">
+      <Icon size={24} />
+    </div>
+    <h2 className="text-3xl font-light tracking-tight text-white md:text-5xl">
+      {title}<span className="text-cyan-400">.</span>
+    </h2>
+    <div className="ml-4 h-px flex-1 bg-gradient-to-r from-cyan-500/20 to-transparent" />
+  </motion.div>
+);
+
+export const SocialLink = ({ href, icon }) => (
+  <motion.a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    whileHover={{ y: -5, color: '#22d3ee', scale: 1.1 }}
+    className="relative z-20 text-gray-500 transition-colors duration-300 hover:drop-shadow-[0_0_8px_rgba(34,211,238,0.8)]"
+  >
+    {icon}
+  </motion.a>
+);


### PR DESCRIPTION
## Description
This PR introduces the **Line Art Portfolio** template under the "Minimal / Clean" category, resolving issue #1915. 

The design strictly adheres to the requested aesthetic, featuring a delicate "drafting/blueprint" vibe with wireframe-style project previews, abstract inline SVG line art, a faint grid background, and thin single-weight borders. All animations are smooth and subtle, ensuring the focus remains on the clean layout.

Closes #1915 

## 🎯 Features & Aesthetics Implemented
- **Minimalist Design**: Wireframe corner accents (`+`), strict single-weight stroke icons (via `lucide-react`), and thin `border-zinc-200` lines throughout.
- **Drafting Grid Background**: Added a subtle 40x40 CSS grid background to emphasize the sketchbook/blueprint feel.
- **Wireframe Project Previews**: Image containers feature wireframe hover effects and technical mono-font labels.
- **Smooth Animations**: Integrated `framer-motion` for elegant scroll-triggered fade-ins and line-drawing dividers.
- **Dynamic Content**: 100% of the portfolio data is dynamically rendered from `dummy_data.json`. Zero hardcoded content.
- **Fully Responsive**: Carefully crafted breakpoints for mobile, tablet, and desktop viewing.

## ✅ Technical Checklist
- [x] Built with React (JSX) and Tailwind CSS (utility classes only)
- [x] No external CSS frameworks used
- [x] Icons sourced from `lucide-react` with `strokeWidth={1}`
- [x] Animations implemented using `framer-motion`
- [x] Standalone and modular component strictly inside `frontend/src/components/portfolio/templates/Line_Art_Portfolio/index.jsx`
- [x] No hardcoded data (all mapped from `dummy_data.json`)

## 📸 Mandatory Screenshots
<img width="244" height="518" alt="Screenshot 2026-06-01 at 3 13 38 PM" src="https://github.com/user-attachments/assets/50c6407a-5032-4a24-bca8-5133fe13a5c3" />
<img width="1279" height="619" alt="Screenshot 2026-06-01 at 3 13 58 PM" src="https://github.com/user-attachments/assets/2daf18e6-847f-4cf1-9c04-c6bc2f73be59" />

### 🎬 Screen Recording

https://github.com/user-attachments/assets/c9f7755d-6287-4dba-b704-12308dae8b16



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two new portfolio templates: Line Art Portfolio and OLED Black Portfolio
  * Added complete portfolio sections including hero, about, skills, projects, experience timeline, testimonials, and contact
  * Integrated smooth animations and visual effects throughout both templates for enhanced user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->