### PR TITLE
fix: handle unhandled promise rejection in recordOpen

### DIFF
--- a/backend/src/routes/emailTracking.js
+++ b/backend/src/routes/emailTracking.js
@@ -21,7 +21,9 @@ router.get('/open/:token', asyncHandler(async (req, res) => {
     const { token } = req.params;
 
     // Fire-and-forget: do not await so the pixel is served immediately
-    recordOpen(token);
+    recordOpen(token).catch(err => 
+        console.error('Failed to record open:', err)
+    );
 
     res.set({
         'Content-Type': 'image/gif',


### PR DESCRIPTION
## Description
Added .catch() handler to recordOpen(token) call in the email 
tracking pixel endpoint to prevent unhandled promise rejections 
from crashing the Node.js server.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2596 

## Testing
- [ ] Unit tests pass
- [x ] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
-N/A

## Checklist
- [ x] Code follows project style guidelines
- [x ] Self-reviewed my code
- [x ] Added comments where necessary
- [ ] Updated documentation
- [x ] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in email tracking to prevent potential issues and ensure reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->