### PR TITLE
feat(interview): add interview preparation tracker dashboard

### DIFF
--- a/docs/interview-prep-tracker.md
+++ b/docs/interview-prep-tracker.md
@@ -1,0 +1,49 @@
+# Interview Preparation Tracker
+
+## Overview
+
+The **Interview Preparation Tracker** helps candidates structure daily interview prep across DSA, aptitude, CS subjects, and mock interviews. Data is stored in the browser via `localStorage` (no backend required).
+
+## Access
+
+- **Route:** `/interview-prep-tracker`
+- **Hub:** Career Growth → **Interview Prep Tracker**
+
+Related tools (separate features):
+
+| Tool | Route | Purpose |
+|------|-------|---------|
+| AI Interview Prep | `/interview-prep` | Live mock interviews with AI scoring |
+| Interview Analytics | `/dashboard/analytics` | Historical mock interview charts (API) |
+
+## Features
+
+- Daily preparation checklist (5 default tasks, reset per calendar day)
+- Category session counters: DSA, Aptitude, CS Subjects, Mock Interviews
+- Overall daily progress percentage
+- Learning streak (current + best)
+- Weekly summary (last 7 days)
+- Completed vs pending task lists for today
+
+## Storage
+
+- **Key:** `careerpilot_interview_prep_tracker_v1`
+- **Retention:** Day records older than 90 days are pruned on load
+- **Schema version:** `1` (see `frontend/src/lib/interviewPrepTracker.js`)
+
+## Development
+
+```bash
+cd frontend
+npm run dev
+```
+
+Open `/interview-prep-tracker` while signed in.
+
+## Testing
+
+Run manual checks from the PR test plan. Optional lint:
+
+```bash
+cd frontend && npm run lint
+```

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,6 +42,7 @@ const Enhance = lazy(() => import("./pages/Enhance"));
 const ResumeView = lazy(() => import("./pages/ResumeView"));
 const JobAlerts = lazy(() => import("./pages/JobAlerts"));
 const InterviewPrep = lazy(() => import("./pages/InterviewPrep"));
+const InterviewPrepTracker = lazy(() => import("./pages/InterviewPrepTracker"));
 const UserProfile = lazy(() => import("./pages/UserProfile"));
 const SecuritySettings = lazy(() => import("./pages/SecuritySettings"));
 const EmailGenerator = lazy(() => import("./pages/EmailGenerator"));
@@ -297,6 +298,7 @@ function AppRoutes() {
   } 
 />
         <Route path="/interview-prep" element={<ProtectedRoute><Suspense fallback={<LoadingScreen label="Loading Interview Prep..." />}><InterviewPrep /></Suspense></ProtectedRoute>} />
+        <Route path="/interview-prep-tracker" element={<ProtectedRoute><Suspense fallback={<LoadingScreen label="Loading Interview Prep Tracker..." />}><InterviewPrepTracker /></Suspense></ProtectedRoute>} />
         <Route path="/profile" element={<ProtectedRoute><Suspense fallback={<LoadingScreen label="Loading Profile..." />}><UserProfile /></Suspense></ProtectedRoute>} />
         <Route path="/profile/:uid" element={<ProtectedRoute><Suspense fallback={<LoadingScreen label="Loading Profile..." />}><UserProfile /></Suspense></ProtectedRoute>} />
         <Route path="/security" element={<ProtectedRoute><Suspense fallback={<LoadingScreen label="Loading Security Settings..." />}><SecuritySettings /></Suspense></ProtectedRoute>} />

--- a/frontend/src/components/interviewPrep/CategoryTrackerCard.jsx
+++ b/frontend/src/components/interviewPrep/CategoryTrackerCard.jsx
@@ -1,0 +1,51 @@
+import { Minus, Plus } from 'lucide-react';
+import { CATEGORY_META, getCategoryProgressPercent } from '../../lib/interviewPrepTracker';
+import ProgressBar from './ProgressBar';
+
+/**
+ * Tracks session count for a single preparation category.
+ */
+export default function CategoryTrackerCard({
+  categoryId,
+  categoryProgress,
+  onIncrement,
+  onDecrement,
+}) {
+  const meta = CATEGORY_META[categoryId];
+  const sessions = categoryProgress[categoryId]?.sessionsCompleted ?? 0;
+  const percent = getCategoryProgressPercent(categoryProgress, categoryId);
+
+  return (
+    <article className="rounded-2xl border border-border bg-card p-5 hover:border-primary/30 transition-colors">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="font-black text-foreground">{meta.label}</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">{meta.description}</p>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => onDecrement(categoryId)}
+            disabled={sessions <= 0}
+            className="p-2 rounded-lg border border-border text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            aria-label={`Decrease ${meta.label} sessions`}
+          >
+            <Minus className="w-4 h-4" />
+          </button>
+          <span className="min-w-[2rem] text-center font-black text-foreground tabular-nums" aria-live="polite">
+            {sessions}
+          </span>
+          <button
+            type="button"
+            onClick={() => onIncrement(categoryId)}
+            className="p-2 rounded-lg border border-border text-primary hover:bg-primary/10 transition-colors"
+            aria-label={`Increase ${meta.label} sessions`}
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+      <ProgressBar value={percent} label="Goal progress (30 sessions)" barClassName="bg-gradient-to-r from-emerald-500 to-primary" />
+    </article>
+  );
+}

--- a/frontend/src/components/interviewPrep/DailyChecklist.jsx
+++ b/frontend/src/components/interviewPrep/DailyChecklist.jsx
@@ -1,0 +1,58 @@
+import { CheckCircle2, Circle } from 'lucide-react';
+import { CATEGORY_META } from '../../lib/interviewPrepTracker';
+
+/**
+ * Today's preparation checklist with accessible toggles.
+ */
+export default function DailyChecklist({ tasks, onToggle }) {
+  return (
+    <section
+      className="rounded-3xl border border-border bg-card p-6 shadow-sm"
+      aria-labelledby="daily-checklist-heading"
+    >
+      <h2 id="daily-checklist-heading" className="text-lg font-black text-foreground mb-1">
+        Daily preparation checklist
+      </h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        Check off items as you complete them today. Progress saves automatically.
+      </p>
+
+      <ul className="space-y-3" role="list">
+        {tasks.map((task) => {
+          const categoryLabel = CATEGORY_META[task.category]?.label ?? task.category;
+          return (
+            <li key={task.id}>
+              <label
+                className={`flex items-start gap-3 p-4 rounded-2xl border cursor-pointer transition-colors ${
+                  task.completed
+                    ? 'bg-emerald-500/10 border-emerald-500/30'
+                    : 'bg-muted/30 border-border hover:border-primary/30'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={task.completed}
+                  onChange={() => onToggle(task.id)}
+                />
+                {task.completed ? (
+                  <CheckCircle2 className="w-5 h-5 text-emerald-500 shrink-0 mt-0.5" aria-hidden="true" />
+                ) : (
+                  <Circle className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+                )}
+                <span className="flex-1 min-w-0">
+                  <span className={`block text-sm font-bold ${task.completed ? 'text-foreground line-through opacity-80' : 'text-foreground'}`}>
+                    {task.label}
+                  </span>
+                  <span className="text-[10px] font-black uppercase tracking-widest text-muted-foreground mt-1 inline-block">
+                    {categoryLabel}
+                  </span>
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/interviewPrep/ProgressBar.jsx
+++ b/frontend/src/components/interviewPrep/ProgressBar.jsx
@@ -1,0 +1,40 @@
+import { motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+/**
+ * Accessible horizontal progress bar using design tokens.
+ */
+export default function ProgressBar({
+  value = 0,
+  label,
+  className = '',
+  barClassName = 'bg-gradient-to-r from-primary to-secondary',
+}) {
+  const clamped = Math.min(100, Math.max(0, value));
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {label && (
+        <div className="flex justify-between items-center text-sm">
+          <span className="text-muted-foreground font-medium">{label}</span>
+          <span className="text-foreground font-bold tabular-nums">{clamped}%</span>
+        </div>
+      )}
+      <div
+        className="h-2.5 bg-muted rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label || 'Progress'}
+      >
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${clamped}%` }}
+          transition={{ duration: 0.6, ease: 'easeOut' }}
+          className={cn('h-full rounded-full', barClassName)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/interviewPrep/StreakTracker.jsx
+++ b/frontend/src/components/interviewPrep/StreakTracker.jsx
@@ -1,0 +1,50 @@
+import { Flame, Trophy } from 'lucide-react';
+import Badge from '../Badge';
+
+/**
+ * Displays current and longest preparation streaks.
+ */
+export default function StreakTracker({ streak }) {
+  const current = streak?.current ?? 0;
+  const longest = streak?.longest ?? 0;
+
+  return (
+    <section
+      className="rounded-3xl border border-border bg-card p-6 shadow-sm"
+      aria-labelledby="streak-heading"
+    >
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <h2 id="streak-heading" className="text-lg font-black text-foreground flex items-center gap-2">
+            <Flame className="w-5 h-5 text-amber-500" aria-hidden="true" />
+            Learning streak
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Complete at least one daily checklist item to keep your streak alive.
+          </p>
+        </div>
+        <Badge variant="warning" dot>
+          {current} day{current === 1 ? '' : 's'}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="rounded-2xl bg-amber-500/10 border border-amber-500/20 p-4 text-center">
+          <p className="text-3xl font-black text-amber-500 tabular-nums">{current}</p>
+          <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest mt-1">
+            Current streak
+          </p>
+        </div>
+        <div className="rounded-2xl bg-primary/10 border border-primary/20 p-4 text-center">
+          <p className="text-3xl font-black text-primary tabular-nums flex items-center justify-center gap-1">
+            <Trophy className="w-6 h-6" aria-hidden="true" />
+            {longest}
+          </p>
+          <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest mt-1">
+            Best streak
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/interviewPrep/TaskSummaryPanels.jsx
+++ b/frontend/src/components/interviewPrep/TaskSummaryPanels.jsx
@@ -1,0 +1,55 @@
+import { CheckCircle2, ListTodo } from 'lucide-react';
+import { CATEGORY_META } from '../../lib/interviewPrepTracker';
+
+function TaskList({ title, icon: Icon, tasks, emptyMessage, accentClass }) {
+  return (
+    <div className={`rounded-2xl border p-5 ${accentClass}`}>
+      <h3 className="text-sm font-black text-foreground flex items-center gap-2 mb-4">
+        <Icon className="w-4 h-4" aria-hidden="true" />
+        {title}
+        <span className="ml-auto text-xs font-bold text-muted-foreground tabular-nums">
+          {tasks.length}
+        </span>
+      </h3>
+      {tasks.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="space-y-2" role="list">
+          {tasks.map((task) => (
+            <li key={task.id} className="text-sm text-foreground font-medium flex items-center gap-2">
+              <span className="w-1.5 h-1.5 rounded-full bg-current opacity-60 shrink-0" />
+              <span className="flex-1">{task.label}</span>
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                {CATEGORY_META[task.category]?.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Completed vs pending task lists for today.
+ */
+export default function TaskSummaryPanels({ completed, pending }) {
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      <TaskList
+        title="Completed today"
+        icon={CheckCircle2}
+        tasks={completed}
+        emptyMessage="No items completed yet — start with your checklist above."
+        accentClass="border-emerald-500/20 bg-emerald-500/5"
+      />
+      <TaskList
+        title="Pending today"
+        icon={ListTodo}
+        tasks={pending}
+        emptyMessage="You’re all caught up for today. Great work!"
+        accentClass="border-amber-500/20 bg-amber-500/5"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/interviewPrep/WeeklySummary.jsx
+++ b/frontend/src/components/interviewPrep/WeeklySummary.jsx
@@ -1,0 +1,58 @@
+import { BarChart3, CalendarDays } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+/**
+ * Seven-day checklist completion summary.
+ */
+export default function WeeklySummary({ weekly }) {
+  if (!weekly) return null;
+
+  return (
+    <section
+      className="rounded-3xl border border-border bg-card p-6 shadow-sm"
+      aria-labelledby="weekly-summary-heading"
+    >
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h2 id="weekly-summary-heading" className="text-lg font-black text-foreground flex items-center gap-2">
+            <CalendarDays className="w-5 h-5 text-primary" aria-hidden="true" />
+            Weekly summary
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            {weekly.totalCompleted} of {weekly.totalTasks} checklist items completed this week
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-sm font-bold text-foreground">
+          <BarChart3 className="w-4 h-4 text-emerald-500" aria-hidden="true" />
+          <span className="tabular-nums">{weekly.averagePercent}%</span>
+          <span className="text-muted-foreground font-medium">avg. completion</span>
+        </div>
+      </div>
+
+      <ul className="grid grid-cols-7 gap-2" aria-label="Daily completion for the past week">
+        {weekly.days.map((day) => (
+          <li key={day.dateKey} className="flex flex-col items-center gap-2 min-w-0">
+            <span className="text-[10px] font-black uppercase tracking-wider text-muted-foreground truncate w-full text-center">
+              {day.label}
+            </span>
+            <div
+              className="w-full aspect-square max-w-[3rem] rounded-xl bg-muted border border-border flex items-end overflow-hidden"
+              title={`${day.completed} of ${day.total} tasks`}
+            >
+              <motion.div
+                initial={{ height: 0 }}
+                animate={{ height: `${day.percent}%` }}
+                transition={{ duration: 0.5 }}
+                className="w-full bg-gradient-to-t from-primary to-secondary rounded-t-lg min-h-[4px]"
+                role="presentation"
+              />
+            </div>
+            <span className="text-[10px] font-bold text-foreground tabular-nums">
+              {day.completed}/{day.total}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useInterviewPrepTracker.js
+++ b/frontend/src/hooks/useInterviewPrepTracker.js
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  decrementCategory,
+  ensureToday,
+  getDayRecord,
+  getOverallStats,
+  getTodayKey,
+  incrementCategory,
+  loadTrackerState,
+  saveTrackerState,
+  toggleTask,
+} from '../lib/interviewPrepTracker';
+
+/**
+ * Manages interview preparation tracker state with localStorage persistence.
+ */
+export function useInterviewPrepTracker() {
+  const [state, setState] = useState(() => loadTrackerState());
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    saveTrackerState(state);
+  }, [state, hydrated]);
+
+  const persist = useCallback((updater) => {
+    setState((prev) => ensureToday(updater(prev)));
+  }, []);
+
+  const handleToggleTask = useCallback((taskId) => {
+    persist((prev) => toggleTask(prev, taskId));
+  }, [persist]);
+
+  const handleIncrementCategory = useCallback((categoryId) => {
+    persist((prev) => incrementCategory(prev, categoryId));
+  }, [persist]);
+
+  const handleDecrementCategory = useCallback((categoryId) => {
+    persist((prev) => decrementCategory(prev, categoryId));
+  }, [persist]);
+
+  const stats = getOverallStats(state);
+  const todayTasks = getDayRecord(state, getTodayKey())?.tasks ?? [];
+
+  return {
+    state,
+    stats,
+    todayTasks,
+    hydrated,
+    toggleTask: handleToggleTask,
+    incrementCategory: handleIncrementCategory,
+    decrementCategory: handleDecrementCategory,
+  };
+}

--- a/frontend/src/lib/interviewPrepTracker.js
+++ b/frontend/src/lib/interviewPrepTracker.js
@@ -1,0 +1,291 @@
+/**
+ * Local persistence and derived metrics for the Interview Preparation Tracker.
+ * @module interviewPrepTracker
+ */
+
+export const INTERVIEW_PREP_STORAGE_KEY = 'careerpilot_interview_prep_tracker_v1';
+
+export const TRACKER_VERSION = 1;
+
+export const CATEGORY_IDS = ['dsa', 'aptitude', 'csSubjects', 'mockInterview'];
+
+export const CATEGORY_META = {
+  dsa: { label: 'DSA', description: 'Data structures & algorithms practice' },
+  aptitude: { label: 'Aptitude', description: 'Quantitative & logical reasoning' },
+  csSubjects: { label: 'CS Subjects', description: 'OS, DBMS, CN, OOP, etc.' },
+  mockInterview: { label: 'Mock Interviews', description: 'Timed mock sessions & reviews' },
+};
+
+const DEFAULT_DAILY_TASKS = [
+  { id: 'daily-review-notes', label: 'Review yesterday’s notes', category: 'csSubjects' },
+  { id: 'daily-dsa-problem', label: 'Solve at least 1 DSA problem', category: 'dsa' },
+  { id: 'daily-aptitude-set', label: 'Complete an aptitude practice set', category: 'aptitude' },
+  { id: 'daily-cs-revision', label: 'Revise one CS core subject topic', category: 'csSubjects' },
+  { id: 'daily-mock-prep', label: 'Practice behavioral / HR answers', category: 'mockInterview' },
+];
+
+function emptyCategoryProgress() {
+  return CATEGORY_IDS.reduce((acc, id) => {
+    acc[id] = { sessionsCompleted: 0, minutesSpent: 0 };
+    return acc;
+  }, {});
+}
+
+export function createDefaultState() {
+  const today = getTodayKey();
+  return {
+    version: TRACKER_VERSION,
+    categoryProgress: emptyCategoryProgress(),
+    days: {
+      [today]: buildDayRecord(today),
+    },
+    streak: { current: 0, longest: 0, lastActiveDate: null },
+  };
+}
+
+function buildDayRecord(dateKey) {
+  return {
+    date: dateKey,
+    tasks: DEFAULT_DAILY_TASKS.map((task) => ({
+      ...task,
+      completed: false,
+      completedAt: null,
+    })),
+  };
+}
+
+/** @returns {string} YYYY-MM-DD in local timezone */
+export function getTodayKey(date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function parseDateKey(dateKey) {
+  const [y, m, d] = dateKey.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function addDays(dateKey, delta) {
+  const next = parseDateKey(dateKey);
+  next.setDate(next.getDate() + delta);
+  return getTodayKey(next);
+}
+
+function migrateState(raw) {
+  if (!raw || typeof raw !== 'object') return createDefaultState();
+  if (raw.version !== TRACKER_VERSION) {
+    return { ...createDefaultState(), ...raw, version: TRACKER_VERSION };
+  }
+  return raw;
+}
+
+export function loadTrackerState() {
+  if (typeof window === 'undefined') return createDefaultState();
+  try {
+    const stored = window.localStorage.getItem(INTERVIEW_PREP_STORAGE_KEY);
+    if (!stored) return createDefaultState();
+    return ensureToday(migrateState(JSON.parse(stored)));
+  } catch {
+    return createDefaultState();
+  }
+}
+
+export function saveTrackerState(state) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(INTERVIEW_PREP_STORAGE_KEY, JSON.stringify(state));
+}
+
+/** Ensures today exists in days map and prunes records older than 90 days. */
+export function ensureToday(state) {
+  const today = getTodayKey();
+  const days = { ...state.days };
+
+  if (!days[today]) {
+    days[today] = buildDayRecord(today);
+  }
+
+  const cutoff = addDays(today, -90);
+  Object.keys(days).forEach((key) => {
+    if (key < cutoff) delete days[key];
+  });
+
+  const next = { ...state, days };
+  next.streak = computeStreak(next);
+  return next;
+}
+
+export function getDayRecord(state, dateKey = getTodayKey()) {
+  return state.days[dateKey] || null;
+}
+
+export function toggleTask(state, taskId, dateKey = getTodayKey()) {
+  const next = ensureToday({ ...state });
+  const day = next.days[dateKey];
+  if (!day) return next;
+
+  const tasks = day.tasks.map((task) => {
+    if (task.id !== taskId) return task;
+    const completed = !task.completed;
+    return {
+      ...task,
+      completed,
+      completedAt: completed ? new Date().toISOString() : null,
+    };
+  });
+
+  next.days = { ...next.days, [dateKey]: { ...day, tasks } };
+  next.streak = computeStreak(next);
+  return next;
+}
+
+export function incrementCategory(state, categoryId, { sessions = 1, minutes = 0 } = {}) {
+  if (!CATEGORY_IDS.includes(categoryId)) return state;
+  const next = ensureToday({ ...state });
+  const current = next.categoryProgress[categoryId] || { sessionsCompleted: 0, minutesSpent: 0 };
+  next.categoryProgress = {
+    ...next.categoryProgress,
+    [categoryId]: {
+      sessionsCompleted: current.sessionsCompleted + sessions,
+      minutesSpent: current.minutesSpent + minutes,
+    },
+  };
+  return next;
+}
+
+export function decrementCategory(state, categoryId) {
+  if (!CATEGORY_IDS.includes(categoryId)) return state;
+  const next = ensureToday({ ...state });
+  const current = next.categoryProgress[categoryId] || { sessionsCompleted: 0, minutesSpent: 0 };
+  next.categoryProgress = {
+    ...next.categoryProgress,
+    [categoryId]: {
+      sessionsCompleted: Math.max(0, current.sessionsCompleted - 1),
+      minutesSpent: current.minutesSpent,
+    },
+  };
+  return next;
+}
+
+/**
+ * A day counts toward the streak if at least one daily task is completed.
+ */
+export function computeStreak(state) {
+  const activeDates = Object.keys(state.days)
+    .filter((dateKey) => {
+      const day = state.days[dateKey];
+      return day?.tasks?.some((t) => t.completed);
+    })
+    .sort();
+
+  if (activeDates.length === 0) {
+    return { current: 0, longest: 0, lastActiveDate: null };
+  }
+
+  let longest = 0;
+  let run = 0;
+  let prev = null;
+
+  activeDates.forEach((dateKey) => {
+    if (!prev) {
+      run = 1;
+    } else if (addDays(prev, 1) === dateKey) {
+      run += 1;
+    } else {
+      run = 1;
+    }
+    longest = Math.max(longest, run);
+    prev = dateKey;
+  });
+
+  const today = getTodayKey();
+  const lastActive = activeDates[activeDates.length - 1];
+  let current = 0;
+
+  if (lastActive === today || addDays(lastActive, 1) === today) {
+    current = 1;
+    for (let i = activeDates.length - 2; i >= 0; i -= 1) {
+      if (addDays(activeDates[i], 1) === activeDates[i + 1]) {
+        current += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  return { current, longest, lastActiveDate: lastActive };
+}
+
+export function getTaskLists(state, dateKey = getTodayKey()) {
+  const day = getDayRecord(state, dateKey);
+  if (!day) return { completed: [], pending: [] };
+  const completed = day.tasks.filter((t) => t.completed);
+  const pending = day.tasks.filter((t) => !t.completed);
+  return { completed, pending };
+}
+
+/** Overall progress: share of today's checklist completed (0–100). */
+export function getTodayProgressPercent(state, dateKey = getTodayKey()) {
+  const day = getDayRecord(state, dateKey);
+  if (!day?.tasks?.length) return 0;
+  const done = day.tasks.filter((t) => t.completed).length;
+  return Math.round((done / day.tasks.length) * 100);
+}
+
+/** Category progress as % toward a soft goal of 30 sessions per category. */
+export function getCategoryProgressPercent(categoryProgress, categoryId) {
+  const sessions = categoryProgress[categoryId]?.sessionsCompleted ?? 0;
+  const goal = 30;
+  return Math.min(100, Math.round((sessions / goal) * 100));
+}
+
+export function getWeeklySummary(state) {
+  const today = getTodayKey();
+  const days = [];
+
+  for (let i = 6; i >= 0; i -= 1) {
+    const dateKey = addDays(today, -i);
+    const day = state.days[dateKey];
+    const total = day?.tasks?.length ?? DEFAULT_DAILY_TASKS.length;
+    const completed = day?.tasks?.filter((t) => t.completed).length ?? 0;
+    const label = parseDateKey(dateKey).toLocaleDateString(undefined, {
+      weekday: 'short',
+    });
+    days.push({
+      dateKey,
+      label,
+      completed,
+      total,
+      percent: total ? Math.round((completed / total) * 100) : 0,
+    });
+  }
+
+  const totalCompleted = days.reduce((sum, d) => sum + d.completed, 0);
+  const totalTasks = days.reduce((sum, d) => sum + d.total, 0);
+
+  return {
+    days,
+    totalCompleted,
+    totalTasks,
+    averagePercent: totalTasks ? Math.round((totalCompleted / totalTasks) * 100) : 0,
+  };
+}
+
+export function getOverallStats(state) {
+  const { completed, pending } = getTaskLists(state);
+  const weekly = getWeeklySummary(state);
+  const categoryTotals = CATEGORY_IDS.reduce((acc, id) => {
+    acc[id] = state.categoryProgress[id]?.sessionsCompleted ?? 0;
+    return acc;
+  }, {});
+
+  return {
+    todayProgress: getTodayProgressPercent(state),
+    streak: state.streak,
+    completedCount: completed.length,
+    pendingCount: pending.length,
+    weekly,
+    categoryTotals,
+  };
+}

--- a/frontend/src/pages/InterviewPrepTracker.jsx
+++ b/frontend/src/pages/InterviewPrepTracker.jsx
@@ -1,0 +1,178 @@
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import {
+  ArrowLeft,
+  ChevronRight,
+  ClipboardList,
+  Flame,
+  Target,
+  TrendingUp,
+} from 'lucide-react';
+import { useInterviewPrepTracker } from '../hooks/useInterviewPrepTracker';
+import { CATEGORY_IDS } from '../lib/interviewPrepTracker';
+import ProgressBar from '../components/interviewPrep/ProgressBar';
+import StreakTracker from '../components/interviewPrep/StreakTracker';
+import WeeklySummary from '../components/interviewPrep/WeeklySummary';
+import CategoryTrackerCard from '../components/interviewPrep/CategoryTrackerCard';
+import DailyChecklist from '../components/interviewPrep/DailyChecklist';
+import TaskSummaryPanels from '../components/interviewPrep/TaskSummaryPanels';
+import { getTaskLists } from '../lib/interviewPrepTracker';
+
+const statCards = [
+  { key: 'todayProgress', label: "Today's progress", icon: Target, suffix: '%' },
+  { key: 'completedCount', label: 'Completed', icon: ClipboardList, suffix: '' },
+  { key: 'pendingCount', label: 'Pending', icon: TrendingUp, suffix: '' },
+  { key: 'streakCurrent', label: 'Streak', icon: Flame, suffix: 'd' },
+];
+
+export default function InterviewPrepTracker() {
+  const {
+    state,
+    stats,
+    todayTasks,
+    hydrated,
+    toggleTask,
+    incrementCategory,
+    decrementCategory,
+  } = useInterviewPrepTracker();
+
+  const { completed, pending } = getTaskLists(state);
+
+  const statValues = {
+    todayProgress: stats.todayProgress,
+    completedCount: stats.completedCount,
+    pendingCount: stats.pendingCount,
+    streakCurrent: stats.streak.current,
+  };
+
+  if (!hydrated) {
+    return (
+      <div className="min-h-[50vh] flex items-center justify-center bg-background">
+        <div className="w-10 h-10 border-4 border-muted border-t-primary rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <motion.nav
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground mb-6"
+          aria-label="Breadcrumb"
+        >
+          <Link
+            to="/dashboard"
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors font-medium"
+          >
+            <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+            Dashboard
+          </Link>
+          <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" />
+          <Link to="/hub/career" className="hover:text-foreground transition-colors font-medium">
+            Career Growth
+          </Link>
+          <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" />
+          <span className="text-foreground font-semibold">Interview Prep Tracker</span>
+        </motion.nav>
+
+        <motion.header
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          className="mb-10 p-8 glass rounded-3xl glow border-border/50 relative overflow-hidden"
+        >
+          <div className="absolute top-0 right-0 -mr-20 -mt-20 w-72 h-72 bg-primary/10 rounded-full blur-3xl pointer-events-none" />
+          <div className="relative">
+            <p className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.2em] text-primary mb-4">
+              <ClipboardList className="w-4 h-4" aria-hidden="true" />
+              Preparation dashboard
+            </p>
+            <h1 className="text-3xl md:text-4xl font-black text-foreground tracking-tight mb-2">
+              Interview Preparation Tracker
+            </h1>
+            <p className="text-base md:text-lg text-muted-foreground font-medium max-w-2xl">
+              Track DSA, aptitude, CS subjects, and mock interviews with a daily checklist, streaks, and weekly insights — saved on this device.
+            </p>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Looking for AI mock interviews?{' '}
+              <Link to="/interview-prep" className="text-primary font-bold hover:underline">
+                Open AI Interview Prep
+              </Link>
+            </p>
+          </div>
+        </motion.header>
+
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.05 }}
+          className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8"
+        >
+          {statCards.map(({ key, label, icon: Icon, suffix }) => (
+            <div
+              key={key}
+              className="rounded-2xl border border-border bg-card p-5 text-center shadow-sm"
+            >
+              <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center mx-auto mb-3">
+                <Icon className="w-5 h-5 text-primary" aria-hidden="true" />
+              </div>
+              <p className="text-2xl font-black text-foreground tabular-nums">
+                {statValues[key]}
+                {suffix}
+              </p>
+              <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mt-1">
+                {label}
+              </p>
+            </div>
+          ))}
+        </motion.div>
+
+        <div className="mb-8 rounded-3xl border border-border bg-card p-6 shadow-sm">
+          <ProgressBar value={stats.todayProgress} label="Overall daily completion" />
+        </div>
+
+        <div className="grid lg:grid-cols-2 gap-6 mb-8">
+          <StreakTracker streak={stats.streak} />
+          <WeeklySummary weekly={stats.weekly} />
+        </div>
+
+        <section className="mb-8" aria-labelledby="category-tracking-heading">
+          <h2 id="category-tracking-heading" className="text-xl font-black text-foreground mb-4 flex items-center gap-2">
+            <span className="w-1.5 h-6 rounded-full bg-primary" aria-hidden="true" />
+            Category tracking
+          </h2>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {CATEGORY_IDS.map((categoryId) => (
+              <CategoryTrackerCard
+                key={categoryId}
+                categoryId={categoryId}
+                categoryProgress={state.categoryProgress}
+                onIncrement={incrementCategory}
+                onDecrement={decrementCategory}
+              />
+            ))}
+          </div>
+        </section>
+
+        <div className="grid lg:grid-cols-[1.4fr_1fr] gap-6 mb-8">
+          <DailyChecklist tasks={todayTasks} onToggle={toggleTask} />
+          <div className="space-y-4">
+            <TaskSummaryPanels completed={completed} pending={pending} />
+            <div className="rounded-2xl border border-border bg-muted/30 p-4 text-xs text-muted-foreground leading-relaxed">
+              <strong className="text-foreground">Mock interview tip:</strong> Log a session in Mock Interviews after each practice run, then use{' '}
+              <Link to="/interview-prep" className="text-primary font-bold hover:underline">
+                AI Interview Prep
+              </Link>{' '}
+              for scored feedback and{' '}
+              <Link to="/dashboard/analytics" className="text-primary font-bold hover:underline">
+                Interview Analytics
+              </Link>{' '}
+              for trends.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/hubs/CareerGrowthHub.jsx
+++ b/frontend/src/pages/hubs/CareerGrowthHub.jsx
@@ -1,4 +1,4 @@
-import { GraduationCap, Mic, Mail, Linkedin, Sparkles, Award } from 'lucide-react'
+import { GraduationCap, Mic, Mail, Linkedin, Sparkles, Award, ClipboardList } from 'lucide-react'
 import HubLayout from '../../components/HubLayout'
 import ToolCard from '../../components/ToolCard'
 
@@ -11,6 +11,14 @@ export default function CareerGrowthHub() {
       color="primary"
       breadcrumb="Career Growth"
     >
+      <ToolCard
+        to="/interview-prep-tracker"
+        icon={ClipboardList}
+        title="Interview Prep Tracker"
+        description="Daily checklist, DSA & aptitude tracking, streaks, and weekly preparation summaries."
+        badge="Local"
+        color="emerald-500"
+      />
       <ToolCard
         to="/interview-prep"
         icon={Mic}


### PR DESCRIPTION
## Description
Adds a client-side Interview Preparation Tracker at `/interview-prep-tracker` with daily checklist, category session tracking (DSA, aptitude, CS subjects, mock interviews), progress %, weekly summary, streak, and completed/pending views. Data persists via localStorage.

## Type of Change
- [x] New feature

## Related Issue
Fixes #2593 

## Architecture decisions
- New page under Career Growth hub, separate from AI mock interview (`/interview-prep`) and API analytics (`/dashboard/analytics`).
- Storage key: `careerpilot_interview_prep_tracker_v1`.

## Testing
- [x] Manual testing completed
- [ ] `npm run lint` in frontend (run locally after `npm install`)



## Checklist
- [x] Follows project style guidelines
- [x] Documentation added (`docs/interview-prep-tracker.md`)
- [x] No new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interview Preparation Tracker: A new dashboard for structuring daily interview prep. Features include daily checklist for tasks, category-based session tracking with progress toward 30-session goals per category, learning streak counter, weekly completion summary, and daily progress visualization. All data is stored locally in your browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->