### PR TITLE
fix(backend): remove unused multer-storage-cloudinary causing peer dependency conflict

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,6 @@
     "marked": "^18.0.3",
     "mongoose": "^9.6.2",
     "multer": "^1.4.5-lts.1",
-    "multer-storage-cloudinary": "^4.0.0",
     "node-cron": "^4.2.1",
     "node-fetch": "^3.3.2",
     "nodemailer": "^8.0.7",


### PR DESCRIPTION
## Description
Removes the unused `multer-storage-cloudinary@4.0.0` dependency from 
backend/package.json which was causing `npm install` to fail for all 
new contributors.

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #2603

## Testing
- [x] Ran `npm install` in /backend — completes successfully after this change
- [x] Confirmed `multer-storage-cloudinary` is not imported anywhere in the codebase

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused backend dependency to optimize project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->