### PR TITLE
feat: add Zod-based request payload validation middleware

### DIFF
--- a/backend/src/middleware/validateRequest.js
+++ b/backend/src/middleware/validateRequest.js
@@ -1,17 +1,23 @@
+import { ZodError } from 'zod';
+
 const validateRequest = (schema) => {
   return (req, res, next) => {
     try {
       schema.parse(req.body);
       next();
     } catch (error) {
-      const details = (error.issues ?? error.errors ?? []).map((issue) => ({
-        field: issue.path?.join('.') || 'root',
-        message: issue.message,
-      }));
-      return res.status(400).json({
-        error: 'Validation failed',
-        details,
-      });
+      if (error instanceof ZodError) {
+        const details = error.issues.map((issue) => ({
+          field: issue.path.join('.') || 'root',
+          message: issue.message,
+        }));
+        return res.status(400).json({
+          success: false,
+          error: 'Validation failed',
+          details,
+        });
+      }
+      next(error);
     }
   };
 };

--- a/backend/src/middleware/validateRequest.js
+++ b/backend/src/middleware/validateRequest.js
@@ -1,0 +1,19 @@
+const validateRequest = (schema) => {
+  return (req, res, next) => {
+    try {
+      schema.parse(req.body);
+      next();
+    } catch (error) {
+      const details = (error.issues ?? error.errors ?? []).map((issue) => ({
+        field: issue.path?.join('.') || 'root',
+        message: issue.message,
+      }));
+      return res.status(400).json({
+        error: 'Validation failed',
+        details,
+      });
+    }
+  };
+};
+
+export default validateRequest;


### PR DESCRIPTION
## Description\nAdded a reusable middleware for request body validation using Zod schemas.\n\n## Changes\n- Created backend/src/middleware/validateRequest.js\n- Returns validation error details on failure\n- Compatible with Zod schemas\n\n## Related Issue\nCloses #2760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved request validation: invalid submissions now return HTTP 400 with a clear, structured response including a "details" array of field-specific messages.
  * Non-validation errors are forwarded so other error handling remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->