### PR TITLE
feat: add CSRF protection middleware

### DIFF
--- a/backend/src/middleware/csrfProtection.js
+++ b/backend/src/middleware/csrfProtection.js
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+
+const CSRF_COOKIE_NAME = 'csrf-token';
+const CSRF_HEADER_NAME = 'x-csrf-token';
+
+const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
+const generateToken = () => {
+  return crypto.randomBytes(32).toString('hex');
+};
+
+export const csrfProtection = (req, res, next) => {
+  if (SAFE_METHODS.includes(req.method)) {
+    if (!req.cookies[CSRF_COOKIE_NAME]) {
+      const token = generateToken();
+      res.cookie(CSRF_COOKIE_NAME, token, {
+        httpOnly: false,
+        sameSite: 'strict',
+        secure: process.env.NODE_ENV === 'production',
+      });
+    }
+    return next();
+  }
+
+  const cookieToken = req.cookies?.[CSRF_COOKIE_NAME];
+  const headerToken = req.headers[CSRF_HEADER_NAME];
+
+  if (!cookieToken || !headerToken) {
+    return res.status(403).json({
+      error: 'CSRF validation failed',
+      message: 'Missing CSRF token',
+    });
+  }
+
+  if (!crypto.timingSafeEqual(Buffer.from(cookieToken), Buffer.from(headerToken))) {
+    return res.status(403).json({
+      error: 'CSRF validation failed',
+      message: 'Invalid CSRF token',
+    });
+  }
+
+  next();
+};


### PR DESCRIPTION
## Description\nAdded CSRF protection using double-submit cookie pattern with no external dependencies.\n\n## Changes\n- Created backend/src/middleware/csrfProtection.js\n- Integrated into Express app in index.js\n- Uses crypto.timingSafeEqual for secure token comparison\n\n## Related Issue\nCloses #2762