### PR TITLE
feat: add focus trap hook for modal accessibility

### DIFF
--- a/frontend/src/hooks/useFocusTrap.js
+++ b/frontend/src/hooks/useFocusTrap.js
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export function useFocusTrap(active) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!active || !ref.current) return;
+
+    const container = ref.current;
+    const previouslyFocused = document.activeElement;
+
+    const getFocusableElements = () =>
+      container.querySelectorAll(FOCUSABLE_SELECTOR);
+
+    const focusFirstElement = () => {
+      const elements = getFocusableElements();
+      if (elements.length > 0) {
+        elements[0].focus();
+      }
+    };
+
+    focusFirstElement();
+
+    const handleKeyDown = (e) => {
+      if (e.key !== 'Tab') return;
+
+      const elements = getFocusableElements();
+      if (elements.length === 0) return;
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (previouslyFocused && previouslyFocused.focus) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [active]);
+
+  return ref;
+}


### PR DESCRIPTION
## Description\nCreated a reusable React hook that traps keyboard focus within modal dialogs, improving accessibility compliance.\n\n## Changes\n- Created frontend/src/hooks/useFocusTrap.js\n- Traps Tab/Shift+Tab within focusable elements\n- Restores focus to previously focused element on deactivation\n\n## Related Issue\nCloses #2807