### PR TITLE
fix(cors): require FRONTEND_URL in production and gate localhost origins

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -95,12 +95,30 @@ const PORT = process.env.PORT || 5001;
 console.log('🔧 FRONTEND_URL env var:', process.env.FRONTEND_URL);
 
 // CORS configuration - MUST come before helmet
-const allowedOrigins = [
-  'http://localhost:5173',
-  'http://localhost:3000',
-  'https://careerpilotyy.netlify.app',  // Hardcoded as fallback
-  process.env.FRONTEND_URL,
-].filter(Boolean).map(url => url.replace(/\/$/, '')); // Remove trailing slashes
+// Localhost origins are only trusted outside production. In production the
+// allowed origins come from FRONTEND_URL (plus the known deployed frontend),
+// so a misconfigured deployment fails fast instead of silently trusting
+// developer machine origins.
+const buildAllowedOrigins = () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (isProduction && !process.env.FRONTEND_URL) {
+    throw new Error('FRONTEND_URL must be set in production for CORS configuration.');
+  }
+
+  const origins = [
+    'https://careerpilotyy.netlify.app', // known deployed frontend
+    process.env.FRONTEND_URL,
+  ];
+
+  if (!isProduction) {
+    origins.push('http://localhost:5173', 'http://localhost:3000');
+  }
+
+  return origins.filter(Boolean).map(url => url.replace(/\/$/, '')); // Remove trailing slashes
+};
+
+const allowedOrigins = buildAllowedOrigins();
 
 console.log('🔧 Allowed origins:', allowedOrigins);
 


### PR DESCRIPTION
## Description

The CORS allowlist in `backend/src/index.js` hardcoded `http://localhost:5173` and `http://localhost:3000` unconditionally, so those developer origins were trusted in every environment, including production. A production deployment that forgot to set `FRONTEND_URL` would also silently fall back to a permissive list rather than failing.

## Related Issue

Closes #2881

## Changes Made

| File | Change |
|---|---|
| `backend/src/index.js` | Replaced the static `allowedOrigins` array with `buildAllowedOrigins()`. Localhost origins are added only when `NODE_ENV` is not `production`. In production, a missing `FRONTEND_URL` throws at startup so the misconfiguration is caught immediately. |

## Testing Done

- `node --check src/index.js` passes.
- In development the localhost origins remain allowed.
- In production with `FRONTEND_URL` set, only the deployed frontend and `FRONTEND_URL` are allowed.
- In production without `FRONTEND_URL`, startup throws with a clear message.

## Checklist

- [x] No merge conflicts with the base branch
- [x] Change is focused on the reported surface
- [x] No em dashes or double hyphens in comments

## Program

Contributing under GSSoC '26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CORS security with environment-aware origin validation. Production mode now enforces frontend URL configuration and restricts allowed origins accordingly, improving deployment security. Non-production environments include localhost support for development flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->