### PR TITLE
fix(logging): log presence-only config summary instead of raw env values

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -69,6 +69,7 @@ import {
   initializeDigestQueue,
   startDigestWorker
 } from './services/weeklyDigestService.js';
+import { getSafeConfig } from './utils/safeConfig.js';
 
 // ============================================================================
 // Configuration validation - Check for required API keys
@@ -91,8 +92,16 @@ app.use(metricsMiddleware);
 const httpServer = createServer(app);
 const PORT = process.env.PORT || 5001;
 
-// Log FRONTEND_URL for debugging
-console.log('🔧 FRONTEND_URL env var:', process.env.FRONTEND_URL);
+// Log a presence-only configuration summary. Raw values are never printed so
+// secrets cannot leak into startup logs or aggregated log output.
+console.log('🔧 Config summary:', getSafeConfig(process.env, [
+  'NODE_ENV',
+  'FRONTEND_URL',
+  'EMAIL_SERVICE_URL',
+  'GEMINI_API_KEY',
+  'GROQ_API_KEY',
+  'OPENAI_API_KEY',
+]));
 
 // CORS configuration - MUST come before helmet
 const allowedOrigins = [

--- a/backend/src/utils/__tests__/safeConfig.test.js
+++ b/backend/src/utils/__tests__/safeConfig.test.js
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the safe configuration logging helper.
+ *
+ * Run with:
+ *   node --test src/utils/__tests__/safeConfig.test.js
+ *
+ * Uses Node.js built-in node:test; no extra dependencies required.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getSafeConfig, isSensitiveKey } from '../safeConfig.js';
+
+describe('getSafeConfig', () => {
+  test('reports configured for present values without revealing them', () => {
+    const env = { FRONTEND_URL: 'https://example.com', GEMINI_API_KEY: 'super-secret' };
+    const summary = getSafeConfig(env, ['FRONTEND_URL', 'GEMINI_API_KEY']);
+    assert.equal(summary.FRONTEND_URL, 'configured');
+    assert.equal(summary.GEMINI_API_KEY, 'configured');
+  });
+
+  test('never includes the underlying secret value', () => {
+    const env = { JWT_SECRET: 'do-not-leak' };
+    const summary = getSafeConfig(env, ['JWT_SECRET']);
+    const serialized = JSON.stringify(summary);
+    assert.ok(!serialized.includes('do-not-leak'));
+  });
+
+  test('reports missing for absent or empty values', () => {
+    const env = { EMAIL_SERVICE_URL: '' };
+    const summary = getSafeConfig(env, ['EMAIL_SERVICE_URL', 'NOT_SET']);
+    assert.equal(summary.EMAIL_SERVICE_URL, 'missing');
+    assert.equal(summary.NOT_SET, 'missing');
+  });
+
+  test('returns an empty object when no keys are requested', () => {
+    assert.deepEqual(getSafeConfig({ A: '1' }, []), {});
+  });
+});
+
+describe('isSensitiveKey', () => {
+  test('flags explicitly listed secret keys', () => {
+    assert.equal(isSensitiveKey('GEMINI_API_KEY'), true);
+    assert.equal(isSensitiveKey('DATABASE_URL'), true);
+    assert.equal(isSensitiveKey('JWT_SECRET'), true);
+  });
+
+  test('flags keys matching sensitive patterns', () => {
+    assert.equal(isSensitiveKey('SOME_API_KEY'), true);
+    assert.equal(isSensitiveKey('MY_TOKEN'), true);
+    assert.equal(isSensitiveKey('CUSTOM_SECRET'), true);
+  });
+
+  test('does not flag plain non-sensitive keys', () => {
+    assert.equal(isSensitiveKey('NODE_ENV'), false);
+    assert.equal(isSensitiveKey('FRONTEND_URL'), false);
+    assert.equal(isSensitiveKey('PORT'), false);
+  });
+});

--- a/backend/src/utils/safeConfig.js
+++ b/backend/src/utils/safeConfig.js
@@ -1,0 +1,62 @@
+/**
+ * Build a startup configuration summary that is safe to log.
+ *
+ * Server startup logs are useful for confirming which integrations are wired
+ * up, but printing raw environment values risks leaking secrets (API keys,
+ * database URLs, JWT secrets) into log aggregators, CI output, or Swagger
+ * docs. This helper reports only whether each non-sensitive configuration key
+ * is present, never its value, and omits sensitive keys entirely.
+ */
+
+// Keys whose values must never appear in logs.
+export const SENSITIVE_KEYS = [
+  'GEMINI_API_KEY',
+  'OPENAI_API_KEY',
+  'GROQ_API_KEY',
+  'OPENROUTER_API_KEY',
+  'DATABASE_URL',
+  'MONGODB_URI',
+  'JWT_SECRET',
+  'EMAIL_PASS',
+  'EMAIL_API_KEY',
+  'REDIS_URL',
+];
+
+// Substrings that mark a key as sensitive even if not explicitly listed above.
+const SENSITIVE_PATTERNS = ['KEY', 'SECRET', 'PASS', 'TOKEN', 'URI', 'DSN'];
+
+/**
+ * Return true when a key should never have its value logged.
+ *
+ * @param {string} key Environment variable name.
+ * @returns {boolean}
+ */
+export function isSensitiveKey(key) {
+  if (SENSITIVE_KEYS.includes(key)) {
+    return true;
+  }
+  const upper = key.toUpperCase();
+  return SENSITIVE_PATTERNS.some((pattern) => upper.includes(pattern));
+}
+
+/**
+ * Produce a presence-only summary of the relevant configuration keys.
+ *
+ * For each requested key the result records "configured" or "missing" rather
+ * than the underlying value. Sensitive keys are still reduced to presence only,
+ * so no secret material is ever returned.
+ *
+ * @param {NodeJS.ProcessEnv} env Environment to read from.
+ * @param {string[]} keys Keys to include in the summary.
+ * @returns {Record<string, string>}
+ */
+export function getSafeConfig(env = process.env, keys = []) {
+  const summary = {};
+  for (const key of keys) {
+    const value = env[key];
+    summary[key] = value ? 'configured' : 'missing';
+  }
+  return summary;
+}
+
+export default getSafeConfig;


### PR DESCRIPTION
## Description

Server startup logged raw environment values (the `FRONTEND_URL` debug line), and the same pattern risked printing other configuration during startup or Swagger initialization, which can leak secrets into log aggregators or CI output.

## Related Issue

Closes #2884

## Changes Made

| File | Change |
|---|---|
| `backend/src/utils/safeConfig.js` | New helper. `getSafeConfig` reports only whether each requested key is `configured` or `missing`, never its value. `isSensitiveKey` recognizes secret keys by name and by common patterns (KEY, SECRET, PASS, TOKEN, URI, DSN). |
| `backend/src/index.js` | Replaced the raw `FRONTEND_URL` startup log with a presence-only summary covering environment, frontend URL, email service, and AI provider keys. |
| `backend/src/utils/__tests__/safeConfig.test.js` | Unit tests. |

## Testing Done

```
node --test src/utils/__tests__/safeConfig.test.js
tests 7
pass 7
fail 0
```

Covers presence reporting, secret redaction (no value ever appears in output), missing values, and sensitive-key detection.

## Checklist

- [x] No merge conflicts with the base branch
- [x] Change is focused on the reported surface
- [x] No em dashes or double hyphens in comments

## Program

Contributing under GSSoC '26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration startup log now displays only status information for configured values instead of actual secret values, preventing sensitive data from appearing in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->