### PR TITLE
fix(email): validate email service configuration on startup

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -69,6 +69,7 @@ import {
   initializeDigestQueue,
   startDigestWorker
 } from './services/weeklyDigestService.js';
+import { validateEmailConfig } from './utils/emailConfig.js';
 
 // ============================================================================
 // Configuration validation - Check for required API keys
@@ -259,6 +260,16 @@ app.use((req, res) => {
 app.use(globalErrorHandler);
 const startServer = async () => {
   try {
+    // Fail fast in production when email is not configured; warn otherwise.
+    // Without this check, missing credentials surface only later as silent
+    // send failures.
+    const emailStatus = validateEmailConfig(process.env);
+    if (emailStatus.enabled) {
+      console.log(`📧 ${emailStatus.message}`);
+    } else {
+      console.warn(`⚠️ ${emailStatus.message}`);
+    }
+
     await connectDB();
 
     httpServer.listen(PORT, () => {

--- a/backend/src/utils/__tests__/emailConfig.test.js
+++ b/backend/src/utils/__tests__/emailConfig.test.js
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the email configuration validation helpers.
+ *
+ * Run with:
+ *   node --test src/utils/__tests__/emailConfig.test.js
+ *
+ * Uses Node.js built-in node:test; no extra dependencies required.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  describeEmailConfig,
+  isEmailConfigured,
+  validateEmailConfig,
+} from '../emailConfig.js';
+
+describe('describeEmailConfig', () => {
+  test('detects external service configuration', () => {
+    const env = { EMAIL_SERVICE_URL: 'https://mail.example.com', EMAIL_API_KEY: 'key' };
+    assert.deepEqual(describeEmailConfig(env), { configured: true, mode: 'external' });
+  });
+
+  test('detects SMTP configuration', () => {
+    const env = { EMAIL_USER: 'user@example.com', EMAIL_PASS: 'secret' };
+    assert.deepEqual(describeEmailConfig(env), { configured: true, mode: 'smtp' });
+  });
+
+  test('prefers external mode when both are present', () => {
+    const env = {
+      EMAIL_SERVICE_URL: 'https://mail.example.com',
+      EMAIL_API_KEY: 'key',
+      EMAIL_USER: 'user@example.com',
+      EMAIL_PASS: 'secret',
+    };
+    assert.equal(describeEmailConfig(env).mode, 'external');
+  });
+
+  test('reports none when nothing is configured', () => {
+    assert.deepEqual(describeEmailConfig({}), { configured: false, mode: 'none' });
+  });
+
+  test('treats partial SMTP config as not configured', () => {
+    assert.equal(describeEmailConfig({ EMAIL_USER: 'user@example.com' }).configured, false);
+  });
+});
+
+describe('isEmailConfigured', () => {
+  test('true when external is set', () => {
+    assert.equal(
+      isEmailConfigured({ EMAIL_SERVICE_URL: 'https://m', EMAIL_API_KEY: 'k' }),
+      true
+    );
+  });
+
+  test('false when nothing is set', () => {
+    assert.equal(isEmailConfigured({}), false);
+  });
+});
+
+describe('validateEmailConfig', () => {
+  test('returns enabled status when configured', () => {
+    const result = validateEmailConfig({ EMAIL_USER: 'u@e.com', EMAIL_PASS: 'p' });
+    assert.equal(result.enabled, true);
+    assert.equal(result.mode, 'smtp');
+  });
+
+  test('throws in production when not configured', () => {
+    assert.throws(
+      () => validateEmailConfig({ NODE_ENV: 'production' }),
+      /required in production/
+    );
+  });
+
+  test('warns (does not throw) outside production when not configured', () => {
+    const result = validateEmailConfig({ NODE_ENV: 'development' });
+    assert.equal(result.enabled, false);
+    assert.equal(result.mode, 'none');
+  });
+});

--- a/backend/src/utils/emailConfig.js
+++ b/backend/src/utils/emailConfig.js
@@ -1,0 +1,72 @@
+/**
+ * Email service configuration validation.
+ *
+ * The mail service (src/services/mailService.js) sends mail through one of two
+ * paths: an external Vercel email service (EMAIL_SERVICE_URL + EMAIL_API_KEY)
+ * or a direct SMTP fallback (EMAIL_USER + EMAIL_PASS, with EMAIL_HOST
+ * defaulting to smtp.gmail.com). If neither is configured, email features fail
+ * silently at send time. These helpers let the server detect that at startup.
+ */
+
+/**
+ * Determine which email delivery mode, if any, is configured.
+ *
+ * @param {NodeJS.ProcessEnv} env Environment to read from.
+ * @returns {{ configured: boolean, mode: 'external' | 'smtp' | 'none' }}
+ */
+export function describeEmailConfig(env = process.env) {
+  const hasExternal = Boolean(env.EMAIL_SERVICE_URL && env.EMAIL_API_KEY);
+  if (hasExternal) {
+    return { configured: true, mode: 'external' };
+  }
+
+  const hasSmtp = Boolean(env.EMAIL_USER && env.EMAIL_PASS);
+  if (hasSmtp) {
+    return { configured: true, mode: 'smtp' };
+  }
+
+  return { configured: false, mode: 'none' };
+}
+
+/**
+ * Return true when at least one email delivery path is fully configured.
+ *
+ * @param {NodeJS.ProcessEnv} env Environment to read from.
+ * @returns {boolean}
+ */
+export function isEmailConfigured(env = process.env) {
+  return describeEmailConfig(env).configured;
+}
+
+/**
+ * Validate email configuration for a given environment.
+ *
+ * In production, missing email configuration is a hard error so the
+ * deployment fails fast rather than silently dropping notification email. In
+ * other environments it is a soft warning and email is treated as disabled.
+ *
+ * @param {NodeJS.ProcessEnv} env Environment to read from.
+ * @returns {{ enabled: boolean, mode: string, message: string }}
+ * @throws {Error} When configuration is missing in production.
+ */
+export function validateEmailConfig(env = process.env) {
+  const { configured, mode } = describeEmailConfig(env);
+
+  if (configured) {
+    return { enabled: true, mode, message: `Email service configured (${mode}).` };
+  }
+
+  if (env.NODE_ENV === 'production') {
+    throw new Error(
+      'Email service configuration is required in production. Set EMAIL_SERVICE_URL and EMAIL_API_KEY, or EMAIL_USER and EMAIL_PASS.'
+    );
+  }
+
+  return {
+    enabled: false,
+    mode: 'none',
+    message: 'Email service disabled: no credentials configured.',
+  };
+}
+
+export default validateEmailConfig;


### PR DESCRIPTION
## Description

The mail service (`backend/src/services/mailService.js`) sends through an external service (`EMAIL_SERVICE_URL` plus `EMAIL_API_KEY`) or an SMTP fallback (`EMAIL_USER` plus `EMAIL_PASS`), but nothing verified either was configured at startup. With credentials missing, email features failed silently only when a send was attempted.

## Related Issue

Closes #2883

## Changes Made

| File | Change |
|---|---|
| `backend/src/utils/emailConfig.js` | New helpers: `describeEmailConfig`, `isEmailConfigured`, `validateEmailConfig`. They mirror the mail service's actual configuration logic (external service or SMTP fallback). |
| `backend/src/index.js` | `startServer` now validates email config before listening. In production a missing configuration throws so the deployment fails fast; otherwise it logs a warning and treats email as disabled. |
| `backend/src/utils/__tests__/emailConfig.test.js` | Unit tests. |

## Testing Done

```
node --test src/utils/__tests__/emailConfig.test.js
tests 10
pass 10
fail 0
```

Covers external and SMTP detection, mode precedence, partial configuration, and the production-versus-development behaviour.

## Checklist

- [x] No merge conflicts with the base branch
- [x] Change is focused on the reported surface
- [x] No em dashes or double hyphens in comments

## Program

Contributing under GSSoC '26.