### PR TITLE
feat: implement brutalist zine collage portfolio template #3258

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -254,9 +254,7 @@ function AppRoutes() {
 
         
 
-        <Route path="/templates/chatbot" element={<ChatbotPortfolio />} />
-
-        {/* <Route path="/templates/day-night-cycle" element={<DayNightCycle />} /> */}
+               {/* <Route path="/templates/day-night-cycle" element={<DayNightCycle />} /> */}
         <Route path="/templates/rainforest-canopy" element={<RainforestCanopy />} />
         <Route path="/templates/northern-fjords" element={<NorthernFjords />} />
         <Route path="/templates/duotone-bold" element={<DuotoneBold />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -112,6 +112,7 @@ import LowPolyTerrain from './components/portfolio/templates/Low_Poly_Terrain/in
 import HighFashion from './components/portfolio/templates/High_Fashion/index.jsx';
 import TypographicWheatpastePosterWall from './components/portfolio/templates/Typographic_Wheatpaste_Poster_Wall/index.jsx';
 import TestSocialLinks from './pages/TestSocialLinks';
+import ZineCollage from './components/portfolio/templates/ZineCollage';
 
 function LoadingScreen({ label }) {
   return (
@@ -261,6 +262,7 @@ function AppRoutes() {
         <Route path="/templates/duotone-bold" element={<DuotoneBold />} />
         <Route path="/templates/chromatic-glitch" element={<ChromaticGlitch />} />
         <Route path="/templates/swiss-typography" element={<SwissTypography />} />
+      
         <Route path="/templates/desert-dunes" element={<DesertDunes />} />
         <Route path="/templates/psychedelic-swirl" element={<PsychedelicSwirl />} />
         <Route path="/templates/memphis-pop" element={<MemphisPop />} />
@@ -272,7 +274,7 @@ function AppRoutes() {
         <Route path="/templates/low-poly-terrain" element={<LowPolyTerrain />} />
         <Route path="/templates/high-fashion" element={<HighFashion />} />
         <Route path="/templates/typographic-wheatpaste-poster-wall" element={<TypographicWheatpastePosterWall />} />
-
+        <Route path="/templates/zine-collage" element={<ZineCollage />} />
         <Route path="/templates/chatbot" element={<ChatbotPortfolio />} /> 
         <Route path="/templates/glassmorphism" element={<GlassmorphismTemplate/>} />
         {/* Core Protected Routes */}

--- a/frontend/src/components/portfolio/templates/ZineCollage.jsx
+++ b/frontend/src/components/portfolio/templates/ZineCollage.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-export default function ZineCollage({ data }) {
-  // 🔒 100% Anonymous generic fallback data for public open-source safety
+// Accept both portfolioData (global contract) and data (fallback)
+export default function ZineCollage({ data, portfolioData }) {
+  
+  // 🔒 Safe anonymous template fallbacks
   const localDefault = {
     personal: {
       name: "Alex Morgan",
@@ -34,20 +36,26 @@ export default function ZineCollage({ data }) {
         technologies: ["JavaScript", "Web Audio API", "CSS Grid"]
       }
     ],
-    skills: ["React.js", "Tailwind CSS", "JavaScript (ES6+)", "Framer Motion", "UI/UX Design", "Git & GitHub", "Node.js", "Web APIs"]
+    skills: ["React.js", "Tailwind CSS", "JavaScript (ES6+)", "Framer Motion", "UI/UX Design", "Git & GitHub", "Node.js"]
   };
 
-  const profile = data && Object.keys(data).length > 0 ? data : localDefault;
-  const { personal = {}, experience = [], projects = [], skills = [] } = profile;
+  // 🔄 Normalize incoming props contract
+  const incoming = portfolioData || data || {};
+
+  // 🧩 CodeAnt Fix: Section-by-section default merging instead of all-or-nothing
+  const personal = incoming.personal && Object.keys(incoming.personal).length > 0 ? incoming.personal : localDefault.personal;
+  const experience = incoming.experience && incoming.experience.length > 0 ? incoming.experience : localDefault.experience;
+  const projects = incoming.projects && incoming.projects.length > 0 ? incoming.projects : localDefault.projects;
+  const skills = incoming.skills && incoming.skills.length > 0 ? incoming.skills : localDefault.skills;
 
   return (
     <div className="min-h-screen bg-[#f4ebd0] text-[#1e1e1e] font-mono p-6 md:p-12 selection:bg-black selection:text-white">
       
       {/* 📰 HEADER MASTHEAD */}
       <header className="border-4 border-black p-6 bg-white shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] max-w-5xl mx-auto mb-12 -rotate-1">
-        <h1 className="text-4xl md:text-6xl font-black uppercase tracking-tighter">{personal.name}</h1>
+        <h1 className="text-4xl md:text-6xl font-black uppercase tracking-tighter">{personal.name || "Alex Morgan"}</h1>
         <p className="text-lg md:text-xl font-bold border-t-2 border-black mt-4 pt-2 tracking-tight">
-          {personal.title} // VOL. 01
+          {personal.title || "Creative Developer"} // VOL. 01
         </p>
       </header>
 

--- a/frontend/src/components/portfolio/templates/ZineCollage.jsx
+++ b/frontend/src/components/portfolio/templates/ZineCollage.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+
+export default function ZineCollage({ data }) {
+  // 🔒 100% Anonymous generic fallback data for public open-source safety
+  const localDefault = {
+    personal: {
+      name: "Alex Morgan",
+      title: "Creative Developer // Interface Designer",
+      summary: "Crafting digital experiences at the intersection of avant-garde design systems and clean frontend architecture. Specialized in unconventional layouts, interactive visual mechanics, and pushing the limits of the traditional web canvas."
+    },
+    experience: [
+      {
+        position: "Frontend Engineering Intern",
+        company: "Studio Nexus Labs",
+        startDate: "Jan 2025",
+        description: "Spearheaded modular UI component development and streamlined layout styling frameworks for high-traffic agency web properties."
+      },
+      {
+        position: "Open Source Contributor",
+        company: "DevCom Community Initiative",
+        startDate: "Aug 2025",
+        description: "Contributed to core responsive rendering layout logic and optimized compilation performance thresholds across shared UI toolkits."
+      }
+    ],
+    projects: [
+      {
+        name: "Hyper-Grid Canvas Engine",
+        description: "An experimental web environment featuring interactive user interface mechanics and radical typography formatting layouts.",
+        technologies: ["React", "Tailwind CSS", "Framer Motion"]
+      },
+      {
+        name: "Retro Sound Workstation",
+        description: "A customizable in-browser soundboard workspace simulating hardware racks using responsive CSS layouts.",
+        technologies: ["JavaScript", "Web Audio API", "CSS Grid"]
+      }
+    ],
+    skills: ["React.js", "Tailwind CSS", "JavaScript (ES6+)", "Framer Motion", "UI/UX Design", "Git & GitHub", "Node.js", "Web APIs"]
+  };
+
+  const profile = data && Object.keys(data).length > 0 ? data : localDefault;
+  const { personal = {}, experience = [], projects = [], skills = [] } = profile;
+
+  return (
+    <div className="min-h-screen bg-[#f4ebd0] text-[#1e1e1e] font-mono p-6 md:p-12 selection:bg-black selection:text-white">
+      
+      {/* 📰 HEADER MASTHEAD */}
+      <header className="border-4 border-black p-6 bg-white shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] max-w-5xl mx-auto mb-12 -rotate-1">
+        <h1 className="text-4xl md:text-6xl font-black uppercase tracking-tighter">{personal.name}</h1>
+        <p className="text-lg md:text-xl font-bold border-t-2 border-black mt-4 pt-2 tracking-tight">
+          {personal.title} // VOL. 01
+        </p>
+      </header>
+
+      {/* 🧩 COLLAGE CANVAS MASHUP */}
+      <main className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-12 gap-8 items-start">
+        
+        {/* LEFT COLUMN PANEL */}
+        <div className="md:col-span-5 space-y-8">
+          {/* Bio Manifest Card */}
+          <section className="border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] rotate-1">
+            <h2 className="text-xl font-black bg-black text-white px-2 py-1 inline-block uppercase mb-4 tracking-wider">
+              Manifesto // Bio
+            </h2>
+            <p className="leading-relaxed font-semibold text-sm md:text-base">{personal.summary}</p>
+          </section>
+
+          {/* Stamped Label Skills Card */}
+          <section className="border-4 border-black bg-white p-6 shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] -rotate-1">
+            <h2 className="text-xl font-black bg-black text-white px-2 py-1 inline-block uppercase mb-4 tracking-wider">
+              Core_Arsenal [Skills]
+            </h2>
+            <div className="flex flex-wrap gap-2 pt-2">
+              {skills.map((skill, index) => (
+                <span 
+                  key={index} 
+                  className="bg-black text-white px-2.5 py-1 text-xs font-black uppercase tracking-tight shadow-[2px_2px_0px_0px_rgba(100,100,100,1)] transform hover:scale-105 transition-transform"
+                >
+                  {skill}
+                </span>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        {/* RIGHT COLUMN PANEL */}
+        <div className="md:col-span-7 space-y-8">
+          {/* Experience Stack */}
+          <section className="space-y-6">
+            <h2 className="text-2xl font-black uppercase tracking-tight underline decoration-4 mb-4">
+              LOGGED_FRAGMENTS [EXPERIENCE]
+            </h2>
+            {experience.map((exp, index) => (
+              <div 
+                key={index} 
+                className={`border-4 border-black p-6 bg-white shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] transition-transform hover:rotate-0 ${
+                  index % 2 === 0 ? '-rotate-1' : 'rotate-1'
+                }`}
+              >
+                <div className="flex justify-between items-baseline mb-1 gap-2">
+                  <h3 className="text-lg font-black uppercase tracking-tight">{exp.position}</h3>
+                  <span className="text-[10px] bg-black text-white px-1.5 py-0.5 font-bold shrink-0">{exp.startDate}</span>
+                </div>
+                <h4 className="text-sm font-bold text-gray-700 uppercase mb-3">@{exp.company}</h4>
+                <p className="text-xs font-medium border-l-2 border-dashed border-black pl-3 leading-relaxed">{exp.description}</p>
+              </div>
+            ))}
+          </section>
+
+          {/* Polaroid Clipboard Projects Section */}
+          <section className="space-y-6 pt-4">
+            <h2 className="text-2xl font-black uppercase tracking-tight underline decoration-4 mb-4">
+              CUT_OUT_BLUEPRINTS [PROJECTS]
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {projects.map((proj, index) => (
+                <div 
+                  key={index} 
+                  className={`border-4 border-black p-4 bg-white shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] pb-8 transform hover:scale-[1.02] transition-transform ${
+                    index % 2 === 0 ? 'rotate-1' : '-rotate-2'
+                  }`}
+                >
+                  <div className="bg-gray-100 border-2 border-black aspect-video mb-3 flex items-center justify-center p-2 text-center">
+                    <span className="text-[10px] font-black uppercase tracking-widest text-gray-500">// CAPTURE_FRAME_0{index + 1}</span>
+                  </div>
+                  <h3 className="text-md font-black uppercase tracking-tight mb-1">{proj.name}</h3>
+                  <p className="text-[11px] font-medium leading-normal text-gray-800 mb-3">{proj.description}</p>
+                  <div className="flex flex-wrap gap-1">
+                    {proj.technologies?.map((tech, tIdx) => (
+                      <span key={tIdx} className="text-[9px] font-bold border border-black px-1 bg-[#f4ebd0]">{tech}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/data/templates.js
+++ b/frontend/src/data/templates.js
@@ -429,6 +429,15 @@ export const templates = [
     "createdAt": "2026-05-31",
     "isComplete": true
   },
+
+  {
+    id: "zine-collage",
+    title: "Zine Collage",
+    category: "Brutalist",
+    description: "An asymmetric, high-contrast scrapbook magazine layout featuring heavy ink borders, rotated clipping frames, and retro label-maker accents.",
+    isComplete: true
+  },
+  
   {
     "id": "Cinematic",
     "title": "Cinematic",


### PR DESCRIPTION
## **User description**
## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #(issue number)

## Testing
- [ ] Unit tests pass
- [ ] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [ ] Attached Screenshots or Screen Recordings (showing before and after)
- *If your PR does not make any visual/UI changes, please write "N/A"*

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [ ] No new warnings generated


___

## **CodeAnt-AI Description**
**Add a new brutalist zine-style portfolio template**

### What Changed
- Added a new collage-inspired portfolio layout with bold headers, cut-out project cards, stacked experience blocks, and tagged skills
- Shows fallback profile content when no data is provided, so the template still renders with sample copy
- Registered the new template at `/templates/zine-collage` so it can be opened from the app

### Impact
`✅ More portfolio template choices`
`✅ Easier previewing of zine-style layouts`
`✅ Fewer empty-template screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Zine Collage portfolio template with a collage-style layout and a public route for easy access.
* **Style**
  * Updated headings, labels, and layout styling for a more distinctive zine look.
* **Bug Fixes / Improvements**
  * More resilient data handling: template now merges defaults per section (personal, experience, projects, skills) when input is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->