### PR TITLE
fix: resolve portfolio IDOR false-positive and double response server crash

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -415,19 +415,12 @@ router.put('/:slug', verifyToken, validatePortfolioSlug, validatePortfolioConten
   if (!portfolio) {
     throw new ApiError(404, `Portfolio "${slug}" not found.`);
   }
-res.status(200).json({
-  success: true,
-  message: 'Portfolio updated successfully.',
-  data: portfolio,
-});
-
 
   res.status(200).json({
     success: true,
     message: 'Portfolio updated successfully.',
     data: portfolio,
   });
-  
 }));
 
 /**
@@ -437,16 +430,25 @@ router.post('/:id/save', verifyToken, asyncHandler(async (req, res) => {
   const { id } = req.params;
   const { content } = req.body;
 
-  // Authorization check (IDOR Protection)
-  if (req.user.uid !== id) {
-    throw new ApiError(403, 'Unauthorized access to this portfolio.');
+  const isConnected = mongoose.connection.readyState === 1;
+
+  if (isConnected) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw new ApiError(400, 'Invalid portfolio ID format.');
+    }
+    const portfolio = await Portfolio.findById(id).lean();
+    if (!portfolio) {
+      throw new ApiError(404, 'Portfolio not found.');
+    }
+    if (portfolio.userId !== req.user.uid) {
+      throw new ApiError(403, 'Unauthorized access to this portfolio.');
+    }
   }
 
   if (!content) {
     throw new ApiError(400, 'Content is required for saving.');
   }
 
-  const isConnected = mongoose.connection.readyState === 1;
   let latestVersion;
 
   if (isConnected) {
@@ -544,11 +546,20 @@ router.post('/:id/save', verifyToken, asyncHandler(async (req, res) => {
 router.get('/:id/versions', verifyToken, asyncHandler(async (req, res) => {
   const { id } = req.params;
 
-  if (req.user.uid !== id) {
-    throw new ApiError(403, 'Unauthorized access to version history.');
-  }
-
   const isConnected = mongoose.connection.readyState === 1;
+
+  if (isConnected) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw new ApiError(400, 'Invalid portfolio ID format.');
+    }
+    const portfolio = await Portfolio.findById(id).lean();
+    if (!portfolio) {
+      throw new ApiError(404, 'Portfolio not found.');
+    }
+    if (portfolio.userId !== req.user.uid) {
+      throw new ApiError(403, 'Unauthorized access to version history.');
+    }
+  }
 
   let versions;
   if (isConnected) {
@@ -576,11 +587,20 @@ router.get('/:id/versions', verifyToken, asyncHandler(async (req, res) => {
 router.post('/:id/restore/:versionId', verifyToken, asyncHandler(async (req, res) => {
   const { id, versionId } = req.params;
 
-  if (req.user.uid !== id) {
-    throw new ApiError(403, 'Unauthorized access to restore this portfolio.');
-  }
-
   const isConnected = mongoose.connection.readyState === 1;
+
+  if (isConnected) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw new ApiError(400, 'Invalid portfolio ID format.');
+    }
+    const portfolio = await Portfolio.findById(id).lean();
+    if (!portfolio) {
+      throw new ApiError(404, 'Portfolio not found.');
+    }
+    if (portfolio.userId !== req.user.uid) {
+      throw new ApiError(403, 'Unauthorized access to restore this portfolio.');
+    }
+  }
 
   let versionToRestore;
   if (isConnected) {


### PR DESCRIPTION
## **User description**
## Description
This PR resolves two critical bugs in the portfolio routing logic (`backend/src/routes/portfolio.js`) that were preventing users from successfully saving their portfolios and causing server instability.

### Fixes Included:
1. **Portfolio IDOR / Authorization Fix (`/:id/save`, `/:id/versions`, `/:id/restore/:versionId`)**
   - **Bug:** The previous code checked `req.user.uid !== id`, mistakenly comparing a Firebase User ID directly to the portfolio's MongoDB ObjectId. This caused all saves to fail with a `403 Unauthorized` error.
   - **Fix:** Refactored the endpoints to first query the MongoDB `Portfolio` document by `id`, and securely check if the `portfolio.userId` matches `req.user.uid`.
2. **Double Response Crash (`PUT /:slug`)**
   - **Bug:** Calling `res.status(200).json(...)` twice in the update handler caused an `ERR_HTTP_HEADERS_SENT` crash.
   - **Fix:** Removed the duplicate response block.

## Related Issue
Closes #3455

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified that saving and restoring portfolios now bypasses the false 403 error and securely validates ownership.
- [x] My changes generate no new warnings or syntax errors


___

## **CodeAnt-AI Description**
Fix portfolio saving and restore errors, and stop a duplicate update response crash

### What Changed
- Saving, viewing version history, and restoring a portfolio now check ownership against the portfolio record instead of blocking valid users with a false unauthorized error
- These portfolio actions now return clear errors when the portfolio ID is invalid or the portfolio cannot be found
- Updating a portfolio now sends only one response, preventing server crashes from duplicate replies

### Impact
`✅ Fewer false unauthorized errors`
`✅ Reliable portfolio saves and restores`
`✅ Fewer portfolio update crashes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed duplicate responses when updating portfolio information through the API.
  * Improved authorization and validation for portfolio versioning features to ensure proper database connectivity and secure access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->