### PR TITLE
fix: remove duplicate REDIS_URL definition from backend .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -292,7 +292,6 @@ ADMIN_UIDS=
 
 
 # BullMQ Monitoring Dashboard
-REDIS_URL=redis://127.0.0.1:6379
 BULL_BOARD_ENABLED=true
 BULL_BOARD_USERNAME=admin
 BULL_BOARD_PASSWORD=change-this-password


### PR DESCRIPTION
## **User description**
## Description

Removes a duplicate `REDIS_URL` definition from `backend/.env.example`.

## Problem

`REDIS_URL` is currently defined twice in the same environment example file:

```env
REDIS_URL=redis://localhost:6379
```

and

```env
REDIS_URL=redis://127.0.0.1:6379
```

When contributors copy the file into a real `.env`, the second definition overrides the first, which can lead to confusion and unintended configuration behavior.

## Type of Change

* [x] Bug fix

## Related Issue

Fixes #3473

## Testing

* [x] Tested locally
* [x] Verified only one line was removed
* [x] Verified no other files were modified

## Changes Made

* Removed the duplicate `REDIS_URL` entry under the BullMQ Monitoring Dashboard section
* Retained the primary `REDIS_URL` definition used for Redis/BullMQ configuration

## Screenshots

N/A


___

## **CodeAnt-AI Description**
**Remove the extra Redis URL entry from the backend example config**

### What Changed
- Removed the duplicate `REDIS_URL` line from `backend/.env.example`
- The example now shows one Redis address for local BullMQ setup, which avoids conflicting values when copying the file into a real `.env`

### Impact
`✅ Fewer configuration mistakes`
`✅ Clearer local setup instructions`
`✅ Less confusion when setting Redis values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->