### PR TITLE
fix: reset LinkedIn loading state after login handler execution

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -84,18 +84,21 @@ export default function Login() {
   }
 
   const handleLinkedInLogin = () => {
-    if (!loginWithLinkedIn) {
-      toast.error('LinkedIn login integration is not configured.')
-      return
-    }
-    setLinkedinLoading(true)
-    try {
-      loginWithLinkedIn()
-    } catch (error) {
-      toast.error(error.message || 'Failed to login with LinkedIn')
-      setLinkedinLoading(false)
-    }
+  if (!loginWithLinkedIn) {
+    toast.error('LinkedIn login integration is not configured.')
+    return
   }
+
+  setLinkedinLoading(true)
+
+  try {
+    loginWithLinkedIn()
+  } catch (error) {
+    toast.error(error.message || 'Failed to login with LinkedIn')
+  } finally {
+    setLinkedinLoading(false)
+  }
+}
 
   const handleTotpSubmit = async (e) => {
     e.preventDefault()


### PR DESCRIPTION
## **User description**
## Description

This PR fixes an issue where the LinkedIn login loading state was not being reset after the authentication handler completed execution.

Previously, `setLinkedinLoading(false)` was only called inside the `catch` block. Since the current `loginWithLinkedIn()` implementation neither throws errors nor manages the loading state internally, the loading indicator could remain active indefinitely.

This PR moves the loading state cleanup into a `finally` block to ensure it is always reset regardless of the execution path.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Other (describe)

## Related Issue

Fixes #<ISSUE_NUMBER>

## Testing

* [ ] Unit tests pass
* [x] Tested Locally
* [ ] New tests added

### Local Testing Performed

1. Started the application locally.
2. Navigated to the Login page.
3. Clicked the "Continue with LinkedIn" button.
4. Verified that the loading state is activated.
5. Dismissed the alert displayed by the current `loginWithLinkedIn()` implementation.
6. Confirmed that the loading state is reset correctly after the handler completes.

## Screenshots (MANDATORY for UI/UX changes)

N/A

## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [ ] Added comments where necessary
* [ ] Updated documentation
* [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Reset the LinkedIn login spinner after the login handler finishes**

### What Changed
- The LinkedIn login loading indicator now always turns off after the login attempt ends
- If LinkedIn login is not set up, users still see the configuration error and the spinner never starts
- If the login call fails, users still get the error message and the loading state is cleared immediately

### Impact
`✅ No stuck LinkedIn login spinner`
`✅ Clearer LinkedIn login error handling`
`✅ Fewer login retries caused by frozen loading state`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the LinkedIn login button's loading indicator would not clear after a successful login, potentially causing the UI to appear unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->