### PR TITLE
feat: Add Image Export for Resume Previews (Fixes #3515)

### DIFF
--- a/frontend/src/pages/ResumeView.jsx
+++ b/frontend/src/pages/ResumeView.jsx
@@ -13,6 +13,7 @@ import { SkeletonList } from '../components/ui/Skeleton'
 import ResumeVersions from '../components/ResumeVersions'
 import AtsProgressChart from '../components/AtsProgressChart'
 import { Loader2 } from 'lucide-react'
+import html2canvas from 'html2canvas'
 
 export default function ResumeView() {
   const { resumeId } = useParams()
@@ -21,6 +22,8 @@ export default function ResumeView() {
   const [resume, setResume] = useState(null)
   const [loading, setLoading] = useState(true)
   const [downloading, setDownloading] = useState(false)
+  const [downloadingImage, setDownloadingImage] = useState(false)
+  const [imageFormat, setImageFormat] = useState('png')
   const [activeTab, setActiveTab] = useState('preview') // 'preview' | 'versions' | 'ats'
   const [previewTab, setPreviewTab] = useState('enhanced') // 'enhanced' | 'original'
   const [scoreData, setScoreData] = useState(null)
@@ -118,6 +121,43 @@ export default function ResumeView() {
       toast.error(error.message || 'Failed to download PDF')
     } finally {
       setDownloading(false)
+    }
+  }
+
+  const handleDownloadImage = async () => {
+    try {
+      setDownloadingImage(true)
+      
+      const targetElement = document.querySelector('.resume-preview') || document.querySelector('pre.whitespace-pre-wrap')
+
+      if (!targetElement) {
+        toast.error('Resume preview not found')
+        return
+      }
+
+      toast.success(`Exporting resume as ${imageFormat.toUpperCase()}`)
+      
+      const canvas = await html2canvas(targetElement, { 
+        scale: 2,
+        useCORS: true,
+        backgroundColor: '#ffffff'
+      })
+      
+      const dataUrl = canvas.toDataURL(`image/${imageFormat}`)
+
+      const a = document.createElement('a')
+      a.href = dataUrl
+      a.download = `${resume?.title || 'resume'}_${previewTab}.${imageFormat === 'jpeg' ? 'jpg' : 'png'}`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+
+      toast.success('Image downloaded successfully!')
+    } catch (error) {
+      console.error('Image download failed:', error)
+      toast.error('Failed to download image')
+    } finally {
+      setDownloadingImage(false)
     }
   }
 
@@ -325,6 +365,18 @@ export default function ResumeView() {
       <option value="Large">Large</option>
     </select>
   </div>
+
+  <div>
+    <label className="block text-sm mb-1">Image Format</label>
+    <select
+      value={imageFormat}
+      onChange={(e) => setImageFormat(e.target.value)}
+      className="border rounded px-2 py-1"
+    >
+      <option value="png">PNG</option>
+      <option value="jpeg">JPEG</option>
+    </select>
+  </div>
 </div>
                 <div className="flex gap-2 flex-wrap">
                  <Button
@@ -341,6 +393,20 @@ export default function ResumeView() {
     'Download PDF'
   )}
 </Button>
+                  <Button
+                    variant="primary"
+                    onClick={handleDownloadImage}
+                    disabled={downloadingImage}
+                  >
+                    {downloadingImage ? (
+                      <div className="flex items-center gap-2">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Generating Image...
+                      </div>
+                    ) : (
+                      'Download as Image'
+                    )}
+                  </Button>
                   <Button
                     variant="primary"
                     onClick={handleAnalyzeResume}


### PR DESCRIPTION
## **User description**
## Description
Implemented a "Download as Image" functionality in the `ResumeView.jsx` component. This allows users to easily export and share their AI-enhanced resumes as PNG or JPEG images directly on social media platforms for better engagement. The feature utilizes `html2canvas` to capture the resume preview container, includes a format selection dropdown (PNG/JPEG), and mimics the subtle loading state of the existing PDF download flow.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #3515

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
<img width="1280" height="800" alt="screenshot" src="https://github.com/user-attachments/assets/e846435a-5ffa-49a7-8a0e-15ee8d589b25" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Add image export for resume previews**

### What Changed
- Users can now download the resume preview as an image instead of only as a PDF.
- The download flow includes a format choice between PNG and JPEG.
- The image export shows a loading state while the file is being generated and gives a success or failure message when finished.
- The exported file name uses the resume title and the selected preview version.

### Impact
`✅ Easier sharing on social platforms`
`✅ More download format options`
`✅ Clearer export progress`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume previews can now be exported as images in PNG or JPEG format
  * Added "Image Format" selector in the preview toolbar for choosing between export formats
  * Added "Download as Image" button for exporting with auto-generated filenames based on resume title

<!-- end of auto-generated comment: release notes by coderabbit.ai -->