### PR TITLE
fix: accept LinkedIn URLs without www subdomain (#3520)

### DIFF
--- a/frontend/src/__tests__/resumeValidation.test.js
+++ b/frontend/src/__tests__/resumeValidation.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { validateLinkedIn } from '../utils/resumeValidation'
+
+describe('validateLinkedIn', () => {
+  it('accepts a URL without the www. subdomain', () => {
+    expect(validateLinkedIn('https://linkedin.com/in/john-doe')).toBe('')
+  })
+
+  it('accepts a URL with the www. subdomain', () => {
+    expect(validateLinkedIn('https://www.linkedin.com/in/john-doe')).toBe('')
+  })
+
+  it('treats an empty value as valid (optional field)', () => {
+    expect(validateLinkedIn('')).toBe('')
+    expect(validateLinkedIn('   ')).toBe('')
+  })
+
+  it('rejects a non-LinkedIn URL', () => {
+    expect(validateLinkedIn('https://example.com/in/john')).not.toBe('')
+  })
+
+  it('rejects a LinkedIn URL with an empty/too-short profile path', () => {
+    expect(validateLinkedIn('https://linkedin.com/in/')).not.toBe('')
+    expect(validateLinkedIn('https://www.linkedin.com/in/a')).not.toBe('')
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(validateLinkedIn('  https://linkedin.com/in/john-doe  ')).toBe('')
+  })
+})

--- a/frontend/src/utils/resumeValidation.js
+++ b/frontend/src/utils/resumeValidation.js
@@ -45,14 +45,15 @@ export function validatePhone(digits) {
   return ''
 }
 
-/** LinkedIn: must start with https://linkedin.com/in/ */
+/** LinkedIn: must start with https://linkedin.com/in/ (www. is optional). */
 export function validateLinkedIn(url) {
   const trimmed = (url || '').trim()
   if (!trimmed) return '' // optional field
-  if (!trimmed.startsWith('https://www.linkedin.com/in/')) {
-    return 'LinkedIn URL must start with https://www.linkedin.com/in/'
+  const match = trimmed.match(/^https:\/\/(?:www\.)?linkedin\.com\/in\/(.*)$/)
+  if (!match) {
+    return 'LinkedIn URL must start with https://linkedin.com/in/ or https://www.linkedin.com/in/'
   }
-  const profile = trimmed.replace('https://www.linkedin.com/in/', '')
+  const profile = match[1]
   if (!profile || profile.length < 2) return 'Please include a valid LinkedIn profile path.'
   return ''
 }


### PR DESCRIPTION
## Description
Fixes a validation bug where `validateLinkedIn` rejected valid LinkedIn URLs without the `www.` subdomain (e.g. `https://linkedin.com/in/john-doe`), even though the function's JSDoc said it should accept them. The check now treats `www.` as optional via regex, and a Vitest unit test was added.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #3520

## Testing
- [x] Unit tests pass
- [x] Tested Locally
- [x] New tests added

## Screenshots (MANDATORY for UI/UX changes)
N/A — no visual/UI changes (validation logic only)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

___

## **CodeAnt-AI Description**
**Allow LinkedIn profile links without the www subdomain**

### What Changed
- LinkedIn profile URLs are now accepted with or without `www`, so both `https://linkedin.com/in/...` and `https://www.linkedin.com/in/...` pass validation
- The validation message now lists both accepted LinkedIn URL formats
- Added tests for valid links, invalid links, empty values, short profile paths, and links with extra spaces

### Impact
`✅ Fewer LinkedIn link rejections`
`✅ Smoother resume submission`
`✅ Clearer LinkedIn URL errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for LinkedIn profile URL validation, including edge cases and format variations

* **Improvements**
  * Enhanced LinkedIn URL validation to accept multiple valid LinkedIn profile URL formats
  * Improved input handling with automatic whitespace trimming
  * Strengthened validation logic to properly reject malformed URLs and non-LinkedIn links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->