### PR TITLE
Prevent forwarding of context props in Sidebar components

### DIFF
--- a/frontend/src/components/ui/Sidebar.jsx
+++ b/frontend/src/components/ui/Sidebar.jsx
@@ -98,6 +98,9 @@ export const SidebarBody = (props) => {
 export const DesktopSidebar = ({
     className,
     children,
+    open: _open,
+    setOpen: _setOpen,
+    animate: _animate,
     ...props
 }) => {
     const { open, setOpen, animate } = useSidebarInternal();
@@ -134,6 +137,9 @@ export const DesktopSidebar = ({
 export const MobileSidebar = ({
     className,
     children,
+    open: _open,
+    setOpen: _setOpen,
+    animate: _animate,
     ...props
 }) => {
     const { open, setOpen } = useSidebarInternal();


### PR DESCRIPTION
## Description
Prevented context-bound props from being forwarded to DOM elements in Sidebar components.

## Related Issue
Closes #3532

## Changes Made
- Filtered open, setOpen, and animate props
- Preserved existing Sidebar behavior
- Removed potential React DOM warnings

## Checklist
- [x] Tested locally
- [x] No functional changes
- [x] Linked the related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component prop handling to prevent unintended DOM attribute forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->