### PR TITLE
Fix Navbar dropdowns state conflict (#4088)

### DIFF
--- a/frontend/src/__tests__/Navbar.test.jsx
+++ b/frontend/src/__tests__/Navbar.test.jsx
@@ -1,0 +1,151 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Navbar from '../components/Navbar'
+
+// Mock useAuth
+const mockLogout = vi.fn()
+const mockUser = {
+  displayName: 'Test User',
+  email: 'test@example.com'
+}
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    logout: mockLogout
+  })
+}))
+
+// Mock useTheme
+const mockToggleTheme = vi.fn()
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    toggleTheme: mockToggleTheme
+  })
+}))
+
+// Mock AIProviderSelector
+vi.mock('../components/AIProviderSelector', () => ({
+  default: () => <div>Mock AIProviderSelector</div>
+}))
+
+describe('Navbar component dropdowns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders Navbar and initially does not show search suggestions or user dropdown', () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByText('Frontend Developer')).not.toBeInTheDocument()
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument()
+  })
+
+  test('focusing search input opens search suggestions dropdown and closing it on blur', async () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    )
+
+    const searchInput = screen.getByPlaceholderText('Search anything...')
+    
+    // Focus search input
+    fireEvent.focus(searchInput)
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
+
+    // Blur search input
+    fireEvent.blur(searchInput)
+    
+    // Wait for the timeout to finish
+    await waitFor(() => {
+      expect(screen.queryByText('Frontend Developer')).not.toBeInTheDocument()
+    })
+  })
+
+  test('clicking user menu opens profile dropdown and toggles it', async () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    )
+
+    const userMenuButton = screen.getByLabelText('User menu')
+    
+    // Click user menu button to open profile dropdown
+    fireEvent.click(userMenuButton)
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+
+    // Click again to close
+    fireEvent.click(userMenuButton)
+    await waitFor(() => {
+      expect(screen.queryByText('Profile')).not.toBeInTheDocument()
+    })
+  })
+
+  test('opening profile dropdown closes search suggestions dropdown, and focusing search input closes profile dropdown', async () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    )
+
+    const searchInput = screen.getByPlaceholderText('Search anything...')
+    const userMenuButton = screen.getByLabelText('User menu')
+
+    // Focus search -> search dropdown opens
+    fireEvent.focus(searchInput)
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument()
+
+    // Click profile button -> search dropdown closes, profile dropdown opens
+    fireEvent.click(userMenuButton)
+    await waitFor(() => {
+      expect(screen.queryByText('Frontend Developer')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+
+    // Focus search again -> profile dropdown closes, search dropdown opens
+    fireEvent.focus(searchInput)
+    await waitFor(() => {
+      expect(screen.queryByText('Profile')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
+  })
+
+  test('pressing Escape closes both dropdowns', async () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    )
+
+    const searchInput = screen.getByPlaceholderText('Search anything...')
+    const userMenuButton = screen.getByLabelText('User menu')
+
+    // Focus search -> search dropdown opens
+    fireEvent.focus(searchInput)
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
+
+    // Press Escape
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByText('Frontend Developer')).not.toBeInTheDocument()
+    })
+
+    // Click profile button -> profile dropdown opens
+    fireEvent.click(userMenuButton)
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+
+    // Press Escape
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByText('Profile')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/__tests__/Navbar.test.jsx
+++ b/frontend/src/__tests__/Navbar.test.jsx
@@ -148,4 +148,36 @@ describe('Navbar component dropdowns', () => {
       expect(screen.queryByText('Profile')).not.toBeInTheDocument()
     })
   })
+
+  test('tabbing from search input to suggestion button keeps dropdown open, and tabbing out closes it', async () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    )
+
+    const searchInput = screen.getByPlaceholderText('Search anything...')
+    
+    // Focus search -> search dropdown opens
+    fireEvent.focus(searchInput)
+    const suggestionButton = screen.getByText('Frontend Developer')
+    expect(suggestionButton).toBeInTheDocument()
+
+    // Move focus to the suggestion button (simulating Tab key)
+    fireEvent.blur(searchInput, { relatedTarget: suggestionButton })
+    fireEvent.focus(suggestionButton)
+
+    // Suggestion dropdown should still be open
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument()
+
+    // Tab out of the suggestion button to document body or somewhere outside
+    const outsideElement = document.createElement('button')
+    document.body.appendChild(outsideElement)
+    fireEvent.blur(suggestionButton, { relatedTarget: outsideElement })
+    
+    await waitFor(() => {
+      expect(screen.queryByText('Frontend Developer')).not.toBeInTheDocument()
+    })
+    document.body.removeChild(outsideElement)
+  })
 })

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useTheme } from '../hooks/useTheme'
@@ -33,8 +33,53 @@ export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
-  const [showDropdown, setShowDropdown] = useState(false)
+  const [searchDropdownOpen, setSearchDropdownOpen] = useState(false)
+  const [profileDropdownOpen, setProfileDropdownOpen] = useState(false)
   const [notificationCount] = useState(3)
+
+  const searchRef = useRef(null)
+  const profileRef = useRef(null)
+
+  const openProfile = () => {
+    setSearchDropdownOpen(false)
+    setProfileDropdownOpen(true)
+  }
+
+  const toggleProfileDropdown = () => {
+    setSearchDropdownOpen(false)
+    setProfileDropdownOpen((prev) => !prev)
+  }
+
+  const openSearchDropdown = () => {
+    setProfileDropdownOpen(false)
+    setSearchDropdownOpen(true)
+  }
+
+  useEffect(() => {
+    const handleOutsideClick = (event) => {
+      if (searchRef.current && !searchRef.current.contains(event.target)) {
+        setSearchDropdownOpen(false)
+      }
+      if (profileRef.current && !profileRef.current.contains(event.target)) {
+        setProfileDropdownOpen(false)
+      }
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setSearchDropdownOpen(false)
+        setProfileDropdownOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleOutsideClick)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [])
 
   useEffect(() => {
     const handleScroll = () => {
@@ -132,7 +177,7 @@ export default function Navbar() {
           <div className="hidden lg:flex items-center gap-2">
 
             {/* Search Bar */}
-            <div className="relative">
+            <div ref={searchRef} className="relative">
               <div className="flex items-center bg-muted border border-border rounded-xl px-3 py-2 w-72 focus-within:ring-2 focus-within:ring-primary/40 transition-all">
                 <Search className="w-4 h-4 text-muted-foreground mr-2" />
 
@@ -141,15 +186,15 @@ export default function Navbar() {
                   placeholder="Search anything..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  onFocus={() => setShowDropdown(true)}
-                  onBlur={() => setTimeout(() => setShowDropdown(false), 200)}
+                  onFocus={openSearchDropdown}
+                  onBlur={() => setTimeout(() => setSearchDropdownOpen(false), 200)}
                   className="bg-transparent outline-none text-sm w-full text-foreground placeholder:text-muted-foreground"
                 />
               </div>
 
               {/* Suggestions Dropdown */}
               <AnimatePresence>
-                {showDropdown && (
+                {searchDropdownOpen && (
                   <motion.div
                     initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
@@ -241,12 +286,12 @@ export default function Navbar() {
                 </button>
 
                 {/* User Dropdown */}
-                <div className="relative">
+                <div ref={profileRef} className="relative">
                   <button
-                    onClick={() => setShowDropdown(!showDropdown)}
+                    onClick={toggleProfileDropdown}
                     className="flex items-center gap-2 px-3 py-2 bg-muted border border-border rounded-full hover:bg-accent transition-all"
                     aria-label="User menu"
-                    aria-expanded={showDropdown}
+                    aria-expanded={profileDropdownOpen}
                   >
                     <div className="w-8 h-8 rounded-full overflow-hidden bg-primary/20 flex items-center justify-center">
                       <img
@@ -264,7 +309,7 @@ export default function Navbar() {
                   </button>
 
                   <AnimatePresence>
-                    {showDropdown && (
+                    {profileDropdownOpen && (
                       <motion.div
                         initial={{ opacity: 0, y: 10 }}
                         animate={{ opacity: 1, y: 0 }}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -39,6 +39,7 @@ export default function Navbar() {
 
   const searchRef = useRef(null)
   const profileRef = useRef(null)
+  const searchTimeoutRef = useRef(null)
 
   const openProfile = () => {
     setSearchDropdownOpen(false)
@@ -51,8 +52,22 @@ export default function Navbar() {
   }
 
   const openSearchDropdown = () => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current)
+      searchTimeoutRef.current = null
+    }
     setProfileDropdownOpen(false)
     setSearchDropdownOpen(true)
+  }
+
+  const handleSearchBlur = () => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current)
+    }
+    searchTimeoutRef.current = setTimeout(() => {
+      setSearchDropdownOpen(false)
+      searchTimeoutRef.current = null
+    }, 200)
   }
 
   useEffect(() => {
@@ -78,6 +93,9 @@ export default function Navbar() {
     return () => {
       document.removeEventListener('mousedown', handleOutsideClick)
       document.removeEventListener('keydown', handleKeyDown)
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current)
+      }
     }
   }, [])
 
@@ -187,7 +205,7 @@ export default function Navbar() {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   onFocus={openSearchDropdown}
-                  onBlur={() => setTimeout(() => setSearchDropdownOpen(false), 200)}
+                  onBlur={handleSearchBlur}
                   className="bg-transparent outline-none text-sm w-full text-foreground placeholder:text-muted-foreground"
                 />
               </div>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -60,7 +60,11 @@ export default function Navbar() {
     setSearchDropdownOpen(true)
   }
 
-  const handleSearchBlur = () => {
+  const handleSearchBlur = (event) => {
+    if (searchRef.current && searchRef.current.contains(event.relatedTarget)) {
+      return
+    }
+
     if (searchTimeoutRef.current) {
       clearTimeout(searchTimeoutRef.current)
     }
@@ -195,7 +199,11 @@ export default function Navbar() {
           <div className="hidden lg:flex items-center gap-2">
 
             {/* Search Bar */}
-            <div ref={searchRef} className="relative">
+            <div
+              ref={searchRef}
+              className="relative"
+              onBlur={handleSearchBlur}
+            >
               <div className="flex items-center bg-muted border border-border rounded-xl px-3 py-2 w-72 focus-within:ring-2 focus-within:ring-primary/40 transition-all">
                 <Search className="w-4 h-4 text-muted-foreground mr-2" />
 
@@ -205,7 +213,6 @@ export default function Navbar() {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   onFocus={openSearchDropdown}
-                  onBlur={handleSearchBlur}
                   className="bg-transparent outline-none text-sm w-full text-foreground placeholder:text-muted-foreground"
                 />
               </div>


### PR DESCRIPTION
## **User description**
This PR resolves issue #4088 by splitting the single `showDropdown` state variable in Navbar.jsx into two separate state variables: `searchDropdownOpen` and `profileDropdownOpen`. It also adds container refs for outside clicks and an Escape keypress handler to close the active dropdowns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a comprehensive test suite for the Navbar, validating search suggestions behavior, profile menu toggling, keyboard dismissal (Escape), and click-outside closing.

* **Improvements**
  * Refined Navbar dropdown handling by separating search suggestions and profile menu states.
  * Improved user experience for opening/closing menus, including robust handling of outside clicks and the Escape key to dismiss the currently active dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix Navbar search and profile dropdown conflicts**

### What Changed
- Search suggestions and the user menu now open and close independently, so one menu no longer leaves the other in the wrong state
- Opening the search box closes the user menu, and opening the user menu closes search suggestions
- Clicking outside either menu or pressing Escape now closes the open dropdown
- Tabbing from the search box to a suggestion keeps the suggestions open, which improves keyboard use
- Added tests that cover opening, closing, switching between, and dismissing both dropdowns

### Impact
`✅ Fewer conflicting Navbar menus`
`✅ Clearer dropdown behavior for search and profile`
`✅ Easier keyboard and click-outside dismissal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
