### PR TITLE
fix(frontend): restore mobile navigation and fix profile skeleton the…

### DIFF
--- a/frontend/src/components/MobileNav.jsx
+++ b/frontend/src/components/MobileNav.jsx
@@ -1,61 +1,56 @@
 import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
 import {
-    Bell,
-    CalendarDays,
-    Home,
+    LayoutDashboard,
+    Briefcase,
+    FileText,
+    Globe,
+    User,
     Menu,
-    Search,
     Settings,
-    UserCircle,
     X,
 } from "lucide-react";
 import { cn } from "../lib/utils";
 
-const primaryTabs = [
-    { label: "Home", href: "/", icon: Home },
-    { label: "Search", href: "/search", icon: Search },
-    { label: "Calendar", href: "/calendar", icon: CalendarDays },
-    { label: "Alerts", href: "/notifications", icon: Bell },
-    { label: "Profile", href: "/profile", icon: UserCircle },
+const defaultTabs = [
+    { to: "/dashboard", icon: LayoutDashboard, label: "Home" },
+    { to: "/hub/jobs", icon: Briefcase, label: "Jobs" },
+    { to: "/hub/resume", icon: FileText, label: "Resume" },
+    { to: "/hub/portfolio", icon: Globe, label: "Portfolio" },
+    { to: "/profile", icon: User, label: "Profile" },
 ];
 
 const secondaryLinks = [
-    { label: "Settings", href: "/settings", icon: Settings },
+    { to: "/settings", icon: Settings, label: "Settings" },
 ];
 
-function getCurrentPath() {
-    if (typeof window === "undefined") return "";
-    return window.location.pathname;
-}
-
-function MobileNavItem({ item, activePath, onClick, drawerItem = false }) {
+function MobileNavItem({ item, onClick, drawerItem = false }) {
     const Icon = item.icon;
-    const isActive = activePath === item.href;
 
     return (
-        <a
-            href={item.href}
+        <NavLink
+            to={item.to}
             onClick={onClick}
-            aria-current={isActive ? "page" : undefined}
-            className={cn(
-                "flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition-colors",
+            className={({ isActive }) => cn(
+                "flex min-h-11 min-w-11 items-center justify-center rounded-xl text-muted-foreground transition-all duration-200",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                isActive && "bg-accent text-accent-foreground",
+                isActive 
+                    ? "bg-primary/10 text-primary border border-primary/20 font-semibold shadow-sm" 
+                    : "border border-transparent hover:bg-muted/50 hover:text-foreground",
                 drawerItem
-                    ? "flex-row justify-start gap-3 px-3 text-sm font-medium"
+                    ? "flex-row justify-start gap-3 px-4 py-3 text-sm font-medium w-full"
                     : "flex-col gap-1 px-1 text-[11px] font-medium leading-none"
             )}
         >
             <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
             <span className={cn(!drawerItem && "truncate")}>{item.label}</span>
-        </a>
+        </NavLink>
     );
 }
 
 export default function MobileNav({
-    tabs = primaryTabs,
+    tabs = defaultTabs,
     menuLinks = secondaryLinks,
-    activePath = getCurrentPath(),
 }) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -79,25 +74,24 @@ export default function MobileNav({
         <>
             <nav
                 aria-label="Mobile navigation"
-                className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/95 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur md:hidden"
+                className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/95 px-3 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur md:hidden"
             >
-                <div className="grid grid-cols-[44px_1fr] items-center gap-2">
+                <div className="grid grid-cols-[44px_1fr] items-center gap-3">
                     <button
                         type="button"
                         onClick={() => setIsMenuOpen(true)}
                         aria-label="Open menu"
                         aria-expanded={isMenuOpen}
-                        className="flex h-11 w-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                        className="flex h-11 w-11 items-center justify-center rounded-xl text-foreground transition-all duration-200 border border-transparent hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     >
                         <Menu className="h-5 w-5" aria-hidden="true" />
                     </button>
 
-                    <div className="grid grid-cols-5 gap-1">
+                    <div className="grid grid-cols-5 gap-1.5">
                         {tabs.slice(0, 5).map((item) => (
                             <MobileNavItem
-                                key={item.href || item.label}
+                                key={item.to || item.label}
                                 item={item}
-                                activePath={activePath}
                             />
                         ))}
                     </div>
@@ -110,12 +104,12 @@ export default function MobileNav({
                         type="button"
                         aria-label="Close menu"
                         onClick={() => setIsMenuOpen(false)}
-                        className="absolute inset-0 h-full w-full bg-foreground/40"
+                        className="absolute inset-0 h-full w-full bg-foreground/40 backdrop-blur-sm transition-opacity"
                     />
 
                     <aside
                         aria-label="Secondary navigation"
-                        className="absolute inset-x-0 bottom-0 max-h-[82vh] overflow-y-auto border-t border-border bg-background px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-3 shadow-lg"
+                        className="absolute inset-x-0 bottom-0 max-h-[82vh] overflow-y-auto border-t border-border bg-background px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-4 shadow-2xl rounded-t-2xl"
                     >
                         <div className="flex min-h-11 items-center justify-between">
                             <h2 className="text-base font-semibold text-foreground">Menu</h2>
@@ -123,18 +117,17 @@ export default function MobileNav({
                                 type="button"
                                 onClick={() => setIsMenuOpen(false)}
                                 aria-label="Close menu"
-                                className="flex h-11 w-11 items-center justify-center rounded-md text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                                className="flex h-11 w-11 items-center justify-center rounded-xl text-foreground transition-all duration-200 border border-transparent hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                             >
                                 <X className="h-5 w-5" aria-hidden="true" />
                             </button>
                         </div>
 
-                        <div className="mt-2 grid gap-1">
+                        <div className="mt-3 grid gap-1.5">
                             {menuLinks.map((item) => (
                                 <MobileNavItem
-                                    key={item.href || item.label}
+                                    key={item.to || item.label}
                                     item={item}
-                                    activePath={activePath}
                                     drawerItem
                                     onClick={() => setIsMenuOpen(false)}
                                 />

--- a/frontend/src/components/ui/Skeleton.jsx
+++ b/frontend/src/components/ui/Skeleton.jsx
@@ -208,10 +208,10 @@ export function SkeletonCommentList({ count = 3, className = '' }) {
 /** Full-page Profile skeleton */
 export function SkeletonProfile({ className = '' }) {
   return (
-    <div className={`min-h-screen bg-black ${className}`}>
+    <div className={`min-h-screen bg-background ${className}`}>
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
         {/* Profile Header */}
-        <div className="rounded-2xl bg-zinc-900/80 border border-zinc-800 p-6">
+        <div className="rounded-2xl bg-card border border-border p-6">
           <div className="flex flex-col sm:flex-row items-start gap-5">
             <SkeletonCircle className="w-20 h-20 rounded-2xl flex-shrink-0" />
             <div className="flex-1 space-y-3 w-full">
@@ -221,19 +221,19 @@ export function SkeletonProfile({ className = '' }) {
             </div>
             <SkeletonBlock className="h-9 w-28 rounded-lg self-start" />
           </div>
-          <div className="mt-5 pt-5 border-t border-zinc-800">
+          <div className="mt-5 pt-5 border-t border-border">
             <SkeletonText lines={2} />
           </div>
         </div>
 
         {/* Stats */}
         <div className="grid grid-cols-2 gap-4">
-          <div className="rounded-2xl bg-zinc-900/80 border border-zinc-800 p-5">
+          <div className="rounded-2xl bg-card border border-border p-5">
             <SkeletonCircle className="w-10 h-10 mx-auto mb-2 rounded-xl" />
             <SkeletonBlock className="h-8 w-16 mx-auto mb-1" />
             <SkeletonBlock className="h-3 w-24 mx-auto" />
           </div>
-          <div className="rounded-2xl bg-zinc-900/80 border border-zinc-800 p-5">
+          <div className="rounded-2xl bg-card border border-border p-5">
             <SkeletonCircle className="w-10 h-10 mx-auto mb-2 rounded-xl" />
             <SkeletonBlock className="h-8 w-16 mx-auto mb-1" />
             <SkeletonBlock className="h-3 w-24 mx-auto" />
@@ -245,7 +245,7 @@ export function SkeletonProfile({ className = '' }) {
           <div className="flex justify-between items-center mb-4">
             <SkeletonBlock className="h-6 w-32" />
           </div>
-          <div className="rounded-2xl bg-zinc-900/80 border border-zinc-800 divide-y divide-zinc-800">
+          <div className="rounded-2xl bg-card border border-border divide-y divide-border">
             {[1, 2, 3].map((i) => (
               <div key={i} className="p-4 space-y-2">
                 <SkeletonBlock className="h-4 w-1/3" />


### PR DESCRIPTION
## **User description**
# fix(frontend): restore mobile navigation and fix profile skeleton theme compatibility

## Description
This PR resolves two UI issues:
1. **Mobile Navigation Restored**: Fixes the broken links in the `MobileNav.jsx` component by routing to real, working paths (`/dashboard`, `/hub/jobs`, `/hub/resume`, `/hub/portfolio`, `/profile`) and configures `NavLink` to handle highlighting active tabs with brand theme tokens.
2. **Profile Skeleton Theme Fix**: Resolves an issue where the `SkeletonProfile` component rendered a solid black container background and dark gray elements even when the application was in Light Theme. It now correctly uses semantic theme variables (`bg-background`, `bg-card`, `border-border`, `divide-border`).

## Type of Change
- [x] Bug fix
- [ ] New feature

## Related Issue
Fixes #4075 

## Testing
- [x] Tested Locally (Verified mobile navigation and profile skeletons adapt beautifully in both light and dark modes)
- [x] Verified project compiles and builds successfully (`npm run build` exits with code 0)

## Screenshots

https://github.com/user-attachments/assets/f84e1e50-c4e3-4669-b487-a0c92a24727a



## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Restore working mobile navigation and fix profile loading styles**

### What Changed
- Mobile navigation now opens real destinations for Home, Jobs, Resume, Portfolio, Profile, and Settings instead of broken links
- The active tab is highlighted clearly, and the mobile menu uses a more polished, touch-friendly layout
- The profile loading skeleton now follows the app theme in both light and dark mode instead of showing dark-only backgrounds

### Impact
`✅ Fewer broken mobile navigation taps`
`✅ Clearer active tab highlighting`
`✅ Consistent profile loading screens in light and dark mode`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation now uses route-aware links for improved active state management.

* **Style**
  * Updated mobile navigation layout and styling.
  * Refreshed skeleton loading screens with improved color scheme and added visual dividers to profile previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->