### PR TITLE
fix(resume): add auto-save and draft recovery to ResumeBuilder (#4079)

### DIFF
--- a/frontend/src/pages/ResumeBuilder.jsx
+++ b/frontend/src/pages/ResumeBuilder.jsx
@@ -113,6 +113,76 @@ const [careerGoals, setCareerGoals] = useState([
 
 const [goalProgress, setGoalProgress] = useState(0)
 
+  const [hasDraft, setHasDraft] = useState(false)
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+  const [draftContent, setDraftContent] = useState(null)
+
+  useEffect(() => {
+    const saved = localStorage.getItem("resumeBuilderDraft");
+    if (saved) {
+      try {
+        const draft = JSON.parse(saved);
+        setDraftContent(draft);
+        setHasDraft(true);
+      } catch (e) {
+        console.error("Failed to parse draft", e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (hasDraft) return; 
+
+    const draft = {
+      personalInfo: personal,
+      phoneCode,
+      phoneDigits,
+      education,
+      experience,
+      projects,
+      skills,
+      currentStep,
+      targetRole
+    };
+    localStorage.setItem("resumeBuilderDraft", JSON.stringify(draft));
+    
+    const isDirty = personal.name || education[0].school || experience[0].title || projects[0].name || skills;
+    setHasUnsavedChanges(!!isDirty);
+  }, [personal, phoneCode, phoneDigits, education, experience, projects, skills, currentStep, targetRole, hasDraft]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasUnsavedChanges]);
+
+  const restoreDraft = () => {
+    if (draftContent) {
+      if (draftContent.personalInfo) setPersonal(draftContent.personalInfo);
+      if (draftContent.phoneCode) setPhoneCode(draftContent.phoneCode);
+      if (draftContent.phoneDigits) setPhoneDigits(draftContent.phoneDigits);
+      if (draftContent.education) setEducation(draftContent.education);
+      if (draftContent.experience) setExperience(draftContent.experience);
+      if (draftContent.projects) setProjects(draftContent.projects);
+      if (draftContent.skills !== undefined) setSkills(draftContent.skills);
+      if (draftContent.currentStep !== undefined) setCurrentStep(draftContent.currentStep);
+      if (draftContent.targetRole !== undefined) setTargetRole(draftContent.targetRole);
+    }
+    setHasDraft(false);
+    setDraftContent(null);
+  };
+
+  const clearDraft = () => {
+    localStorage.removeItem("resumeBuilderDraft");
+    setHasDraft(false);
+    setDraftContent(null);
+  };
+
   useEffect(() => {
   const suggestions = []
   let score = 100
@@ -646,6 +716,10 @@ useEffect(() => {
         jobRole: targetRole || 'Software Engineer',
         title:   `${personal.name || 'My'} Resume - ${new Date().toLocaleDateString()}`,
       })
+
+      localStorage.removeItem("resumeBuilderDraft")
+      setHasUnsavedChanges(false)
+
       toast.success('Resume created successfully!')
       navigate(`/enhance/${response.data.id}`)
     } catch (error) {
@@ -1643,6 +1717,24 @@ useEffect(() => {
           </h1>
           <p className="text-muted-foreground mt-2">Build a professional resume from scratch.</p>
         </div>
+
+        {/* Draft Notification */}
+        {hasDraft && (
+          <div className="bg-primary/10 border border-primary/20 rounded-xl p-4 mb-8 flex flex-col sm:flex-row items-center justify-between gap-4">
+            <div>
+              <h3 className="font-semibold text-primary">Unsaved Draft Detected</h3>
+              <p className="text-sm text-primary/80">You have a resume draft in progress. Would you like to restore it?</p>
+            </div>
+            <div className="flex gap-3">
+              <button onClick={clearDraft} className="px-4 py-2 text-sm rounded-lg border border-primary/20 text-primary hover:bg-primary/10 transition-colors">
+                Start fresh
+              </button>
+              <button onClick={restoreDraft} className="px-4 py-2 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shadow-sm">
+                Continue editing
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* Progress Stepper */}
         <div className="mb-8 flex items-center justify-between relative">


### PR DESCRIPTION
## **User description**
## Description
Brief description of changes

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #(issue number)

## Testing
- [ ] Unit tests pass
- [ ] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [ ] Attached Screenshots or Screen Recordings (showing before and after)
- *If your PR does not make any visual/UI changes, please write "N/A"*

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [ ] No new warnings generated


## Description

Resolves #4079 

This PR implements an auto-save and draft recovery mechanism for the Resume Builder to prevent users from losing their progress due to accidental page refreshes, tab closures, or navigation. 

### Changes Made
- **Local Storage Auto-Save:** Added a `useEffect` in `ResumeBuilder.jsx` that automatically saves the user's progress (Personal Info, Education, Experience, Projects, Skills, Current Step, etc.) to `localStorage` under `resumeBuilderDraft` on every state change.
- **Draft Recovery Banner:** Implemented logic to check for a pre-existing draft upon component mount. If a draft is detected, users are presented with a banner giving them the option to "Continue editing" (which restores their progress) or "Start fresh" (which clears the local storage).
- **Accidental Navigation Warning:** Added a `beforeunload` event listener. When the user has unsaved changes, the browser will natively prompt a warning if they try to close the tab or refresh the page mid-fill.
- **Draft Cleanup:** Upon successfully generating the resume, the draft is cleared from `localStorage` to ensure subsequent resume builds start with a clean slate.

### Testing Instructions
1. Navigate to `/hub/resume`.
2. Fill out some details in the first or second step of the wizard.
3. Refresh the page. You should see a banner indicating a draft is detected.
4. Click "Continue editing" to verify that your form fields and progress are fully restored.
5. Attempt to close the browser tab or navigate away to an external URL, and verify the `beforeunload` confirmation dialog appears.
6. Complete the wizard and generate the resume. Return to `/hub/resume` and verify the draft has been cleared and no banner is shown.


https://github.com/user-attachments/assets/a091565d-f43c-44c1-9774-561bbd89a055


___

## **CodeAnt-AI Description**
**Save resume progress and restore unfinished drafts**

### What Changed
- Resume Builder now saves in-progress details automatically so users can come back after refreshing, closing the tab, or leaving the page.
- If an unfinished draft is found, users see a prompt to either continue editing from where they left off or start over with a blank resume.
- Users are warned before closing or refreshing the page when they have unsaved changes.
- Finished resumes clear the saved draft so the next build starts clean.

### Impact
`✅ Fewer lost resume drafts`
`✅ Safer resume editing after refresh or tab close`
`✅ Shorter time to resume unfinished builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume drafts now automatically save as you edit
  * Saved drafts persist and can be restored on return visits
  * Draft notification banner displays options to restore or start fresh
  * Unsaved changes warning prevents accidental data loss when navigating away

<!-- end of auto-generated comment: release notes by coderabbit.ai -->