### PR TITLE
feat(security): implement session management & invalidation with Redis

### DIFF
--- a/backend/src/services/__tests__/sessionManager.test.js
+++ b/backend/src/services/__tests__/sessionManager.test.js
@@ -1,0 +1,122 @@
+import { describe, test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import RedisMock from 'ioredis-mock';
+import redisManager from '../../config/redis.js';
+import {
+  createSession,
+  getSession,
+  touchSession,
+  invalidateSession,
+  invalidateAllSessions,
+  getUserSessions,
+} from '../sessionManager.js';
+
+const CONNECTION_NAME = 'sessions';
+
+describe('sessionManager', () => {
+  before(() => {
+    // Replace the lazily-created Redis client with an in-memory mock.
+    // ioredis-mock doesn't set `.status`, but redisManager.get() checks
+    // existing.client.status to decide whether to reuse a connection,
+    // so we set it to 'ready' to mimic a healthy ioredis client.
+    const mockClient = new RedisMock();
+    mockClient.status = 'ready';
+    redisManager.connections.set(CONNECTION_NAME, {
+      client: mockClient,
+      status: 'connected',
+    });
+  });
+
+  after(async () => {
+    await redisManager.close(CONNECTION_NAME);
+  });
+
+  beforeEach(async () => {
+    const entry = redisManager.connections.get(CONNECTION_NAME);
+    await entry.client.flushall();
+  });
+
+  test('createSession returns a sessionId and expiresAt', async () => {
+    const { sessionId, expiresAt } = await createSession('user-1', { email: 'a@b.com' });
+    assert.ok(sessionId);
+    assert.equal(sessionId.length, 64);
+    assert.ok(expiresAt > Date.now());
+  });
+
+  test('getSession returns stored session data', async () => {
+    const { sessionId } = await createSession('user-1', { email: 'a@b.com' });
+    const session = await getSession(sessionId);
+    assert.equal(session.uid, 'user-1');
+    assert.equal(session.email, 'a@b.com');
+  });
+
+  test('getSession returns null for unknown sessionId', async () => {
+    const session = await getSession('does-not-exist');
+    assert.equal(session, null);
+  });
+
+  test('touchSession extends expiry and returns true', async () => {
+    const { sessionId, expiresAt } = await createSession('user-1', {}, 10);
+    const ok = await touchSession(sessionId, 1000);
+    assert.equal(ok, true);
+
+    const session = await getSession(sessionId);
+    assert.ok(session.expiresAt > expiresAt);
+  });
+
+  test('touchSession returns false for unknown sessionId', async () => {
+    const ok = await touchSession('nope');
+    assert.equal(ok, false);
+  });
+
+  test('invalidateSession removes the session', async () => {
+    const { sessionId } = await createSession('user-1', {});
+    const ok = await invalidateSession(sessionId);
+    assert.equal(ok, true);
+
+    const session = await getSession(sessionId);
+    assert.equal(session, null);
+  });
+
+  test('invalidateSession returns false for already-removed session', async () => {
+    const { sessionId } = await createSession('user-1', {});
+    await invalidateSession(sessionId);
+    const ok = await invalidateSession(sessionId);
+    assert.equal(ok, false);
+  });
+
+  test('getUserSessions lists active sessions for a user', async () => {
+    const s1 = await createSession('user-2', {});
+    const s2 = await createSession('user-2', {});
+
+    const sessions = await getUserSessions('user-2');
+    assert.equal(sessions.length, 2);
+    assert.ok(sessions.includes(s1.sessionId));
+    assert.ok(sessions.includes(s2.sessionId));
+  });
+
+  test('invalidateAllSessions removes all sessions for a user', async () => {
+    const s1 = await createSession('user-3', {});
+    const s2 = await createSession('user-3', {});
+
+    const count = await invalidateAllSessions('user-3');
+    assert.equal(count, 2);
+
+    assert.equal(await getSession(s1.sessionId), null);
+    assert.equal(await getSession(s2.sessionId), null);
+    assert.deepEqual(await getUserSessions('user-3'), []);
+  });
+
+  test('invalidateAllSessions returns 0 for a user with no sessions', async () => {
+    const count = await invalidateAllSessions('user-no-sessions');
+    assert.equal(count, 0);
+  });
+
+  test('createSession throws without a uid', async () => {
+    await assert.rejects(() => createSession(), /requires a uid/);
+  });
+
+  test('createSession throws with invalid ttlSeconds', async () => {
+    await assert.rejects(() => createSession('user-1', {}, -5), /ttlSeconds/);
+  });
+});

--- a/backend/src/services/sessionManager.js
+++ b/backend/src/services/sessionManager.js
@@ -1,0 +1,128 @@
+import crypto from 'crypto';
+import redisManager from '../config/redis.js';
+
+const CONNECTION_NAME = 'sessions';
+const SESSION_PREFIX = 'session:';
+const USER_SESSIONS_PREFIX = 'user-sessions:';
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+function getClient() {
+  return redisManager.get(CONNECTION_NAME);
+}
+
+function sessionKey(sessionId) {
+  return `${SESSION_PREFIX}${sessionId}`;
+}
+
+function userSessionsKey(uid) {
+  return `${USER_SESSIONS_PREFIX}${uid}`;
+}
+
+export async function createSession(uid, metadata = {}, ttlSeconds = DEFAULT_TTL_SECONDS) {
+  if (!uid) {
+    throw new Error('createSession requires a uid');
+  }
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    throw new Error('ttlSeconds must be a positive number');
+  }
+
+  getClient();
+  const client = await redisManager.waitForReady(CONNECTION_NAME);
+  const sessionId = crypto.randomBytes(32).toString('hex');
+  const createdAt = Date.now();
+  const expiresAt = createdAt + ttlSeconds * 1000;
+
+  const payload = JSON.stringify({ uid, createdAt, expiresAt, ...metadata });
+
+  await client.set(sessionKey(sessionId), payload, 'EX', ttlSeconds);
+  await client.sadd(userSessionsKey(uid), sessionId);
+  await client.expire(userSessionsKey(uid), ttlSeconds);
+
+  return { sessionId, expiresAt };
+}
+
+export async function getSession(sessionId) {
+  if (!sessionId) return null;
+
+  getClient();
+  const client = await redisManager.waitForReady(CONNECTION_NAME);
+  const raw = await client.get(sessionKey(sessionId));
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    await client.del(sessionKey(sessionId));
+    return null;
+  }
+}
+
+export async function touchSession(sessionId, ttlSeconds = DEFAULT_TTL_SECONDS) {
+  if (!sessionId) return false;
+
+  getClient();
+  const client = await redisManager.waitForReady(CONNECTION_NAME);
+  const session = await getSession(sessionId);
+  if (!session) return false;
+
+  session.expiresAt = Date.now() + ttlSeconds * 1000;
+  await client.set(sessionKey(sessionId), JSON.stringify(session), 'EX', ttlSeconds);
+  await client.expire(userSessionsKey(session.uid), ttlSeconds);
+  return true;
+}
+
+export async function invalidateSession(sessionId) {
+  if (!sessionId) return false;
+
+  getClient();
+  const client = await redisManager.waitForReady(CONNECTION_NAME);
+  const session = await getSession(sessionId);
+
+  const deleted = await client.del(sessionKey(sessionId));
+
+  if (session?.uid) {
+    await client.srem(userSessionsKey(session.uid), sessionId);
+  }
+
+  return deleted > 0;
+}
+
+export async function invalidateAllSessions(uid) {
+  if (!uid) return 0;
+
+  getClient();
+  const client = await redisManager.waitForReady(CONNECTION_NAME);
+  const sessionIds = await client.smembers(userSessionsKey(uid));
+
+  if (sessionIds.length === 0) {
+    await client.del(userSessionsKey(uid));
+    return 0;
+  }
+
+  const pipeline = client.pipeline();
+  for (const sessionId of sessionIds) {
+    pipeline.del(sessionKey(sessionId));
+  }
+  pipeline.del(userSessionsKey(uid));
+
+  await pipeline.exec();
+  return sessionIds.length;
+}
+
+export async function getUserSessions(uid) {
+  if (!uid) return [];
+  getClient();
+  const client = await redisManager.waitForReady(CONNECTION_NAME);
+  return client.smembers(userSessionsKey(uid));
+}
+
+const sessionManager = {
+  createSession,
+  getSession,
+  touchSession,
+  invalidateSession,
+  invalidateAllSessions,
+  getUserSessions,
+};
+
+export default sessionManager;


### PR DESCRIPTION
## Description
Implements Redis-based session management and invalidation as required by issue #2768.

- Add sessionManager service using ioredis for session storage
- createSession: generates a cryptographically random session ID, stores session data with TTL (default 7 days)
- getSession: retrieves and validates session data
- touchSession: sliding expiration / refresh TTL
- invalidateSession: deletes a single session
- invalidateAllSessions: deletes all sessions for a user (logout everywhere)
- getUserSessions: lists active session IDs for a user
- Add full test coverage using ioredis-mock (12 tests, all passing)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #2768

## Testing
- [x] Unit tests pass
- [x] Tested Locally
- [x] New tests added

## Test output:



<img width="580" height="338" alt="Screenshot 2026-06-15 at 4 14 59 PM" src="https://github.com/user-attachments/assets/bc84505a-7154-494f-b0bb-2dc3b357af5e" />



✓ createSession returns a sessionId and expiresAt
✓ getSession returns stored session data
✓ getSession returns null for unknown sessionId
✓ touchSession extends expiry and returns true
✓ touchSession returns false for unknown sessionId
✓ invalidateSession removes the session
✓ invalidateSession returns false for already-removed session
✓ getUserSessions lists active sessions for a user
✓ invalidateAllSessions removes all sessions for a user
✓ invalidateAllSessions returns 0 for a user with no sessions
✓ createSession throws without a uid
✓ createSession throws with invalid ttlSeconds

tests 12
pass 12
fail 0
\`\`\`

## Screenshots (MANDATORY for UI/UX changes)
N/A — this is a backend-only service with no UI/visual changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated