### PR TITLE
fix: add GDPR compliant cookie consent banner

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import ChatbotPortfolio from "./components/portfolio/templates/Chatbot_Portfolio
 import GlassmorphismTemplate from "./components/portfolio/templates/Glassmorphism/index";
 
 import JobTracker from './pages/JobTracker';
+import CookieBanner from "./components/CookieBanner";
 
 const Outreach = lazy(() => import('./pages/Outreach'));
 const Community = lazy(() => import('./pages/Community'));
@@ -488,6 +489,7 @@ function AppRoutes() {
         <Route path="*" element={<NotFound />} />
         <Route path="/templates/color-block" element={<ColorBlock />} />
       </Routes>
+      <CookieBanner />
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/CookieBanner.jsx
+++ b/frontend/src/components/CookieBanner.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const accepted = localStorage.getItem("cookiesAccepted");
+
+    if (!accepted) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem("cookiesAccepted", "true");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card/95 px-6 py-4 shadow-2xl backdrop-blur-md">
+      {" "}
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
+          We use cookies to improve your experience, enhance site functionality,
+          and ensure better performance across the platform.{" "}
+          <Link
+            to="/cookies"
+            className="font-medium text-primary underline underline-offset-4 transition-colors duration-200 hover:text-primary/80"
+          >
+            Learn more
+          </Link>
+        </p>
+
+        <div className="flex items-center gap-3">
+          <Link
+            to="/cookies"
+            className="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-muted hover:text-foreground"
+          >
+            Manage Preferences
+          </Link>
+
+          <button
+            onClick={acceptCookies}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-md transition-all duration-200 hover:scale-[1.02] hover:opacity-90 active:scale-[0.98]"
+          >
+            Accept All
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## **User description**
## Description

Adds a cookie consent banner for GDPR compliance and improved user privacy awareness.

### Changes made:

* Added a reusable `CookieBanner` component
* Displays banner for first-time visitors only
* Stores consent state in `localStorage`
* Added navigation links to `/cookies` policy page
* Added responsive styling using existing design system tokens
* Included hover states and improved interaction feedback
* Integrated banner globally within the application router

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Other (describe)

## Related Issue

Fixes #4072

## Testing

* [ ] Unit tests pass
* [x] Tested Locally
* [ ] New tests added

## Screenshot

<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/06852ce8-1399-41d4-9969-1860ef137ccf" />

- ( You can see CookieBanner is coming at bottom )
## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my code
* [ ] Added comments where necessary
* [ ] Updated documentation
* [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Show a cookie consent banner for first-time visitors**

### What Changed
- A cookie consent banner now appears at the bottom of the app for users who have not already accepted cookies
- Clicking **Accept All** saves the choice and hides the banner on future visits
- The banner includes links to the cookie policy and a page to manage preferences

### Impact
`✅ Clearer cookie consent`
`✅ Fewer repeat prompts for returning visitors`
`✅ Easier access to cookie settings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sticky cookie consent banner positioned at the bottom of the page.
  * Users can accept all cookies with a single button click or access additional resources to learn more about our cookie practices and manage their individual preferences.
  * Cookie choices are automatically saved and respected on all future visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->