### PR TITLE
fix: wrap pdfParse in timeout to prevent event loop DoS

### DIFF
--- a/backend/src/routes/upload.js
+++ b/backend/src/routes/upload.js
@@ -75,6 +75,9 @@ router.post('/', verifyToken, handleUpload, validateUpload, asyncHandler(async (
     });
   } catch (error) {
     console.error('PDF parsing error:', error);
+    if (error.message === 'PDF parsing timed out') {
+      throw new ApiError(408, 'PDF parsing timed out. Please try a smaller or simpler file.');
+    }
     throw new ApiError(400, 'Failed to parse PDF. Please ensure the file is a valid PDF document.');
   } finally {
     if (req.file && req.file.path) {
@@ -105,6 +108,9 @@ router.post('/extract-text', verifyToken, handleUpload, validateUpload, asyncHan
     });
   } catch (error) {
     console.error('PDF text extraction error:', error);
+    if (error.message === 'PDF parsing timed out') {
+      throw new ApiError(408, 'PDF parsing timed out. Please try a smaller or simpler file.');
+    }
     throw new ApiError(400, 'Failed to extract text from PDF');
   } finally {
     if (req.file && req.file.path) {

--- a/backend/src/routes/upload.js
+++ b/backend/src/routes/upload.js
@@ -1,5 +1,7 @@
 import express from 'express';
-import pdfParse from 'pdf-parse';
+import { Worker } from 'worker_threads';
+import { fileURLToPath } from 'url';
+import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import fs from 'fs/promises';
 import { handleUpload } from '../middleware/upload.js';
@@ -7,14 +9,45 @@ import { verifyToken } from '../middleware/auth.js';
 import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import { validateUpload } from '../middleware/uploadValidator.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const router = express.Router();
-const parseWithTimeout = (buffer, ms = 8000) =>
-  Promise.race([
-    pdfParse(buffer),
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('PDF parsing timed out')), ms)
-    )
-  ]);
+const parseInWorker = (buffer, ms = 8000) =>
+  new Promise((resolve, reject) => {
+    let settled = false;
+    const worker = new Worker(
+      path.join(__dirname, '../workers/pdfWorker.js'),
+      { workerData: { buffer: buffer.buffer } }
+    );
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      worker.terminate();
+      reject(new Error('PDF parsing timed out'));
+    }, ms);
+
+    worker.on('message', (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (result.success) resolve(result);
+      else reject(new Error(result.error));
+    });
+
+    worker.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    worker.on('exit', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error('PDF worker exited unexpectedly'));
+    });
+  });
 
 // Upload and extract text from PDF
 router.post('/', verifyToken, handleUpload, validateUpload, asyncHandler(async (req, res) => {
@@ -23,7 +56,7 @@ router.post('/', verifyToken, handleUpload, validateUpload, asyncHandler(async (
   }
   try {
     const fileBuffer = await fs.readFile(req.file.path);
-    const pdfData = await parseWithTimeout(fileBuffer);
+    const pdfData = await parseInWorker(fileBuffer);
     const resumeId = uuidv4();
 
     res.json({
@@ -61,7 +94,7 @@ router.post('/extract-text', verifyToken, handleUpload, validateUpload, asyncHan
   }
   try {
     const fileBuffer = await fs.readFile(req.file.path);
-    const pdfData = await parseWithTimeout(fileBuffer);
+    const pdfData = await parseInWorker(fileBuffer);
 
     res.json({
       success: true,

--- a/backend/src/routes/upload.js
+++ b/backend/src/routes/upload.js
@@ -8,6 +8,13 @@ import { asyncHandler, ApiError } from '../middleware/errorHandler.js';
 import { validateUpload } from '../middleware/uploadValidator.js';
 
 const router = express.Router();
+const parseWithTimeout = (buffer, ms = 8000) =>
+  Promise.race([
+    pdfParse(buffer),
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('PDF parsing timed out')), ms)
+    )
+  ]);
 
 // Upload and extract text from PDF
 router.post('/', verifyToken, handleUpload, validateUpload, asyncHandler(async (req, res) => {
@@ -16,7 +23,7 @@ router.post('/', verifyToken, handleUpload, validateUpload, asyncHandler(async (
   }
   try {
     const fileBuffer = await fs.readFile(req.file.path);
-    const pdfData = await pdfParse(fileBuffer);
+    const pdfData = await parseWithTimeout(fileBuffer);
     const resumeId = uuidv4();
 
     res.json({
@@ -54,7 +61,7 @@ router.post('/extract-text', verifyToken, handleUpload, validateUpload, asyncHan
   }
   try {
     const fileBuffer = await fs.readFile(req.file.path);
-    const pdfData = await pdfParse(fileBuffer);
+    const pdfData = await parseWithTimeout(fileBuffer);
 
     res.json({
       success: true,

--- a/backend/src/workers/pdfWorker.js
+++ b/backend/src/workers/pdfWorker.js
@@ -1,0 +1,14 @@
+import { workerData, parentPort } from 'worker_threads';
+import pdfParse from 'pdf-parse';
+
+try {
+  const data = await pdfParse(Buffer.from(workerData.buffer));
+  parentPort.postMessage({
+    success: true,
+    text: data.text,
+    numpages: data.numpages,
+    info: data.info
+  });
+} catch (err) {
+  parentPort.postMessage({ success: false, error: err.message });
+}


### PR DESCRIPTION
## **User description**
## Description
Both `POST /upload` and `POST /upload/extract-text` endpoints were calling `pdfParse(fileBuffer)` 
with no execution timeout. A crafted PDF with deeply nested object streams or thousands of pages 
could block the Node.js event loop indefinitely, causing a DoS for all concurrent requests. 
Added a `parseWithTimeout()` helper that wraps `pdfParse` in a `Promise.race` with an 8-second 
timeout, rejecting with an error if parsing exceeds the limit.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #4133 

## Testing
- [X] Unit tests pass
- [X] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- [ ] Attached Screenshots or Screen Recordings (showing before and after)
- *If your PR does not make any visual/UI changes, please write "N/A"*

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [X] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved PDF text parsing reliability by moving parsing to a background worker.
  * Added an 8-second timeout for PDF parsing so uploads and text extraction don’t stall; timeouts now return a clear request timeout error.
  * Updated upload and text extraction endpoints to use the worker-based parsing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Stop PDF uploads from hanging the server**

### What Changed
- PDF text extraction now runs in a separate worker, so a complex or malformed file can be stopped without freezing other requests
- Both upload endpoints now cancel parsing after 8 seconds and return an error instead of waiting indefinitely
- If the worker fails or exits unexpectedly, the upload now fails cleanly

### Impact
`✅ Fewer upload hangs`
`✅ Lower risk of server lockups`
`✅ Clearer PDF upload failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
