### PR TITLE
Fix Clock naming conflict in Fake WebOS template

### DIFF
--- a/frontend/src/components/portfolio/templates/Fake_WebOS_Operating_System/index.jsx
+++ b/frontend/src/components/portfolio/templates/Fake_WebOS_Operating_System/index.jsx
@@ -432,7 +432,7 @@ function AppContent({ appId, data }) {
 }
 
 /* ─── Clock ─────────────────────────────────────────────── */
-function ClockWidget() {
+function systemWidget() {
   const [time, setTime] = useState(new Date());
   useEffect(() => { const t = setInterval(() => setTime(new Date()), 1000); return () => clearInterval(t); }, []);
   return (


### PR DESCRIPTION
## **User description**
## Description
Rendering Error in the Fake WebOS Operating System portfolio template caused by a naming conflict between the Clock icon imported from `lucide-react` and the custom Clock component.

The custom component was renamed to `systemClock`, and all related references were updated to eliminate the duplicate declaration issue while preserving existing functionality.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes (#4187 )

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes) 
- [x] Added screenshots
<img width="1878" height="939" alt="Screenshot 2026-06-18 185721" src="https://github.com/user-attachments/assets/884d43b2-03ec-4653-b34b-2876bfc86737" />
<img width="1904" height="807" alt="Screenshot 2026-06-18 185745" src="https://github.com/user-attachments/assets/5195f489-88cc-42aa-9372-e83690d1a26a" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [ ] No new warnings generated


___

## **CodeAnt-AI Description**
**Fix the Fake WebOS portfolio template so it renders correctly**

### What Changed
- Renamed the internal clock widget to remove a naming conflict that was preventing the Fake WebOS template from loading
- The portfolio section now renders normally again without the duplicate name error

### Impact
`✅ Fake WebOS template loads again`
`✅ Fewer blank portfolio sections`
`✅ Clearer rendering for visitors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the clock widget component was not rendering correctly due to an incomplete internal refactoring that prevented the component from being properly recognized at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->