### PR TITLE
docs: add ADMIN_EMAILS to backend env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -288,6 +288,11 @@ ENABLE_PREMIUM_THEMES=false
 # Example: ADMIN_UIDS=uid1abc,uid2def
 ADMIN_UIDS=
 
+# Comma-separated email addresses allowed to access admin-only endpoints
+# Type: comma-separated string
+# Example: ADMIN_EMAILS=admin1@example.com,admin2@example.com
+ADMIN_EMAILS=
+
 
 # BullMQ Monitoring Dashboard
 BULL_BOARD_ENABLED=true


### PR DESCRIPTION
## Description

Adds documentation for `ADMIN_EMAILS` in `backend/.env.example`.

## Problem

The `adminOnly` middleware reads `ADMIN_EMAILS` from environment variables for admin authorization, but this variable was not documented in `backend/.env.example`.

## Solution

Added:

* `ADMIN_EMAILS=` placeholder
* Type information
* Example usage

## Type of Change

* [x] Documentation update

## Related Issue

Fixes #4226

## Testing

* [x] Verified `ADMIN_EMAILS` is used in `backend/src/middleware/auth.js`
* [x] Verified it was missing from `backend/.env.example`
* [x] No application logic changed
* [x] No unrelated files modified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration to support admin email management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->