### PR TITLE
fix: remove duplicate res.status(200).json() in PUT /api/portfolio/:slug

### DIFF
--- a/backend/src/routes/portfolio.js
+++ b/backend/src/routes/portfolio.js
@@ -415,19 +415,12 @@ router.put('/:slug', verifyToken, validatePortfolioSlug, validatePortfolioConten
   if (!portfolio) {
     throw new ApiError(404, `Portfolio "${slug}" not found.`);
   }
-res.status(200).json({
-  success: true,
-  message: 'Portfolio updated successfully.',
-  data: portfolio,
-});
-
-
   res.status(200).json({
     success: true,
     message: 'Portfolio updated successfully.',
     data: portfolio,
   });
-  
+
 }));
 
 /**


### PR DESCRIPTION
## **User description**
## Description
Removes the duplicate `res.status(200).json()` call in the PUT /api/portfolio/:slug handler. The second identical block triggered `ERR_HTTP_HEADERS_SENT` on every successful portfolio update because the response was already sent by the first.

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #4282

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
Fix portfolio updates returning an HTTP error after success

### What Changed
- Removed a duplicate success response from `PUT /api/portfolio/:slug`
- Portfolio updates now return one success response instead of triggering an error after the update completes

### Impact
`✅ Successful portfolio updates no longer fail after saving`
`✅ Fewer broken update responses`
`✅ Clearer portfolio save confirmations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with the portfolio update endpoint that was causing response errors when saving changes to your portfolio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->