### PR TITLE
feat(devops): add database migration framework

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,10 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "lint": "eslint src/",
-    "test": "node --test src/schemas/__tests__/schemas.test.js src/schemas/__tests__/interview-extended.test.js src/services/__tests__/jdParser.test.js src/services/__tests__/interview-coding.test.js src/services/__tests__/transcription.test.js src/config/__tests__/socketOptions.test.js"
+    "test": "node --test src/schemas/__tests__/schemas.test.js src/schemas/__tests__/interview-extended.test.js src/services/__tests__/jdParser.test.js src/services/__tests__/interview-coding.test.js src/services/__tests__/transcription.test.js src/config/__tests__/socketOptions.test.js src/migrations/__tests__/migrationRunner.test.js",
+    "migrate": "node src/migrations/migrationRunner.js up",
+    "migrate:status": "node src/migrations/migrationRunner.js status",
+    "migrate:down": "node src/migrations/migrationRunner.js down"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.99.0",

--- a/backend/src/migrations/README.md
+++ b/backend/src/migrations/README.md
@@ -1,0 +1,69 @@
+# Database Migration Framework
+
+Career Pilot backend migrations are executed through:
+
+```bash
+npm run migrate
+npm run migrate:status
+npm run migrate:down -- --steps=1
+npm run migrate -- --dry-run
+```
+
+## Migration file format
+
+Create migration files in:
+
+```txt
+backend/src/migrations/steps
+```
+
+Use a sortable numeric prefix:
+
+```txt
+001-create-user-index.js
+002-backfill-job-alert-status.js
+```
+
+Each migration exports an `up(db)` function and may export a `down(db)` rollback function.
+
+```js
+export const description = 'Create index for user email lookups';
+
+export async function up(db) {
+  await db.collection('users').createIndex({ email: 1 }, { unique: true });
+}
+
+export async function down(db) {
+  await db.collection('users').dropIndex('email_1');
+}
+```
+
+## Safety behavior
+
+- Applied migrations are stored in the `schema_migrations` collection.
+- Already-applied migrations are skipped.
+- A MongoDB-backed lock prevents concurrent migration runs during deployment.
+- Failed migrations are not recorded as applied.
+- `--dry-run` shows pending work without mutating the database.
+
+## Deployment usage
+
+Run migrations after the backend has access to `MONGODB_URI` and before routing production traffic to the new release.
+
+Recommended deployment order:
+
+```bash
+npm install
+npm run migrate
+npm start
+```
+
+## Rollback usage
+
+To roll back the latest applied migration:
+
+```bash
+npm run migrate:down -- --steps=1
+```
+
+Only migrations that define a `down(db)` function can be rolled back.

--- a/backend/src/migrations/__tests__/migrationRunner.test.js
+++ b/backend/src/migrations/__tests__/migrationRunner.test.js
@@ -1,0 +1,254 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import {
+  createMigrationRunner,
+  MIGRATION_COLLECTION,
+} from '../migrationRunner.js';
+
+async function createTempMigrationDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'career-pilot-migrations-'));
+}
+
+async function writeMigration(dir, name, body) {
+  await fs.writeFile(path.join(dir, name), body);
+}
+
+async function withDatabase(fn) {
+  const mongo = await MongoMemoryServer.create();
+  const connection = await mongoose.createConnection(mongo.getUri()).asPromise();
+
+  try {
+    await fn(connection.db);
+  } finally {
+    await connection.close();
+    await mongo.stop();
+  }
+}
+
+test('runs pending migrations in filename order and records them once', async () => {
+  await withDatabase(async (db) => {
+    const dir = await createTempMigrationDir();
+
+    await writeMigration(
+      dir,
+      '002-add-index.js',
+      `
+      export const description = 'second migration';
+      export async function up(db) {
+        await db.collection('events').insertOne({ order: 2 });
+      }
+      export async function down(db) {
+        await db.collection('events').deleteOne({ order: 2 });
+      }
+      `
+    );
+
+    await writeMigration(
+      dir,
+      '001-create-users.js',
+      `
+      export const description = 'first migration';
+      export async function up(db) {
+        await db.collection('events').insertOne({ order: 1 });
+      }
+      export async function down(db) {
+        await db.collection('events').deleteOne({ order: 1 });
+      }
+      `
+    );
+
+    const runner = createMigrationRunner({ db, migrationsDir: dir, logger: { log() {}, warn() {}, error() {} } });
+
+    const firstRun = await runner.up();
+    const secondRun = await runner.up();
+
+    assert.deepEqual(firstRun.applied, ['001-create-users', '002-add-index']);
+    assert.deepEqual(secondRun.applied, []);
+    assert.deepEqual(secondRun.skipped, ['001-create-users', '002-add-index']);
+
+    const events = await db.collection('events').find().sort({ order: 1 }).toArray();
+    assert.deepEqual(events.map((event) => event.order), [1, 2]);
+
+    const records = await db.collection(MIGRATION_COLLECTION).find().toArray();
+    assert.equal(records.length, 2);
+  });
+});
+
+test('status reports applied and pending migrations', async () => {
+  await withDatabase(async (db) => {
+    const dir = await createTempMigrationDir();
+
+    await writeMigration(
+      dir,
+      '001-applied.js',
+      `export async function up() {}`
+    );
+
+    await writeMigration(
+      dir,
+      '002-pending.js',
+      `export async function up() {}`
+    );
+
+    await db.collection(MIGRATION_COLLECTION).insertOne({
+      id: '001-applied',
+      appliedAt: new Date(),
+    });
+
+    const runner = createMigrationRunner({ db, migrationsDir: dir });
+    const status = await runner.status();
+
+    assert.deepEqual(
+      status.map((item) => ({ id: item.id, applied: item.applied })),
+      [
+        { id: '001-applied', applied: true },
+        { id: '002-pending', applied: false },
+      ]
+    );
+  });
+});
+
+test('rolls back the latest applied migration only', async () => {
+  await withDatabase(async (db) => {
+    const dir = await createTempMigrationDir();
+
+    await writeMigration(
+      dir,
+      '001-create-doc.js',
+      `
+      export async function up(db) {
+        await db.collection('items').insertOne({ name: 'one' });
+      }
+      export async function down(db) {
+        await db.collection('items').deleteOne({ name: 'one' });
+      }
+      `
+    );
+
+    await writeMigration(
+      dir,
+      '002-create-doc.js',
+      `
+      export async function up(db) {
+        await db.collection('items').insertOne({ name: 'two' });
+      }
+      export async function down(db) {
+        await db.collection('items').deleteOne({ name: 'two' });
+      }
+      `
+    );
+
+    const runner = createMigrationRunner({ db, migrationsDir: dir });
+
+    await runner.up();
+    const rollback = await runner.down({ steps: 1 });
+
+    assert.deepEqual(rollback.reverted, ['002-create-doc']);
+
+    const items = await db.collection('items').find().sort({ name: 1 }).toArray();
+    assert.deepEqual(items.map((item) => item.name), ['one']);
+  });
+});
+
+test('does not record a failed migration as applied', async () => {
+  await withDatabase(async (db) => {
+    const dir = await createTempMigrationDir();
+
+    await writeMigration(
+      dir,
+      '001-fails.js',
+      `
+      export async function up() {
+        throw new Error('boom');
+      }
+      `
+    );
+
+    const runner = createMigrationRunner({ db, migrationsDir: dir });
+
+    await assert.rejects(() => runner.up(), /Migration 001-fails failed/);
+
+    const records = await db.collection(MIGRATION_COLLECTION).find().toArray();
+    assert.equal(records.length, 0);
+  });
+});
+
+test('dry run reports migrations without mutating the database', async () => {
+  await withDatabase(async (db) => {
+    const dir = await createTempMigrationDir();
+
+    await writeMigration(
+      dir,
+      '001-dry-run.js',
+      `
+      export async function up(db) {
+        await db.collection('items').insertOne({ name: 'created' });
+      }
+      `
+    );
+
+    const runner = createMigrationRunner({ db, migrationsDir: dir });
+    const result = await runner.up({ dryRun: true });
+
+    assert.deepEqual(result.applied, ['001-dry-run']);
+
+    const items = await db.collection('items').find().toArray();
+    const records = await db.collection(MIGRATION_COLLECTION).find().toArray();
+
+    assert.equal(items.length, 0);
+    assert.equal(records.length, 0);
+  });
+});
+
+test('prevents a second runner from executing while a migration lock is active', async () => {
+  await withDatabase(async (db) => {
+    const dir = await createTempMigrationDir();
+
+    await writeMigration(
+      dir,
+      '001-lock-test.js',
+      `
+      export async function up(db) {
+        await db.collection('items').insertOne({ name: 'locked' });
+      }
+      `
+    );
+
+    const firstRunner = createMigrationRunner({
+      db,
+      migrationsDir: dir,
+      owner: 'first-runner',
+      lockTtlMs: 60_000,
+    });
+
+    const secondRunner = createMigrationRunner({
+      db,
+      migrationsDir: dir,
+      owner: 'second-runner',
+      lockTtlMs: 60_000,
+    });
+
+    await firstRunner.ensureIndexes();
+
+    await db.collection('schema_migration_locks').insertOne({
+      _id: 'career-pilot-migration-runner',
+      owner: 'first-runner',
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await assert.rejects(
+      () => secondRunner.up(),
+      /Another migration run is already in progress/
+    );
+
+    const records = await db.collection(MIGRATION_COLLECTION).find().toArray();
+    assert.equal(records.length, 0);
+  });
+});

--- a/backend/src/migrations/migrationRunner.js
+++ b/backend/src/migrations/migrationRunner.js
@@ -302,7 +302,7 @@ return loadedMigrations;
 
       const applied = await migrations
         .find({})
-        .sort({ appliedAt: -1 })
+        .sort({ appliedAt: -1, _id: -1 })
         .limit(steps)
         .toArray();
 

--- a/backend/src/migrations/migrationRunner.js
+++ b/backend/src/migrations/migrationRunner.js
@@ -1,0 +1,319 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import mongoose from 'mongoose';
+import { connectDB } from '../config/database.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const DEFAULT_MIGRATIONS_DIR = path.join(__dirname, 'steps');
+export const MIGRATION_COLLECTION = 'schema_migrations';
+export const MIGRATION_LOCK_COLLECTION = 'schema_migration_locks';
+export const MIGRATION_LOCK_ID = 'career-pilot-migration-runner';
+
+const now = () => new Date();
+
+export class MigrationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'MigrationError';
+    this.details = details;
+  }
+}
+
+export function createMigrationRunner({
+  db,
+  migrationsDir = DEFAULT_MIGRATIONS_DIR,
+  logger = console,
+  lockTtlMs = 5 * 60 * 1000,
+  owner = `${process.pid}-${Date.now()}`,
+} = {}) {
+  if (!db) {
+    throw new MigrationError('MongoDB database handle is required');
+  }
+
+  const migrations = db.collection(MIGRATION_COLLECTION);
+  const locks = db.collection(MIGRATION_LOCK_COLLECTION);
+
+  async function ensureIndexes() {
+    await migrations.createIndex({ id: 1 }, { unique: true });
+    await migrations.createIndex({ appliedAt: -1 });
+    await locks.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+    logger.debug?.('Migration indexes ensured');
+  }
+
+  async function acquireLock() {
+  const expiresAt = new Date(Date.now() + lockTtlMs);
+  const lockDocument = {
+    _id: MIGRATION_LOCK_ID,
+    owner,
+    expiresAt,
+    createdAt: now(),
+    updatedAt: now(),
+  };
+
+  try {
+    await locks.insertOne(lockDocument);
+    return lockDocument;
+  } catch (error) {
+    if (error.code !== 11000) {
+      throw error;
+    }
+  }
+
+  const result = await locks.findOneAndUpdate(
+    {
+      _id: MIGRATION_LOCK_ID,
+      expiresAt: { $lte: now() },
+    },
+    {
+      $set: {
+        owner,
+        expiresAt,
+        updatedAt: now(),
+      },
+    },
+    {
+      returnDocument: 'after',
+    }
+  );
+
+  const lock = result?.value ?? result;
+
+  if (!lock || lock.owner !== owner) {
+    const existingLock = await locks.findOne({ _id: MIGRATION_LOCK_ID });
+
+    throw new MigrationError('Another migration run is already in progress', {
+      lockOwner: existingLock?.owner,
+      expiresAt: existingLock?.expiresAt,
+    });
+  }
+
+  return lock;
+}
+
+  async function releaseLock() {
+    await locks.deleteOne({ _id: MIGRATION_LOCK_ID, owner });
+  }
+
+  async function loadMigrationFiles() {
+    let entries;
+
+    try {
+      entries = await fs.readdir(migrationsDir, { withFileTypes: true });
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        return [];
+      }
+
+      throw new MigrationError('Unable to read migrations directory', {
+        migrationsDir,
+        cause: error.message,
+      });
+    }
+
+    const files = entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => /^\d{3,}-.+\.js$/.test(name))
+      .sort();
+
+    return Promise.all(
+      files.map(async (fileName) => {
+        const filePath = path.join(migrationsDir, fileName);
+        const imported = await import(pathToFileURL(filePath).href);
+        const migration = imported.default || imported;
+
+        validateMigration(migration, fileName);
+
+        return {
+          id: migration.id || fileName.replace(/\.js$/, ''),
+          description: migration.description || '',
+          fileName,
+          up: migration.up,
+          down: migration.down,
+        };
+      })
+    );
+  }
+
+  function validateMigration(migration, fileName) {
+    if (!migration || typeof migration !== 'object') {
+      throw new MigrationError(`Migration ${fileName} must export an object`);
+    }
+
+    if (typeof migration.up !== 'function') {
+      throw new MigrationError(`Migration ${fileName} must export an up(db) function`);
+    }
+
+    if (migration.down && typeof migration.down !== 'function') {
+      throw new MigrationError(`Migration ${fileName} down export must be a function`);
+    }
+  }
+
+  async function getAppliedMigrationIds() {
+    const applied = await migrations
+      .find({}, { projection: { id: 1 } })
+      .sort({ id: 1 })
+      .toArray();
+
+    return new Set(applied.map((migration) => migration.id));
+  }
+
+  async function status() {
+    await ensureIndexes();
+
+    const files = await loadMigrationFiles();
+    const appliedIds = await getAppliedMigrationIds();
+
+    return files.map((migration) => ({
+      id: migration.id,
+      description: migration.description,
+      applied: appliedIds.has(migration.id),
+    }));
+  }
+
+  async function up({ dryRun = false } = {}) {
+    await ensureIndexes();
+    await acquireLock();
+
+    const applied = [];
+    const skipped = [];
+
+    try {
+      const files = await loadMigrationFiles();
+      const appliedIds = await getAppliedMigrationIds();
+
+      for (const migration of files) {
+        if (appliedIds.has(migration.id)) {
+          skipped.push(migration.id);
+          continue;
+        }
+
+        if (dryRun) {
+          applied.push(migration.id);
+          continue;
+        }
+
+        const startedAt = now();
+
+        try {
+          await migration.up(db);
+
+          await migrations.insertOne({
+            id: migration.id,
+            description: migration.description,
+            fileName: migration.fileName,
+            appliedAt: now(),
+            durationMs: now() - startedAt,
+          });
+
+          applied.push(migration.id);
+        } catch (error) {
+          throw new MigrationError(`Migration ${migration.id} failed`, {
+            migrationId: migration.id,
+            cause: error.message,
+          });
+        }
+      }
+
+      return { applied, skipped, dryRun };
+    } finally {
+      await releaseLock();
+    }
+  }
+
+  async function down({ steps = 1, dryRun = false } = {}) {
+    await ensureIndexes();
+    await acquireLock();
+
+    const reverted = [];
+
+    try {
+      const files = await loadMigrationFiles();
+      const byId = new Map(files.map((migration) => [migration.id, migration]));
+
+      const applied = await migrations
+        .find({})
+        .sort({ appliedAt: -1 })
+        .limit(steps)
+        .toArray();
+
+      for (const record of applied) {
+        const migration = byId.get(record.id);
+
+        if (!migration?.down) {
+          throw new MigrationError(`Migration ${record.id} cannot be rolled back`);
+        }
+
+        if (dryRun) {
+          reverted.push(record.id);
+          continue;
+        }
+
+        await migration.down(db);
+        await migrations.deleteOne({ id: record.id });
+        reverted.push(record.id);
+      }
+
+      return { reverted, dryRun };
+    } finally {
+      await releaseLock();
+    }
+  }
+
+  return {
+    up,
+    down,
+    status,
+    loadMigrationFiles,
+    ensureIndexes,
+  };
+}
+
+function parseArgs(argv) {
+  const command = argv[2] || 'status';
+
+  return {
+    command,
+    dryRun: argv.includes('--dry-run'),
+    steps: Number(
+      argv.find((arg) => arg.startsWith('--steps='))?.split('=')[1] || 1
+    ),
+  };
+}
+
+async function runCli() {
+  const { command, dryRun, steps } = parseArgs(process.argv);
+
+  await connectDB();
+
+  const runner = createMigrationRunner({
+    db: mongoose.connection.db,
+  });
+
+  if (command === 'up') {
+    const result = await runner.up({ dryRun });
+    console.log(JSON.stringify(result, null, 2));
+  } else if (command === 'down') {
+    const result = await runner.down({ steps, dryRun });
+    console.log(JSON.stringify(result, null, 2));
+  } else if (command === 'status') {
+    const result = await runner.status();
+    console.table(result);
+  } else {
+    throw new MigrationError(`Unknown migration command: ${command}`);
+  }
+
+  await mongoose.disconnect();
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runCli().catch(async (error) => {
+    console.error(error);
+    await mongoose.disconnect().catch(() => {});
+    process.exit(1);
+  });
+}

--- a/backend/src/migrations/migrationRunner.js
+++ b/backend/src/migrations/migrationRunner.js
@@ -98,6 +98,53 @@ export function createMigrationRunner({
     await locks.deleteOne({ _id: MIGRATION_LOCK_ID, owner });
   }
 
+  async function extendLock() {
+  const result = await locks.updateOne(
+    {
+      _id: MIGRATION_LOCK_ID,
+      owner,
+    },
+    {
+      $set: {
+        expiresAt: new Date(Date.now() + lockTtlMs),
+        updatedAt: now(),
+      },
+    }
+  );
+
+  if (result.matchedCount !== 1) {
+    throw new MigrationError('Migration lock ownership was lost');
+  }
+}
+
+function startLockHeartbeat() {
+  let heartbeatError = null;
+
+  const interval = setInterval(async () => {
+    try {
+      await extendLock();
+    } catch (error) {
+      heartbeatError = error;
+      logger.error?.('Migration lock heartbeat failed', {
+        error: error.message,
+      });
+    }
+  }, Math.max(1000, Math.floor(lockTtlMs / 3)));
+
+  interval.unref?.();
+
+  return {
+    assertHealthy() {
+      if (heartbeatError) {
+        throw heartbeatError;
+      }
+    },
+    stop() {
+      clearInterval(interval);
+    },
+  };
+}
+
   async function loadMigrationFiles() {
     let entries;
 
@@ -120,23 +167,35 @@ export function createMigrationRunner({
       .filter((name) => /^\d{3,}-.+\.js$/.test(name))
       .sort();
 
-    return Promise.all(
-      files.map(async (fileName) => {
-        const filePath = path.join(migrationsDir, fileName);
-        const imported = await import(pathToFileURL(filePath).href);
-        const migration = imported.default || imported;
+    const loadedMigrations = await Promise.all(
+  files.map(async (fileName) => {
+    const filePath = path.join(migrationsDir, fileName);
+    const imported = await import(pathToFileURL(filePath).href);
+    const migration = imported.default || imported;
 
-        validateMigration(migration, fileName);
+    validateMigration(migration, fileName);
 
-        return {
-          id: migration.id || fileName.replace(/\.js$/, ''),
-          description: migration.description || '',
-          fileName,
-          up: migration.up,
-          down: migration.down,
-        };
-      })
-    );
+    return {
+      id: migration.id || fileName.replace(/\.js$/, ''),
+      description: migration.description || '',
+      fileName,
+      up: migration.up,
+      down: migration.down,
+    };
+  })
+);
+
+const seenIds = new Set();
+
+for (const migration of loadedMigrations) {
+  if (seenIds.has(migration.id)) {
+    throw new MigrationError(`Duplicate migration id detected: ${migration.id}`);
+  }
+
+  seenIds.add(migration.id);
+}
+
+return loadedMigrations;
   }
 
   function validateMigration(migration, fileName) {
@@ -178,6 +237,7 @@ export function createMigrationRunner({
   async function up({ dryRun = false } = {}) {
     await ensureIndexes();
     await acquireLock();
+    const heartbeat = startLockHeartbeat();
 
     const applied = [];
     const skipped = [];
@@ -200,7 +260,9 @@ export function createMigrationRunner({
         const startedAt = now();
 
         try {
-          await migration.up(db);
+            heartbeat.assertHealthy();
+            await migration.up(db);
+            heartbeat.assertHealthy();
 
           await migrations.insertOne({
             id: migration.id,
@@ -211,6 +273,7 @@ export function createMigrationRunner({
           });
 
           applied.push(migration.id);
+          appliedIds.add(migration.id);
         } catch (error) {
           throw new MigrationError(`Migration ${migration.id} failed`, {
             migrationId: migration.id,
@@ -221,13 +284,15 @@ export function createMigrationRunner({
 
       return { applied, skipped, dryRun };
     } finally {
-      await releaseLock();
+        heartbeat.stop();
+        await releaseLock();
     }
   }
 
   async function down({ steps = 1, dryRun = false } = {}) {
     await ensureIndexes();
     await acquireLock();
+    const heartbeat = startLockHeartbeat();
 
     const reverted = [];
 
@@ -253,14 +318,17 @@ export function createMigrationRunner({
           continue;
         }
 
+        heartbeat.assertHealthy();
         await migration.down(db);
+        heartbeat.assertHealthy();
         await migrations.deleteOne({ id: record.id });
         reverted.push(record.id);
       }
 
       return { reverted, dryRun };
     } finally {
-      await releaseLock();
+        heartbeat.stop();
+        await releaseLock();
     }
   }
 
@@ -273,15 +341,24 @@ export function createMigrationRunner({
   };
 }
 
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new MigrationError(`${optionName} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
 function parseArgs(argv) {
   const command = argv[2] || 'status';
+  const stepsArg = argv.find((arg) => arg.startsWith('--steps='))?.split('=')[1] || '1';
 
   return {
     command,
     dryRun: argv.includes('--dry-run'),
-    steps: Number(
-      argv.find((arg) => arg.startsWith('--steps='))?.split('=')[1] || 1
-    ),
+    steps: parsePositiveInteger(stepsArg, '--steps'),
   };
 }
 


### PR DESCRIPTION
## **User description**
## Description

This PR adds a focused backend database migration framework for Career Pilot.

### Brief description of changes

* Added `backend/src/migrations/migrationRunner.js`.
* Added migration discovery from `backend/src/migrations/steps`.
* Added `up`, `down`, and `status` migration commands.
* Added applied migration tracking using the `schema_migrations` MongoDB collection.
* Added MongoDB-backed migration locking using the `schema_migration_locks` collection to prevent concurrent migration runs during deployment.
* Added idempotent migration execution by skipping already-applied migrations.
* Added rollback support through optional `down(db)` migration handlers.
* Added `--dry-run` support for deployment verification.
* Added migration npm scripts:

  * `npm run migrate`
  * `npm run migrate:status`
  * `npm run migrate:down`
* Added unit tests for migration ordering, idempotency, rollback, failure handling, dry-run behavior, status reporting, and lock handling.
* Added migration documentation in `backend/src/migrations/README.md`.

### Scope

This PR is intentionally scoped only to Issue #2793.

No actual production migration files were added. The `steps/` directory currently only contains `.gitkeep`, so this PR adds the migration framework without making unrelated schema or data changes.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Performance improvement
- [x] Other (DevOps / deployment infrastructure)

## Related Issue
Fixes #2793

## Testing
- [x] Unit tests pass
- [x] Tested Locally
- [x] New tests added

### Commands run
* `npx eslint src/migrations/migrationRunner.js src/migrations/__tests__/migrationRunner.test.js`

  * Passed with no errors.

* `node --test src/migrations/__tests__/migrationRunner.test.js`

  * 6 migration runner tests passed, 0 failed.

* `npm test`

  * 173 tests passed, 0 failed.

* `npm run migrate:status`

  * CLI executed up to database connection.
  * Failed locally with `ECONNREFUSED localhost:27017` because no local MongoDB instance was running.
  * This is expected without a configured local MongoDB connection. Migration runner behavior is covered using `mongodb-memory-server` tests.


## Screenshots (MANDATORY for UI/UX changes)
N/A for UI/UX changes because this PR does not modify any visual interface.

<img width="464" height="430" alt="Screenshot 2026-06-23 013212" src="https://github.com/user-attachments/assets/a0541e20-1387-4613-9ffc-7cc6246a06eb" />
<br></br>
<img width="672" height="446" alt="Screenshot 2026-06-23 013245" src="https://github.com/user-attachments/assets/585f83bb-8745-44ca-bfb5-cd2ed9972e3b" />

Attached terminal screenshots show:
* focused migration lint command,
* full backend test run,
* `173` tests passed,
* `0` failed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [x] Updated documentation
- [x] No new warnings generated


___

## **CodeAnt-AI Description**
**Add a MongoDB-backed database migration runner for the backend**

### What Changed
- Backend migrations can now be run, checked, and rolled back from the command line
- Migration files are discovered in order, skipped if already applied, and recorded after success
- A lock prevents two migration runs from starting at the same time
- `--dry-run` shows which migrations would run without changing the database
- Added tests for ordering, repeat runs, rollback, failure handling, dry runs, and lock conflicts
- Added migration instructions and file format guidance for deployment and rollback

### Impact
`✅ Safer production deployments`
`✅ Fewer duplicate migration runs`
`✅ Clearer migration rollout and rollback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MongoDB-backed migration runner with commands for applying migrations, viewing status, and step-limited rollback, including dry-run support.
  * Introduced migration npm scripts (`migrate`, `migrate:status`, `migrate:down`) to streamline common operations.
* **Documentation**
  * Added a migrations guide covering file naming/order, module interface (`up`/optional `down`), and deployment/rollback guidance.
* **Tests**
  * Expanded automated test coverage and added end-to-end tests for migration application, rollback, dry-run behavior, failure handling, and concurrency locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->