### PR TITLE
fix(security): resolve dev-only auth bypass vulnerability (#4243)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,14 @@ Career Pilot employs a defense-in-depth strategy to prevent Cross-Site Request F
 3. **Socket.IO Origin Enforcement**: WebSocket connections are protected by an `allowRequest` hook that strictly validates the `Origin` header during the connection handshake. This ensures that an attacker cannot open a WebSocket connection on behalf of a victim from a malicious domain.
 4. **Basic Auth Origin Checks**: Administrative routes using HTTP Basic Auth (such as BullMQ Dashboard) enforce a strict `Origin`/`Referer` check for all state-changing methods (`POST`, `PUT`, `DELETE`). This prevents an attacker from abusing cached Basic Auth credentials via cross-site requests.
 
+## Development Auth Bypass Policy
+
+The application supports a development-only authentication bypass for local testing. This bypass is designed with the following strict constraints to prevent accidental exposure in production:
+
+1. **CLI Argument Only**: The bypass can ONLY be enabled via the explicit `--dev-bypass-auth` command-line argument. Legacy environment variables (e.g., `DEV_BYPASS_AUTH=true`) are no longer supported for enabling this bypass.
+2. **Strictly Development Mode**: The bypass is strictly disabled when `NODE_ENV=production`, regardless of the CLI argument.
+3. **Fail-Closed Startup**: The application will intentionally crash (fail-closed) on startup if it detects the `--dev-bypass-auth` CLI argument OR the legacy `DEV_BYPASS_AUTH=true` environment variable while running in a `production` environment. This prevents accidental legacy misconfigurations from silently exposing the server.
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in **Career Pilot**, please **do not open a public issue**.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -301,12 +301,12 @@ BULL_BOARD_ENABLED=true
 BULL_BOARD_USERNAME=admin
 BULL_BOARD_PASSWORD=change-this-password
 # -----------------------------------------------------------------------------
-# LOCAL DEVELOPMENT ONLY - never set these to true in production
+# LOCAL DEVELOPMENT ONLY - never use in production
 # -----------------------------------------------------------------------------
 
-# Bypass Firebase auth verification for local testing
-# Type: boolean
-DEV_BYPASS_AUTH=false
+# To bypass Firebase auth verification for local testing,
+# pass the --dev-bypass-auth argument to the startup script (e.g., npm run dev -- --dev-bypass-auth)
+# Note: The DEV_BYPASS_AUTH env variable is no longer supported for security reasons.
 
 # UID to use when auth bypass is enabled
 # Type: string

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,15 @@ import portfolioGithubRoutes from './routes/portfolioGithub.js';
 import dotenv from "dotenv";
 dotenv.config();
 
+import { checkDevAuthBypassGuard } from './utils/securityGuard.js';
+
+try {
+  checkDevAuthBypassGuard();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
 import redisManager from './config/redis.js';
 
 import { createServer } from 'http';

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -5,7 +5,8 @@ import { ApiError } from './errorHandler.js';
 export const verifyToken = async (req, res, next) => {
   try {
     // Development bypass
-    if (process.env.NODE_ENV === 'development' && process.env.DEV_BYPASS_AUTH === 'true') {
+    if (process.env.NODE_ENV === 'development' && process.argv.includes('--dev-bypass-auth')) {
+      console.warn('⚠️ WARNING: Development auth bypass is active. This must never be used in production.');
       const adminEmails = (process.env.ADMIN_EMAILS || '')
         .split(',')
         .map((e) => e.trim().toLowerCase())
@@ -87,7 +88,8 @@ export const adminOnly = (req, res, next) => {
 export const optionalAuth = async (req, res, next) => {
   try {
     // Development bypass
-    if (process.env.NODE_ENV === 'development' && process.env.DEV_BYPASS_AUTH === 'true') {
+    if (process.env.NODE_ENV === 'development' && process.argv.includes('--dev-bypass-auth')) {
+      console.warn('⚠️ WARNING: Development auth bypass is active. This must never be used in production.');
       const adminEmails = (process.env.ADMIN_EMAILS || '')
         .split(',')
         .map((e) => e.trim().toLowerCase())

--- a/backend/src/middleware/socketAuth.js
+++ b/backend/src/middleware/socketAuth.js
@@ -39,8 +39,8 @@ export const socketAuthMiddleware = async (socket, next) => {
       next();
     } catch (firebaseError) {
       // Development mode bypass - extract user info from token without verification
-      if (process.env.ALLOW_DEV_SOCKET_AUTH === 'true' || (process.env.NODE_ENV === 'development' && process.env.DEV_BYPASS_AUTH === 'true')) {
-        console.warn('Firebase Admin verification failed, using token payload with ALLOW_DEV_SOCKET_AUTH');
+      if (process.env.NODE_ENV === 'development' && process.argv.includes('--dev-bypass-auth')) {
+        console.warn('⚠️ WARNING: Development socket auth bypass is active. This must never be used in production.');
         const tokenPayload = decodeTokenPayload(token);
         
         if (tokenPayload && tokenPayload.user_id) {

--- a/backend/src/utils/__tests__/securityGuard.test.js
+++ b/backend/src/utils/__tests__/securityGuard.test.js
@@ -1,0 +1,77 @@
+import { test, describe, beforeEach, afterEach, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkDevAuthBypassGuard } from '../securityGuard.js';
+
+describe('Security Guard: checkDevAuthBypassGuard', () => {
+  let originalEnv;
+  let originalArgv;
+
+  beforeEach(() => {
+    // Save original process environment and args
+    originalEnv = { ...process.env };
+    originalArgv = [...process.argv];
+  });
+
+  afterEach(() => {
+    // Restore original process environment and args
+    process.env = originalEnv;
+    process.argv = originalArgv;
+  });
+
+  it('should throw an error in production if legacy DEV_BYPASS_AUTH env var is true', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DEV_BYPASS_AUTH = 'true';
+
+    assert.throws(() => {
+      checkDevAuthBypassGuard();
+    }, /FATAL: Dev auth bypass is enabled in production environment!/);
+  });
+
+  it('should throw an error in production if --dev-bypass-auth CLI flag is present', () => {
+    process.env.NODE_ENV = 'production';
+    process.argv.push('--dev-bypass-auth');
+
+    assert.throws(() => {
+      checkDevAuthBypassGuard();
+    }, /FATAL: Dev auth bypass is enabled in production environment!/);
+  });
+
+  it('should throw an error in production if both legacy env var and CLI flag are present', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DEV_BYPASS_AUTH = 'true';
+    process.argv.push('--dev-bypass-auth');
+
+    assert.throws(() => {
+      checkDevAuthBypassGuard();
+    }, /FATAL: Dev auth bypass is enabled in production environment!/);
+  });
+
+  it('should NOT throw an error in production if no bypass flags are present', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.DEV_BYPASS_AUTH;
+    // ensure argv doesn't contain the flag
+    process.argv = process.argv.filter(arg => arg !== '--dev-bypass-auth');
+
+    assert.doesNotThrow(() => {
+      checkDevAuthBypassGuard();
+    });
+  });
+
+  it('should NOT throw an error in development even if bypass CLI flag is present', () => {
+    process.env.NODE_ENV = 'development';
+    process.argv.push('--dev-bypass-auth');
+
+    assert.doesNotThrow(() => {
+      checkDevAuthBypassGuard();
+    });
+  });
+
+  it('should NOT throw an error in development even if legacy bypass env flag is present', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.DEV_BYPASS_AUTH = 'true';
+
+    assert.doesNotThrow(() => {
+      checkDevAuthBypassGuard();
+    });
+  });
+});

--- a/backend/src/utils/securityGuard.js
+++ b/backend/src/utils/securityGuard.js
@@ -1,0 +1,13 @@
+/**
+ * Security guard to prevent accidental deployment of development authentication bypass.
+ * Throws a fatal error if development auth bypass is enabled in a production environment.
+ */
+export const checkDevAuthBypassGuard = () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const hasLegacyEnvFlag = process.env.DEV_BYPASS_AUTH === 'true';
+  const hasCliFlag = process.argv.includes('--dev-bypass-auth');
+
+  if (isProduction && (hasLegacyEnvFlag || hasCliFlag)) {
+    throw new Error('FATAL: Dev auth bypass is enabled in production environment! Refusing to start.');
+  }
+};


### PR DESCRIPTION
## **User description**
## Description
<!-- Describe your changes in detail -->
This PR addresses the critical security vulnerability identified in #4243. It removes the fail-open development authentication bypass and strictly locks down the bypass behind defense-in-depth measures to prevent accidental exposure in production environments.

Closes #4243 

## Changes Made
<!-- List out the changes made in this PR -->
- **CLI Argument Migration:** Removed support for the `DEV_BYPASS_AUTH` environment variable. The development bypass must now be explicitly invoked via the `--dev-bypass-auth` command-line argument.
- **Fail-Closed Startup Guard:** Implemented `checkDevAuthBypassGuard()` in `src/utils/securityGuard.js` and injected it at the top of the `index.js` lifecycle. The server now immediately crashes on startup if the bypass is enabled while `NODE_ENV=production`.
- **Socket Auth Hardening:** Updated `socketAuth.js` to mirror the CLI argument strictness, preventing WebSocket connections from being bypassed using the legacy mechanism.
- **Documentation & Policy:** Updated `.env.example` to flag the legacy variable as deprecated and fully documented the new strict bypass policy in `SECURITY.md`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security patch (critical fix for a security vulnerability)
- [x] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] **Production Startup Test (Env Var):** Verified that starting the server with `NODE_ENV=production` and `DEV_BYPASS_AUTH=true` instantly throws a fatal error.
- [x] **Production Startup Test (CLI Arg):** Verified that starting the server with `NODE_ENV=production` and `--dev-bypass-auth` instantly throws a fatal error.
- [x] **Unit Testing:** Implemented and passed all suites in `securityGuard.test.js` validating the fatal throw behavior across environment combinations.
- [x] **Local Development Validation:** Confirmed that the fallback development auth flow functions correctly locally only when `NODE_ENV=development` and the exact CLI flag is passed.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`SECURITY.md`, `.env.example`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


___

## **CodeAnt-AI Description**
**Block production startup when dev auth bypass is enabled**

### What Changed
- The app now stops starting if a development auth bypass is enabled in production, preventing accidental exposure.
- Development auth bypass now works only from the `--dev-bypass-auth` startup argument, not from the old environment variable.
- Both normal requests and socket connections show a clear warning when the bypass is active in development.
- Security docs and example environment settings now explain the new bypass rule and remove the old enablement path.

### Impact
`✅ Fewer production auth bypass incidents`
`✅ Safer local testing setup`
`✅ Clearer auth bypass warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened development-only authentication bypass handling to prevent accidental use in production.
  * The bypass now requires a startup flag in development and will stop the server if it’s detected in production.
  * Updated setup guidance to reflect the new enablement method and removed the older environment-based option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->