### PR TITLE
fix(job-alerts): replace direct mailto with secure in-app outreach

### DIFF
--- a/frontend/src/__tests__/email.test.js
+++ b/frontend/src/__tests__/email.test.js
@@ -4,6 +4,7 @@ import {
   sanitizeRecruiterEmail,
   isValidRecruiterEmail,
   buildSafeMailtoUrl,
+  isSafeHttpUrl,
 } from '../utils/emailCheck'
 
 describe('sanitizeRecruiterEmail', () => {
@@ -12,13 +13,20 @@ describe('sanitizeRecruiterEmail', () => {
   })
 
   test('strips injected query parameters', () => {
-    expect(sanitizeRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')).toBe('recruiter@co.com')
-    expect(sanitizeRecruiterEmail('recruiter@co.com&body=phish')).toBe('recruiter@co.com')
+    expect(
+      sanitizeRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')
+    ).toBe('recruiter@co.com')
+
+    expect(
+      sanitizeRecruiterEmail('recruiter@co.com#fragment')
+    ).toBe('recruiter@co.com')
   })
 
-  test('caps length at MAX_EMAIL_LENGTH', () => {
+  test('does not modify long email addresses', () => {
     const longLocal = 'a'.repeat(MAX_EMAIL_LENGTH)
-    expect(sanitizeRecruiterEmail(`${longLocal}@example.com`).length).toBe(MAX_EMAIL_LENGTH)
+    const email = `${longLocal}@example.com`
+
+    expect(sanitizeRecruiterEmail(email)).toBe(email)
   })
 })
 
@@ -33,25 +41,68 @@ describe('isValidRecruiterEmail', () => {
     expect(isValidRecruiterEmail(null)).toBe(false)
   })
 
+  test('rejects email longer than MAX_EMAIL_LENGTH', () => {
+    const longEmail = `${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com`
+
+    expect(isValidRecruiterEmail(longEmail)).toBe(false)
+  })
+
   test('accepts address after stripping injected query parameters', () => {
-    expect(isValidRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')).toBe(true)
-    expect(sanitizeRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')).toBe('recruiter@co.com')
+    expect(
+      isValidRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')
+    ).toBe(true)
+
+    expect(
+      sanitizeRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')
+    ).toBe('recruiter@co.com')
   })
 })
 
 describe('buildSafeMailtoUrl', () => {
   test('builds a mailto link with encoded subject', () => {
-    expect(buildSafeMailtoUrl('jobs@startup.com', { subject: 'Application for Engineer' }))
-      .toBe('mailto:jobs@startup.com?subject=Application+for+Engineer')
+    expect(
+      buildSafeMailtoUrl('jobs@startup.com', {
+        subject: 'Application for Engineer',
+      })
+    ).toBe('mailto:jobs@startup.com?subject=Application+for+Engineer')
   })
 
   test('returns null for invalid email', () => {
-    expect(buildSafeMailtoUrl('bad-address', { subject: 'Hi' })).toBeNull()
+    expect(
+      buildSafeMailtoUrl('bad-address', {
+        subject: 'Hi',
+      })
+    ).toBeNull()
   })
 
   test('ignores injected cc parameters from raw input', () => {
-    const url = buildSafeMailtoUrl('recruiter@co.com?cc=attacker@evil.com', { subject: 'Hello' })
+    const url = buildSafeMailtoUrl(
+      'recruiter@co.com?cc=attacker@evil.com',
+      {
+        subject: 'Hello',
+      }
+    )
+
     expect(url).toBe('mailto:recruiter@co.com?subject=Hello')
     expect(url).not.toContain('attacker@evil.com')
+  })
+})
+
+describe('isSafeHttpUrl', () => {
+  test('accepts http and https URLs', () => {
+    expect(isSafeHttpUrl('https://example.com')).toBe(true)
+    expect(isSafeHttpUrl('http://example.com')).toBe(true)
+  })
+
+  test('rejects unsafe schemes', () => {
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeHttpUrl('data:text/html,test')).toBe(false)
+    expect(isSafeHttpUrl('ftp://example.com')).toBe(false)
+  })
+
+  test('rejects invalid URLs', () => {
+    expect(isSafeHttpUrl('not-a-url')).toBe(false)
+    expect(isSafeHttpUrl('')).toBe(false)
+    expect(isSafeHttpUrl(null)).toBe(false)
   })
 })

--- a/frontend/src/__tests__/email.test.js
+++ b/frontend/src/__tests__/email.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+import {
+  MAX_EMAIL_LENGTH,
+  sanitizeRecruiterEmail,
+  isValidRecruiterEmail,
+  buildSafeMailtoUrl,
+} from '../utils/emailCheck'
+
+describe('sanitizeRecruiterEmail', () => {
+  test('returns a trimmed email', () => {
+    expect(sanitizeRecruiterEmail('  jobs@startup.com  ')).toBe('jobs@startup.com')
+  })
+
+  test('strips injected query parameters', () => {
+    expect(sanitizeRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')).toBe('recruiter@co.com')
+    expect(sanitizeRecruiterEmail('recruiter@co.com&body=phish')).toBe('recruiter@co.com')
+  })
+
+  test('caps length at MAX_EMAIL_LENGTH', () => {
+    const longLocal = 'a'.repeat(MAX_EMAIL_LENGTH)
+    expect(sanitizeRecruiterEmail(`${longLocal}@example.com`).length).toBe(MAX_EMAIL_LENGTH)
+  })
+})
+
+describe('isValidRecruiterEmail', () => {
+  test('accepts valid addresses', () => {
+    expect(isValidRecruiterEmail('jobs@startup.com')).toBe(true)
+  })
+
+  test('rejects invalid addresses', () => {
+    expect(isValidRecruiterEmail('not-an-email')).toBe(false)
+    expect(isValidRecruiterEmail('')).toBe(false)
+    expect(isValidRecruiterEmail(null)).toBe(false)
+  })
+
+  test('accepts address after stripping injected query parameters', () => {
+    expect(isValidRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')).toBe(true)
+    expect(sanitizeRecruiterEmail('recruiter@co.com?cc=attacker@evil.com')).toBe('recruiter@co.com')
+  })
+})
+
+describe('buildSafeMailtoUrl', () => {
+  test('builds a mailto link with encoded subject', () => {
+    expect(buildSafeMailtoUrl('jobs@startup.com', { subject: 'Application for Engineer' }))
+      .toBe('mailto:jobs@startup.com?subject=Application+for+Engineer')
+  })
+
+  test('returns null for invalid email', () => {
+    expect(buildSafeMailtoUrl('bad-address', { subject: 'Hi' })).toBeNull()
+  })
+
+  test('ignores injected cc parameters from raw input', () => {
+    const url = buildSafeMailtoUrl('recruiter@co.com?cc=attacker@evil.com', { subject: 'Hello' })
+    expect(url).toBe('mailto:recruiter@co.com?subject=Hello')
+    expect(url).not.toContain('attacker@evil.com')
+  })
+})

--- a/frontend/src/__tests__/email.test.js
+++ b/frontend/src/__tests__/email.test.js
@@ -22,6 +22,12 @@ describe('sanitizeRecruiterEmail', () => {
     ).toBe('recruiter@co.com')
   })
 
+  test('preserves question marks in the local part', () => {
+    expect(
+      sanitizeRecruiterEmail('dev?jobs@company.com')
+    ).toBe('dev?jobs@company.com')
+  })
+
   test('does not modify long email addresses', () => {
     const longLocal = 'a'.repeat(MAX_EMAIL_LENGTH)
     const email = `${longLocal}@example.com`

--- a/frontend/src/pages/JobAlerts.jsx
+++ b/frontend/src/pages/JobAlerts.jsx
@@ -9,14 +9,21 @@ import {
   Mail,
   ExternalLink,
   Loader2,
-  AlertCircle,
   Sparkles,
-  Zap
+  Zap,
+  Send
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { jobAlertsApi, jobsApi } from '../services/api';
 import { JobAlertModal, JobAlertsList } from '../components';
-import { SkeletonStatCards, SkeletonJobList } from '../components/ui/Skeleton'
+import OutreachPanel from '../components/OutreachPanel';
+import Modal from '../components/Modal';
+import { SkeletonStatCards, SkeletonJobList } from '../components/ui/Skeleton';
+import {
+  buildSafeMailtoUrl,
+  isValidRecruiterEmail,
+  sanitizeRecruiterEmail,
+} from '../utils/emailCheck';
 
 export default function JobAlerts() {
   const [activeTab, setActiveTab] = useState('alerts'); // 'alerts' | 'search'
@@ -26,6 +33,8 @@ export default function JobAlerts() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [searchLoading, setSearchLoading] = useState(false);
+  const [outreachJob, setOutreachJob] = useState(null);
+  const [mailtoConfirm, setMailtoConfirm] = useState(null);
 
   const hoverBorderClassMap = {
     indigo: 'hover:border-primary/30',
@@ -70,6 +79,33 @@ export default function JobAlerts() {
 
   const handleCreateAlertFromSearch = () => {
     setIsModalOpen(true);
+  };
+
+  const handleApplyOutreach = (job) => {
+    setOutreachJob(job);
+  };
+
+  const handleRequestMailto = (job) => {
+    const email = sanitizeRecruiterEmail(job.recruiterEmail);
+    if (!isValidRecruiterEmail(email)) {
+      toast.error('Invalid recruiter email address');
+      return;
+    }
+    setMailtoConfirm({ email, title: job.title });
+  };
+
+  const handleConfirmMailto = () => {
+    if (!mailtoConfirm) return;
+    const url = buildSafeMailtoUrl(mailtoConfirm.email, {
+      subject: `Application for ${mailtoConfirm.title}`,
+    });
+    if (!url) {
+      toast.error('Invalid recruiter email address');
+      setMailtoConfirm(null);
+      return;
+    }
+    window.location.href = url;
+    setMailtoConfirm(null);
   };
 
   return (
@@ -238,7 +274,13 @@ export default function JobAlerts() {
                     animate="animate"
                   >
                     {searchResults.map((job, index) => (
-                      <JobCard key={job.id || index} job={job} index={index} />
+                      <JobCard
+                        key={job.id || index}
+                        job={job}
+                        index={index}
+                        onApplyOutreach={handleApplyOutreach}
+                        onRequestMailto={handleRequestMailto}
+                      />
                     ))}
                   </motion.div>
                 </div>
@@ -268,21 +310,56 @@ export default function JobAlerts() {
         onClose={() => setIsModalOpen(false)}
         onSuccess={fetchStats}
       />
+
+      {outreachJob && (
+        <OutreachPanel
+          companyName={outreachJob.company}
+          companyUrl={
+            outreachJob.applyLink?.startsWith('http') ? outreachJob.applyLink : ''
+          }
+          onClose={() => setOutreachJob(null)}
+        />
+      )}
+
+      <Modal
+        isOpen={!!mailtoConfirm}
+        onClose={() => setMailtoConfirm(null)}
+        title="Open your mail client to apply?"
+        size="sm"
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          You&apos;ll leave CareerPilot and open your email app to send an application
+          {mailtoConfirm?.email ? ` to ${mailtoConfirm.email}` : ''}.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => setMailtoConfirm(null)}
+            className="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirmMailto}
+            className="px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary/90 rounded-lg transition-colors"
+          >
+            Open mail client
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }
 
 // Job Card Component
-function JobCard({ job, index }) {
-  const handleApply = () => {
-    if (job.applyLink) {
-      window.open(job.applyLink, '_blank');
-    }
-  };
+function JobCard({ job, index, onApplyOutreach, onRequestMailto }) {
+  const recruiterEmail = sanitizeRecruiterEmail(job.recruiterEmail);
+  const hasValidRecruiterEmail = isValidRecruiterEmail(recruiterEmail);
 
-  const handleEmail = () => {
-    if (job.recruiterEmail) {
-      window.location.href = `mailto:${job.recruiterEmail}?subject=Application for ${job.title}`;
+  const handleApplyOnSite = () => {
+    if (job.applyLink) {
+      window.open(job.applyLink, '_blank', 'noopener,noreferrer');
     }
   };
 
@@ -310,18 +387,27 @@ function JobCard({ job, index }) {
 
             {/* Action Buttons */}
             <div className="flex gap-2 shrink-0">
-              {job.applyLink && (
+              {job.recruiterEmail && (
                 <button
-                  onClick={handleApply}
+                  onClick={() => onApplyOutreach(job)}
                   className="flex items-center gap-1.5 px-4 py-2 bg-card text-foreground rounded-lg border border-border font-medium hover:bg-muted/20 transition-colors text-sm cursor-pointer"
                 >
-                  <ExternalLink className="w-4 h-4" />
+                  <Send className="w-4 h-4" />
                   Apply
                 </button>
               )}
-              {job.recruiterEmail && (
+              {job.applyLink && (
                 <button
-                  onClick={handleEmail}
+                  onClick={handleApplyOnSite}
+                  className="flex items-center gap-1.5 px-4 py-2 bg-card text-foreground rounded-lg border border-border font-medium hover:bg-muted/20 transition-colors text-sm cursor-pointer"
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  {job.recruiterEmail ? 'Apply on site' : 'Apply'}
+                </button>
+              )}
+              {hasValidRecruiterEmail && (
+                <button
+                  onClick={() => onRequestMailto(job)}
                   className="flex items-center gap-1.5 px-4 py-2 bg-card text-foreground rounded-lg border border-border font-medium hover:bg-muted/60 transition-colors text-sm cursor-pointer"
                 >
                   <Mail className="w-4 h-4" />

--- a/frontend/src/pages/JobAlerts.jsx
+++ b/frontend/src/pages/JobAlerts.jsx
@@ -23,6 +23,7 @@ import {
   buildSafeMailtoUrl,
   isValidRecruiterEmail,
   sanitizeRecruiterEmail,
+  isSafeHttpUrl,
 } from '../utils/emailCheck';
 
 export default function JobAlerts() {
@@ -87,23 +88,28 @@ export default function JobAlerts() {
 
   const handleRequestMailto = (job) => {
     const email = sanitizeRecruiterEmail(job.recruiterEmail);
+  
     if (!isValidRecruiterEmail(email)) {
       toast.error('Invalid recruiter email address');
       return;
     }
+  
     setMailtoConfirm({ email, title: job.title });
   };
 
   const handleConfirmMailto = () => {
     if (!mailtoConfirm) return;
+  
     const url = buildSafeMailtoUrl(mailtoConfirm.email, {
       subject: `Application for ${mailtoConfirm.title}`,
     });
+  
     if (!url) {
       toast.error('Invalid recruiter email address');
       setMailtoConfirm(null);
       return;
     }
+  
     window.location.href = url;
     setMailtoConfirm(null);
   };
@@ -315,7 +321,9 @@ export default function JobAlerts() {
         <OutreachPanel
           companyName={outreachJob.company}
           companyUrl={
-            outreachJob.applyLink?.startsWith('http') ? outreachJob.applyLink : ''
+            isSafeHttpUrl(outreachJob.applyLink)
+              ? outreachJob.applyLink
+              : ''
           }
           onClose={() => setOutreachJob(null)}
         />
@@ -358,9 +366,14 @@ function JobCard({ job, index, onApplyOutreach, onRequestMailto }) {
   const hasValidRecruiterEmail = isValidRecruiterEmail(recruiterEmail);
 
   const handleApplyOnSite = () => {
-    if (job.applyLink) {
-      window.open(job.applyLink, '_blank', 'noopener,noreferrer');
+    if (!job.applyLink) return;
+  
+    if (!isSafeHttpUrl(job.applyLink)) {
+      toast.error('Invalid application link');
+      return;
     }
+  
+    window.open(job.applyLink, '_blank', 'noopener,noreferrer');
   };
 
   return (

--- a/frontend/src/utils/emailCheck.js
+++ b/frontend/src/utils/emailCheck.js
@@ -1,0 +1,37 @@
+/** RFC 5321 maximum email address length */
+export const MAX_EMAIL_LENGTH = 254
+
+const RECRUITER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
+
+/**
+ * Strip query-string injection from API-provided recruiter emails
+ * (e.g. "recruiter@co.com?cc=attacker@evil.com").
+ */
+export function sanitizeRecruiterEmail(raw) {
+  if (!raw || typeof raw !== 'string') return ''
+  const cleaned = raw.trim().split(/[?&#]/)[0].trim()
+  if (!cleaned) return ''
+  return cleaned.length <= MAX_EMAIL_LENGTH ? cleaned : cleaned.slice(0, MAX_EMAIL_LENGTH)
+}
+
+export function isValidRecruiterEmail(email) {
+  const sanitized = sanitizeRecruiterEmail(email)
+  if (!sanitized) return false
+  return RECRUITER_EMAIL_REGEX.test(sanitized)
+}
+
+/**
+ * Build a safe mailto URL with validated recipient and encoded query params.
+ * Returns null when the email is invalid.
+ */
+export function buildSafeMailtoUrl(email, { subject = '', body = '' } = {}) {
+  const sanitized = sanitizeRecruiterEmail(email)
+  if (!isValidRecruiterEmail(sanitized)) return null
+
+  const params = new URLSearchParams()
+  if (subject) params.set('subject', subject)
+  if (body) params.set('body', body)
+
+  const query = params.toString()
+  return query ? `mailto:${sanitized}?${query}` : `mailto:${sanitized}`
+}

--- a/frontend/src/utils/emailCheck.js
+++ b/frontend/src/utils/emailCheck.js
@@ -10,10 +10,22 @@ const RECRUITER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 export function sanitizeRecruiterEmail(raw) {
   if (typeof raw !== 'string') return '';
 
-  return raw
-    .trim()
-    .split(/[?#]/)[0]
-    .trim();
+  const trimmed = raw.trim();
+  const atIndex = trimmed.lastIndexOf('@');
+
+  if (atIndex === -1) return trimmed;
+
+  const queryIndex = trimmed.indexOf('?', atIndex);
+  const fragmentIndex = trimmed.indexOf('#', atIndex);
+
+  const suffixStart = [queryIndex, fragmentIndex]
+    .filter(index => index >= 0)
+    .sort((a, b) => a - b)[0];
+
+  return (suffixStart === undefined
+    ? trimmed
+    : trimmed.slice(0, suffixStart)
+  ).trim();
 }
 
 /**

--- a/frontend/src/utils/emailCheck.js
+++ b/frontend/src/utils/emailCheck.js
@@ -1,23 +1,37 @@
 /** RFC 5321 maximum email address length */
-export const MAX_EMAIL_LENGTH = 254
+export const MAX_EMAIL_LENGTH = 254;
 
-const RECRUITER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
+const RECRUITER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 
 /**
- * Strip query-string injection from API-provided recruiter emails
- * (e.g. "recruiter@co.com?cc=attacker@evil.com").
+ * Removes query/fragment injection while preserving
+ * the original email address.
  */
 export function sanitizeRecruiterEmail(raw) {
-  if (!raw || typeof raw !== 'string') return ''
-  const cleaned = raw.trim().split(/[?&#]/)[0].trim()
-  if (!cleaned) return ''
-  return cleaned.length <= MAX_EMAIL_LENGTH ? cleaned : cleaned.slice(0, MAX_EMAIL_LENGTH)
+  if (typeof raw !== 'string') return '';
+
+  return raw
+    .trim()
+    .split(/[?#]/)[0]
+    .trim();
 }
 
+/**
+ * Validates a recruiter email after sanitization.
+ *
+ * @param {string} email
+ * @returns {boolean}
+ */
 export function isValidRecruiterEmail(email) {
-  const sanitized = sanitizeRecruiterEmail(email)
-  if (!sanitized) return false
-  return RECRUITER_EMAIL_REGEX.test(sanitized)
+  const sanitized = sanitizeRecruiterEmail(email);
+
+  if (!sanitized) return false;
+
+  if (sanitized.length > MAX_EMAIL_LENGTH) {
+    return false;
+  }
+
+  return RECRUITER_EMAIL_REGEX.test(sanitized);
 }
 
 /**
@@ -25,13 +39,32 @@ export function isValidRecruiterEmail(email) {
  * Returns null when the email is invalid.
  */
 export function buildSafeMailtoUrl(email, { subject = '', body = '' } = {}) {
-  const sanitized = sanitizeRecruiterEmail(email)
-  if (!isValidRecruiterEmail(sanitized)) return null
+  if (!isValidRecruiterEmail(email)) return null;
 
-  const params = new URLSearchParams()
-  if (subject) params.set('subject', subject)
-  if (body) params.set('body', body)
+  const sanitized = sanitizeRecruiterEmail(email);
 
-  const query = params.toString()
-  return query ? `mailto:${sanitized}?${query}` : `mailto:${sanitized}`
+  const params = new URLSearchParams();
+  if (subject) params.set('subject', subject);
+  if (body) params.set('body', body);
+
+  const query = params.toString();
+
+  return query ? `mailto:${sanitized}?${query}` : `mailto:${sanitized}`;
+}
+
+/**
+ * Returns true only for valid HTTP/HTTPS URLs.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isSafeHttpUrl(url) {
+  if (!url || typeof url !== "string") return false;
+
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## **User description**
Fixes #4254

## Description

This PR improves the Job Alerts application flow by replacing the default direct `mailto:` behavior with the existing in-app outreach flow while improving recruiter email security.

### Changes

* Replaced the default direct `mailto:` Apply flow with the existing in-app outreach experience.
* Added recruiter email sanitization and validation with a maximum length limit.
* Added a safe mailto fallback that is only available after validation.
* Added a confirmation modal before opening the user's default mail client.
* Added unit tests covering recruiter email sanitization, validation, and safe mailto URL generation.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Performance improvement
* [x] Other (Security improvement)

## Related Issue

Fixes #4254

## Testing

* [x] Added unit tests for recruiter email utilities.
* [x] Verified the project builds successfully (`npm run build`).
* [x] Manually verified the Apply button opens the in-app outreach flow.
* [x] Verified the confirmation dialog before opening the default mail client.
* [x] Verified invalid recruiter emails are rejected.


## Checklist

* [x] Code follows project style guidelines.
* [x] Self-reviewed my code.
* [x] Added tests for new functionality.
* [x] Verified production build succeeds.
* [x] No unrelated files included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a two-step outreach/email flow from search results, including a confirmation prompt before opening the mail client.
  - Updated search result actions to guide users through outreach vs email based on recruiter email availability.
  - On-site apply links now open in a new tab.
  - Introduced shared utilities for safe mailto creation and HTTP/HTTPS URL validation.
- **Bug Fixes**
  - Prevents injected query/fragment content and malformed/oversized values from being used in mailto links.
- **Tests**
  - Added automated coverage for email sanitization/validation, safe mailto generation, and safe HTTP/HTTPS URL checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Use in-app outreach for job applications and make email-based apply actions safer**

### What Changed
- Job search results now open an in-app outreach panel when a recruiter email is available, instead of sending users straight to their mail app.
- Email apply actions now clean recruiter addresses first, reject invalid or overly long emails, and ask for confirmation before opening the mail client.
- On-site apply links now open only trusted web pages, and invalid application links are blocked with an error message.
- Added tests for email cleanup, validation, safe mail links, and safe web links.

### Impact
`✅ Fewer unsafe mail app launches`
`✅ Clearer apply flow for jobs with recruiter email`
`✅ Fewer failed or unsafe application links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
