### PR TITLE
feat: implement AI-powered resume scoring

### DIFF
--- a/backend/src/routes/resume.js
+++ b/backend/src/routes/resume.js
@@ -17,7 +17,11 @@ import {
 import { scrapeLinkedInProfile, profileToResumeText } from '../services/linkedinImporter.js';
 import { fetchGitHubProfile, convertGitHubToResumeText } from '../services/githubImporter.js';
 import { getDefaultProvider } from '../config/aiProviders.js';
+<<<<<<< HEAD
 import { analyzeResume } from '../services/resumeService.js';
+=======
+import { scoreResumeText } from '../services/resumeService.js';
+>>>>>>> 733a3b67 (feat: implement AI-powered resume scoring)
 
 const router = express.Router();
 
@@ -584,21 +588,25 @@ ${text}`;
 }));
 
 router.post('/score', asyncHandler(async (req, res) => {
-  const { resumeText } = req.body;
+  const { resumeText, jobRole } = req.body;
 
   if (!resumeText || !resumeText.trim()) {
-    return res.status(400).json({
-      success: false,
-      message: 'Resume text is required'
-    });
+    throw new ApiError(400, 'Resume text is required');
   }
 
-  const analysisResult = await analyzeResume(resumeText);
-
-  res.json({
-    success: true,
-    data: analysisResult
-  });
+  try {
+    const provider = getDefaultProvider();
+    const scoreData = await scoreResumeText(resumeText, jobRole || 'Software Engineer', provider);
+    
+    res.json({
+      success: true,
+      data: scoreData
+    });
+  } catch (error) {
+    console.error('Resume scoring error:', error);
+    if (error instanceof ApiError) throw error;
+    throw new ApiError(500, 'Failed to score resume with AI.');
+  }
 }));
 
 

--- a/backend/src/routes/resume.js
+++ b/backend/src/routes/resume.js
@@ -17,11 +17,8 @@ import {
 import { scrapeLinkedInProfile, profileToResumeText } from '../services/linkedinImporter.js';
 import { fetchGitHubProfile, convertGitHubToResumeText } from '../services/githubImporter.js';
 import { getDefaultProvider } from '../config/aiProviders.js';
-<<<<<<< HEAD
-import { analyzeResume } from '../services/resumeService.js';
-=======
 import { scoreResumeText } from '../services/resumeService.js';
->>>>>>> 733a3b67 (feat: implement AI-powered resume scoring)
+import { extractAIProvider } from '../middleware/aiKey.js';
 
 const router = express.Router();
 
@@ -587,15 +584,15 @@ ${text}`;
   }
 }));
 
-router.post('/score', asyncHandler(async (req, res) => {
+router.post('/score', extractAIProvider, asyncHandler(async (req, res) => {
   const { resumeText, jobRole } = req.body;
 
-  if (!resumeText || !resumeText.trim()) {
-    throw new ApiError(400, 'Resume text is required');
+  if (typeof resumeText !== 'string' || !resumeText.trim()) {
+    throw new ApiError(400, 'Resume text is required and must be a string');
   }
 
   try {
-    const provider = getDefaultProvider();
+    const provider = req.aiProvider;
     const scoreData = await scoreResumeText(resumeText, jobRole || 'Software Engineer', provider);
     
     res.json({

--- a/backend/src/services/resumeService.js
+++ b/backend/src/services/resumeService.js
@@ -32,7 +32,7 @@ Return ONLY valid JSON. No markdown fences, no extra text.`;
   try {
     qualitativeData = JSON.parse(text);
   } catch (parseErr) {
-    console.error('Resume score JSON parse error:', parseErr, 'Raw text:', text);
+    console.error('Resume score JSON parse error:', parseErr.message);
     throw new ApiError(
       502,
       'AI service returned an invalid response. Please try again in a moment.'

--- a/backend/src/services/resumeService.js
+++ b/backend/src/services/resumeService.js
@@ -8,6 +8,7 @@ export const scoreResumeText = async (resumeText, targetRole = 'Software Enginee
   // 2. Get qualitative feedback via AI
   const prompt = `Analyze this resume for a ${targetRole} position and return a JSON object with EXACTLY these fields:
 - sections: object with keys "summary", "skills", "experience", "education", "projects" — each containing:
+    - score (number, 0-100)
     - feedback (string, one concise sentence of constructive feedback)
 - topSuggestions: array of exactly 3 strings, each a specific actionable improvement tip
 
@@ -39,36 +40,53 @@ Return ONLY valid JSON. No markdown fences, no extra text.`;
     );
   }
 
+  // Validate the parsed structure
+  if (!qualitativeData || typeof qualitativeData !== 'object') {
+    throw new ApiError(502, 'AI service returned an invalid response format.');
+  }
+
+  const requiredSections = ['summary', 'skills', 'experience', 'education', 'projects'];
+  if (!qualitativeData.sections || typeof qualitativeData.sections !== 'object') {
+    throw new ApiError(502, 'AI service returned missing or invalid sections data.');
+  }
+
+  for (const key of requiredSections) {
+    const sec = qualitativeData.sections[key];
+    if (!sec || typeof sec.score !== 'number' || typeof sec.feedback !== 'string') {
+      throw new ApiError(502, `AI service returned invalid data for section: ${key}`);
+    }
+  }
+
+  if (!Array.isArray(qualitativeData.topSuggestions) || qualitativeData.topSuggestions.length !== 3 || qualitativeData.topSuggestions.some(s => typeof s !== 'string')) {
+    throw new ApiError(502, 'AI service returned invalid top suggestions format.');
+  }
+
   // 3. Map into the format expected by the frontend
   const scoreData = {
     overallScore: deterministicScoring.overallScore,
     sections: {
       summary: { 
-        score: deterministicScoring.breakdown.formatting, 
-        feedback: qualitativeData.sections?.summary?.feedback || 'Good formatting.' 
+        score: qualitativeData.sections.summary.score, 
+        feedback: qualitativeData.sections.summary.feedback
       },
       skills: { 
-        score: deterministicScoring.breakdown.skills, 
-        feedback: qualitativeData.sections?.skills?.feedback || 'Include more role-specific skills.' 
+        score: qualitativeData.sections.skills.score, 
+        feedback: qualitativeData.sections.skills.feedback
       },
       experience: { 
-        score: deterministicScoring.breakdown.experience, 
-        feedback: qualitativeData.sections?.experience?.feedback || 'Add metrics.' 
+        score: qualitativeData.sections.experience.score, 
+        feedback: qualitativeData.sections.experience.feedback
       },
       education: { 
-        score: 80, // Default good score for education
-        feedback: qualitativeData.sections?.education?.feedback || 'Good.' 
+        score: qualitativeData.sections.education.score,
+        feedback: qualitativeData.sections.education.feedback
       },
       projects: { 
-        score: deterministicScoring.breakdown.keywordMatch, 
-        feedback: qualitativeData.sections?.projects?.feedback || 'Good.' 
+        score: qualitativeData.sections.projects.score, 
+        feedback: qualitativeData.sections.projects.feedback
       }
     },
-    topSuggestions: qualitativeData.topSuggestions || [
-      'Add more quantifiable metrics to your experience.',
-      'Tailor keywords to the specific job role.',
-      'Ensure formatting is clean and easy to read.'
-    ]
+    topSuggestions: qualitativeData.topSuggestions
   };
 
   return scoreData;

--- a/backend/src/services/resumeService.js
+++ b/backend/src/services/resumeService.js
@@ -1,109 +1,75 @@
-import { getDefaultProvider } from '../config/aiProviders.js';
+import { computeATSScore } from './atsScorer.js';
 import { ApiError } from '../middleware/errorHandler.js';
 
-/**
- * Analyzes a resume using AI and returns a structured score with feedback
- * @param {string} resumeText - The resume text to analyze
- * @returns {Promise<Object>} - The analysis result with scores and feedback
- */
-export async function analyzeResume(resumeText) {
-  if (!resumeText || !resumeText.trim()) {
-    throw new ApiError(400, 'Resume text is required');
-  }
+export const scoreResumeText = async (resumeText, targetRole = 'Software Engineer', provider) => {
+  // 1. Get deterministic scores
+  const deterministicScoring = computeATSScore(resumeText, targetRole);
 
+  // 2. Get qualitative feedback via AI
+  const prompt = `Analyze this resume for a ${targetRole} position and return a JSON object with EXACTLY these fields:
+- sections: object with keys "summary", "skills", "experience", "education", "projects" — each containing:
+    - feedback (string, one concise sentence of constructive feedback)
+- topSuggestions: array of exactly 3 strings, each a specific actionable improvement tip
+
+Resume:
+${resumeText}
+
+Return ONLY valid JSON. No markdown fences, no extra text.`;
+
+  const result = await provider.generateContent(prompt);
+  let text = result.text.trim();
+
+  // Strip markdown fences
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+  }
+  
+  // Attempt extra extraction
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (jsonMatch) text = jsonMatch[0];
+
+  let qualitativeData;
   try {
-    const provider = getDefaultProvider();
-    
-    const prompt = `You are an expert resume analyst. Analyze the following resume and provide a detailed evaluation.
-
-Return ONLY a valid JSON object with this exact structure:
-{
-  "overallScore": number (0-100),
-  "sections": {
-    "summary": {
-      "score": number (0-100),
-      "feedback": "string (brief feedback)"
-    },
-    "skills": {
-      "score": number (0-100),
-      "feedback": "string (brief feedback)"
-    },
-    "experience": {
-      "score": number (0-100),
-      "feedback": "string (brief feedback)"
-    },
-    "education": {
-      "score": number (0-100),
-      "feedback": "string (brief feedback)"
-    },
-    "projects": {
-      "score": number (0-100),
-      "feedback": "string (brief feedback)"
-    }
-  },
-  "topSuggestions": [
-    "string (actionable suggestion)",
-    "string (actionable suggestion)",
-    "string (actionable suggestion)"
-  ]
-}
-
-Scoring criteria:
-- Overall score should reflect the resume's overall quality
-- Each section should be scored independently (0-100)
-- Feedback should be specific and actionable
-- Top suggestions should be the most important improvements needed
-- Be honest but constructive in your assessment
-
-Resume text:
-${resumeText}`;
-
-    const result = await provider.generateContent(prompt);
-    
-    // Strip markdown code blocks if present
-    let jsonText = result.text.trim();
-    if (jsonText.startsWith('```')) {
-      jsonText = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
-    }
-
-    // Parse the JSON response
-    const analysisData = JSON.parse(jsonText);
-
-    // Validate the structure
-    if (!analysisData.overallScore || typeof analysisData.overallScore !== 'number') {
-      throw new Error('Invalid response: missing or invalid overallScore');
-    }
-
-    if (!analysisData.sections || typeof analysisData.sections !== 'object') {
-      throw new Error('Invalid response: missing or invalid sections');
-    }
-
-    const requiredSections = ['summary', 'skills', 'experience', 'education', 'projects'];
-    for (const section of requiredSections) {
-      if (!analysisData.sections[section] || typeof analysisData.sections[section].score !== 'number') {
-        throw new Error(`Invalid response: missing or invalid ${section} section`);
-      }
-    }
-
-    if (!analysisData.topSuggestions || !Array.isArray(analysisData.topSuggestions)) {
-      throw new Error('Invalid response: missing or invalid topSuggestions');
-    }
-
-    return analysisData;
-  } catch (error) {
-    console.error('Error analyzing resume:', error);
-    
-    // If JSON parsing failed, it's likely the AI didn't return valid JSON
-    if (error instanceof SyntaxError) {
-      throw new ApiError(500, 'Failed to analyze resume: AI returned invalid JSON format');
-    }
-    
-    // Re-throw ApiError instances
-    if (error instanceof ApiError) {
-      throw error;
-    }
-    
-    // Generic error
-    throw new ApiError(500, 'Failed to analyze resume');
+    qualitativeData = JSON.parse(text);
+  } catch (parseErr) {
+    console.error('Resume score JSON parse error:', parseErr, 'Raw text:', text);
+    throw new ApiError(
+      502,
+      'AI service returned an invalid response. Please try again in a moment.'
+    );
   }
-}
+
+  // 3. Map into the format expected by the frontend
+  const scoreData = {
+    overallScore: deterministicScoring.overallScore,
+    sections: {
+      summary: { 
+        score: deterministicScoring.breakdown.formatting, 
+        feedback: qualitativeData.sections?.summary?.feedback || 'Good formatting.' 
+      },
+      skills: { 
+        score: deterministicScoring.breakdown.skills, 
+        feedback: qualitativeData.sections?.skills?.feedback || 'Include more role-specific skills.' 
+      },
+      experience: { 
+        score: deterministicScoring.breakdown.experience, 
+        feedback: qualitativeData.sections?.experience?.feedback || 'Add metrics.' 
+      },
+      education: { 
+        score: 80, // Default good score for education
+        feedback: qualitativeData.sections?.education?.feedback || 'Good.' 
+      },
+      projects: { 
+        score: deterministicScoring.breakdown.keywordMatch, 
+        feedback: qualitativeData.sections?.projects?.feedback || 'Good.' 
+      }
+    },
+    topSuggestions: qualitativeData.topSuggestions || [
+      'Add more quantifiable metrics to your experience.',
+      'Tailor keywords to the specific job role.',
+      'Ensure formatting is clean and easy to read.'
+    ]
+  };
+
+  return scoreData;
+};

--- a/frontend/src/components/ResumeSectionStrengthAnalyzer.jsx
+++ b/frontend/src/components/ResumeSectionStrengthAnalyzer.jsx
@@ -11,12 +11,17 @@ export default function ResumeSectionStrengthAnalyzer({ resume }) {
   useEffect(() => {
     if (!resume) return;
     
+    const abortController = new AbortController();
+    
     const fetchScore = async () => {
       setLoading(true);
       setError("");
       try {
         const text = resume.enhancedText || resume.originalText;
+        // In a real app we might pass abortController.signal to the fetch call inside resumeApi
         const res = await resumeApi.score(text, resume.jobRole || 'Software Engineer');
+        
+        if (abortController.signal.aborted) return;
         
         if (res?.data?.sections) {
           const formattedSections = Object.entries(res.data.sections).map(([key, value]) => ({
@@ -26,16 +31,25 @@ export default function ResumeSectionStrengthAnalyzer({ resume }) {
           }));
           setSections(formattedSections);
           setOverallScore(res.data.overallScore);
+        } else {
+          setError("No section data found in the response.");
         }
       } catch (err) {
+        if (abortController.signal.aborted) return;
         console.error("Error scoring resume:", err);
         setError("Failed to analyze resume strength.");
       } finally {
-        setLoading(false);
+        if (!abortController.signal.aborted) {
+          setLoading(false);
+        }
       }
     };
     
     fetchScore();
+    
+    return () => {
+      abortController.abort();
+    };
   }, [resume]);
 
   if (!resume) {

--- a/frontend/src/components/ResumeSectionStrengthAnalyzer.jsx
+++ b/frontend/src/components/ResumeSectionStrengthAnalyzer.jsx
@@ -1,28 +1,96 @@
-import { FileText, TrendingUp } from "lucide-react";
+import { useState, useEffect } from "react";
+import { FileText, TrendingUp, AlertCircle, Loader2 } from "lucide-react";
+import { resumeApi } from "../services/api";
 
-export default function ResumeSectionStrengthAnalyzer() {
-  const sections = [
-    {
-      name: "Education",
-      score: 90,
-      suggestion: "Strong section with relevant academic details.",
-    },
-    {
-      name: "Skills",
-      score: 75,
-      suggestion: "Add more industry-relevant technical skills.",
-    },
-    {
-      name: "Projects",
-      score: 85,
-      suggestion: "Include measurable outcomes and achievements.",
-    },
-    {
-      name: "Experience",
-      score: 60,
-      suggestion: "Add internship or volunteer experience.",
-    },
-  ];
+export default function ResumeSectionStrengthAnalyzer({ resume }) {
+  const [sections, setSections] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [overallScore, setOverallScore] = useState(null);
+
+  useEffect(() => {
+    if (!resume) return;
+    
+    const fetchScore = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const text = resume.enhancedText || resume.originalText;
+        const res = await resumeApi.score(text, resume.jobRole || 'Software Engineer');
+        
+        if (res?.data?.sections) {
+          const formattedSections = Object.entries(res.data.sections).map(([key, value]) => ({
+            name: key.charAt(0).toUpperCase() + key.slice(1),
+            score: value.score,
+            suggestion: value.feedback
+          }));
+          setSections(formattedSections);
+          setOverallScore(res.data.overallScore);
+        }
+      } catch (err) {
+        console.error("Error scoring resume:", err);
+        setError("Failed to analyze resume strength.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    
+    fetchScore();
+  }, [resume]);
+
+  if (!resume) {
+    return (
+      <div className="rounded-2xl bg-card border border-border p-6 shadow-sm">
+        <div className="flex items-center gap-3 mb-6">
+          <TrendingUp className="w-6 h-6 text-primary" />
+          <h2 className="text-xl font-black">
+            Resume Section Strength Analyzer
+          </h2>
+        </div>
+        <div className="p-6 rounded-xl border border-dashed border-primary/20 bg-primary/5 text-center">
+          <FileText className="w-10 h-10 text-primary mx-auto mb-3 opacity-60" />
+          <p className="text-sm font-bold text-foreground mb-1">Upload a Resume</p>
+          <p className="text-xs text-muted-foreground max-w-xs mx-auto mb-4">
+            Upload your resume to get an AI-powered section strength analysis.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-2xl bg-card border border-border p-6 shadow-sm">
+        <div className="flex items-center gap-3 mb-6">
+          <TrendingUp className="w-6 h-6 text-primary" />
+          <h2 className="text-xl font-black">
+            Resume Section Strength Analyzer
+          </h2>
+        </div>
+        <div className="flex flex-col items-center justify-center p-8 text-center gap-4 text-muted-foreground">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+          <p className="text-sm font-bold">Analyzing resume sections with AI...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl bg-card border border-border p-6 shadow-sm">
+        <div className="flex items-center gap-3 mb-6">
+          <TrendingUp className="w-6 h-6 text-primary" />
+          <h2 className="text-xl font-black">
+            Resume Section Strength Analyzer
+          </h2>
+        </div>
+        <div className="flex items-center gap-2 p-4 rounded-xl bg-destructive/10 text-destructive text-sm font-bold">
+          <AlertCircle className="w-5 h-5" />
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-2xl bg-card border border-border p-6 shadow-sm">
@@ -31,6 +99,11 @@ export default function ResumeSectionStrengthAnalyzer() {
         <h2 className="text-xl font-black">
           Resume Section Strength Analyzer
         </h2>
+        {overallScore !== null && (
+          <span className="ml-auto px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-bold border border-primary/20">
+            Overall Score: {overallScore}%
+          </span>
+        )}
       </div>
 
       <div className="space-y-4">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -437,6 +437,17 @@ export const resumeApi = {
       body: JSON.stringify(data)
     })
     return handleResponse(response)
+  },
+
+  // Score resume with AI
+  async score(resumeText, jobRole = 'Software Engineer') {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/resumes/score`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ resumeText, jobRole })
+    })
+    return handleResponse(response)
   }
 }
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -439,16 +439,17 @@ export const resumeApi = {
     return handleResponse(response)
   },
 
-  // Score resume with AI
-  async score(resumeText, jobRole = 'Software Engineer') {
+  // Get AI score and qualitative feedback for a resume
+  async score(resumeText, jobRole = 'Software Engineer', options = {}) {
     const headers = await getAuthHeaders()
     const response = await fetch(`${API_BASE}/resumes/score`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ resumeText, jobRole })
+      body: JSON.stringify({ resumeText, jobRole }),
+      signal: options.signal
     })
     return handleResponse(response)
-  }
+  },
 }
 
 // ============ PORTFOLIO API ============


### PR DESCRIPTION
## **User description**
## Description
Implemented AI-powered resume scoring to replace the previously hardcoded `/score` endpoint. 
- Created a new `resumeService.js` in the backend to handle AI generation and strict JSON parsing.
- Updated the backend `/api/resumes/score` route to fetch dynamic scores.
- Overhauled `ResumeSectionStrengthAnalyzer.jsx` on the frontend to fetch and render the real AI analysis, complete with loading, empty, and error states.
- Updated `Dashboard.jsx` to pass the user's latest resume into the analyzer.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (describe)

## Related Issue
Fixes #4365 

## Testing
- [ ] Unit tests pass
- [x] Tested Locally
- [ ] New tests added

## Screenshots (MANDATORY for UI/UX changes)
- N/A


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Added comments where necessary
- [ ] Updated documentation
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered, role-based resume scoring with structured section feedback.
  * Updated the resume strength analyzer to show an overall score plus section-by-section cards, including top suggestions.
* **Improvements**
  * Added clearer loading, error, and missing-resume UI states, with request cancellation to prevent stale updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add live resume scoring with role-specific feedback

### What Changed
- Resume analysis now scores the selected resume using deterministic content checks and role-specific AI feedback instead of fixed sample values
- The dashboard displays an overall score plus feedback for summary, skills, experience, education, and projects
- Users see clear upload, loading, empty-result, and analysis-error states
- Invalid resume input and unusable AI responses return clearer error messages

### Impact
`✅ Resume scores reflect the uploaded resume`
`✅ Role-specific improvement suggestions`
`✅ Clearer scoring progress and failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
