### PR TITLE
fix: add explicit type attribute to button elements (superseded by smaller PRs)

### DIFF
--- a/frontend/src/__tests__/ThemeProvider.test.jsx
+++ b/frontend/src/__tests__/ThemeProvider.test.jsx
@@ -8,7 +8,7 @@ const TestComponent = () => {
   return (
     <div>
       <span data-testid="theme-display">{theme}</span>
-      <button onClick={toggleTheme}>Toggle Theme</button>
+      <button type="button" onClick={toggleTheme}>Toggle Theme</button>
     </div>
   );
 };

--- a/frontend/src/components/AIProviderSelector.jsx
+++ b/frontend/src/components/AIProviderSelector.jsx
@@ -32,7 +32,7 @@ export default function AIProviderSelector() {
   return (
     <div className="relative" ref={containerRef}>
       {/* Trigger Button */}
-      <button
+      <button type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className="flex items-center gap-2 p-2 rounded-xl bg-muted border border-border hover:bg-accent text-foreground transition-all"
         aria-label="Select AI Provider"
@@ -74,7 +74,7 @@ export default function AIProviderSelector() {
                   const isActive = id === activeProviderId;
                   
                   return (
-                    <button
+                    <button type="button"
                       key={id}
                       onClick={() => {
                         setActiveProvider(id);

--- a/frontend/src/components/AppErrorBoundary.jsx
+++ b/frontend/src/components/AppErrorBoundary.jsx
@@ -23,7 +23,7 @@ class AppErrorBoundary extends React.Component {
             <p className="text-zinc-400 mb-6">
               The application encountered an unexpected error. Please try refreshing the page.
             </p>
-            <button
+            <button type="button"
               onClick={() => window.location.reload()}
               className="px-4 py-2 bg-zinc-800 hover:bg-zinc-700 rounded-lg text-white transition-colors"
             >

--- a/frontend/src/components/AppSidebar.jsx
+++ b/frontend/src/components/AppSidebar.jsx
@@ -161,7 +161,7 @@ function UserSection() {
                     <p className="text-xs text-muted-foreground font-medium truncate">{user.email}</p>
                 </motion.div>
             </div>
-            <button
+            <button type="button"
                 onClick={toggleTheme}
                 className={cn(
                     "flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300 w-full text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer",
@@ -185,7 +185,7 @@ function UserSection() {
                 </motion.span>
             </button>
             <AIProviderIndicator open={open} animate={animate} />
-            <button
+            <button type="button"
                 onClick={() => {
                     handleLogout();
                     setOpen(false);
@@ -255,7 +255,7 @@ export default function AppSidebar({ animate = true }) {
                             </div>
                             {/* AI Tools Collapsible */}
                             <div className="mt-2">
-                                <button
+                                <button type="button"
                                     onClick={() => setOpenAI(!openAI)}
                                     className="flex items-center justify-between w-full px-4 py-3 rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted font-semibold transition-all"
                                 >
@@ -295,7 +295,7 @@ export default function AppSidebar({ animate = true }) {
                         </div>
                     </div>
                     <div className="shrink-0 space-y-2">
-                        <button
+                        <button type="button"
                             onClick={() => setIsBugModalOpen(true)}
                             className={cn(
                                 "flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-300 w-full cursor-pointer text-red-500 bg-red-500/10 hover:bg-red-500/20",

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -245,7 +245,7 @@ const CommandPalette = ({ isOpen, setIsOpen }) => {
                   matchedAction?.icon || Briefcase;
 
                 return (
-                  <button
+                  <button type="button"
                     key={action.id}
                     onClick={() => handleSelect(action)}
                     className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-white/5 transition"
@@ -276,7 +276,7 @@ const CommandPalette = ({ isOpen, setIsOpen }) => {
               const Icon = action.icon;
 
               return (
-                <button
+                <button type="button"
                   key={action.id}
                   onClick={() => handleSelect(action)}
                   className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left transition-all duration-200 ${

--- a/frontend/src/components/CompanyResearch.jsx
+++ b/frontend/src/components/CompanyResearch.jsx
@@ -68,7 +68,7 @@ export default function CompanyResearch({ companyName, industry = '', onClose })
                 <p className="text-xs text-muted-foreground">{industry || 'Company Research'}</p>
               </div>
             </div>
-            <button
+            <button type="button"
               onClick={onClose}
               className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition"
             >

--- a/frontend/src/components/DropZone.jsx
+++ b/frontend/src/components/DropZone.jsx
@@ -194,7 +194,7 @@ export default function DropZone({
                   {isDone ? (
                     <CheckCircle className="w-5 h-5 text-green-500" />
                   ) : (
-                    <button
+                    <button type="button"
                       onClick={(e) => {
                         e.stopPropagation()
                         removeFile(preview.name)

--- a/frontend/src/components/EmailGeneratorPanel.jsx
+++ b/frontend/src/components/EmailGeneratorPanel.jsx
@@ -66,7 +66,7 @@ export default function EmailGeneratorPanel({ companyName, jobTitle, onClose }) 
                 <p className="text-xs text-muted-foreground">{companyName ? `${jobTitle} at ${companyName}` : 'AI Email Generator'}</p>
               </div>
             </div>
-            <button
+            <button type="button"
               onClick={onClose}
               className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition"
             >
@@ -147,7 +147,7 @@ export default function EmailGeneratorPanel({ companyName, jobTitle, onClose }) 
               >
                 <div className="flex items-center justify-between border-b border-border pb-2">
                   <h2 className="text-xl font-bold text-foreground">Your AI Generated Options</h2>
-                  <button onClick={() => setResults(null)} className="text-sm text-primary font-semibold hover:underline">
+                  <button type="button" onClick={() => setResults(null)} className="text-sm text-primary font-semibold hover:underline">
                     Edit Details
                   </button>
                 </div>
@@ -161,7 +161,7 @@ export default function EmailGeneratorPanel({ companyName, jobTitle, onClose }) 
                       <li key={idx} className="flex items-center gap-3 bg-background p-3 rounded-lg shadow-sm border border-border">
                         <span className="shrink-0 w-6 h-6 bg-primary/20 text-primary rounded-full flex items-center justify-center text-sm font-bold">{idx + 1}</span>
                         <span className="text-foreground font-medium text-sm">{subject}</span>
-                        <button
+                        <button type="button"
                           onClick={() => copyToClipboard(subject, `subj-${idx}`)}
                           className="ml-auto text-muted-foreground hover:text-primary transition p-1"
                           title="Copy"
@@ -180,7 +180,7 @@ export default function EmailGeneratorPanel({ companyName, jobTitle, onClose }) 
                       <div key={idx} className="bg-background p-5 rounded-2xl shadow-sm border border-border flex flex-col h-full hover:border-primary/50 transition-all">
                         <div className="flex justify-between items-center mb-4 border-b border-border pb-2">
                           <span className="font-bold text-foreground text-sm">Option {idx + 1}</span>
-                          <button
+                          <button type="button"
                             onClick={() => copyToClipboard(variant, `body-${idx}`)}
                             className="text-xs flex items-center gap-1 text-primary hover:text-primary/80 font-semibold"
                           >

--- a/frontend/src/components/JobAlertModal.jsx
+++ b/frontend/src/components/JobAlertModal.jsx
@@ -129,7 +129,7 @@ export default function JobAlertModal({ isOpen, onClose, onSuccess, editAlert = 
                                     {editAlert ? 'Edit Job Alert' : 'Create Job Alert'}
                                 </h2>
                             </div>
-                            <button
+                            <button type="button"
                                 onClick={onClose}
                                 className="p-1 hover:bg-primary-foreground/20 rounded-lg transition-colors"
                                 aria-label="Close modal"

--- a/frontend/src/components/JobAlertsList.jsx
+++ b/frontend/src/components/JobAlertsList.jsx
@@ -124,7 +124,7 @@ export default function JobAlertsList() {
             <div className="text-center py-12">
                 <AlertCircle className="w-12 h-12 text-destructive mx-auto mb-4" />
                 <p className="text-muted-foreground">{error}</p>
-                <button
+                <button type="button"
                     onClick={fetchAlerts}
                     className="mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
                 >
@@ -144,7 +144,7 @@ export default function JobAlertsList() {
                         Get notified when jobs matching your criteria are posted
                     </p>
                 </div>
-                <button
+                <button type="button"
                     onClick={() => setIsModalOpen(true)}
                     className="flex items-center gap-2 px-4 py-2.5 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-all"
                 >
@@ -161,7 +161,7 @@ export default function JobAlertsList() {
                     <p className="text-muted-foreground mt-2 max-w-sm mx-auto">
                         Create your first alert to get notified about new job opportunities
                     </p>
-                    <button
+                    <button type="button"
                         onClick={() => setIsModalOpen(true)}
                         className="mt-6 px-6 py-2.5 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors"
                     >
@@ -248,7 +248,7 @@ export default function JobAlertsList() {
                                 {/* Actions */}
 <div className="flex items-center gap-2">
     <Tooltip content="Test alert now">
-        <button
+        <button type="button"
             onClick={() => handleTest(alert._id)}
             disabled={testingId === alert._id}
             className="p-2 text-muted-foreground hover:text-emerald-500 hover:bg-emerald-500/10 rounded-lg transition-colors disabled:opacity-50"
@@ -263,7 +263,7 @@ export default function JobAlertsList() {
     </Tooltip>
 
     <Tooltip content={alert.isActive ? 'Pause alert' : 'Activate alert'}>
-        <button
+        <button type="button"
             onClick={() => handleToggle(alert._id)}
             className={`p-2 rounded-lg transition-colors ${
                 alert.isActive
@@ -281,7 +281,7 @@ export default function JobAlertsList() {
     </Tooltip>
 
     <Tooltip content="Edit alert">
-        <button
+        <button type="button"
             onClick={() => handleEdit(alert)}
             className="p-2 text-muted-foreground hover:text-primary hover:bg-primary/10 rounded-lg transition-colors"
             aria-label="Edit alert"
@@ -291,7 +291,7 @@ export default function JobAlertsList() {
     </Tooltip>
 
     <Tooltip content="Delete alert">
-        <button
+        <button type="button"
             onClick={() => handleDelete(alert._id)}
             className="p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
             aria-label="Delete alert"

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -146,7 +146,7 @@ const Modal = ({
                   </p>
                 )}
               </div>
-              <button
+              <button type="button"
                 onClick={onClose}
                 className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
                 aria-label="Close dialog"

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -165,7 +165,7 @@ export default function Navbar() {
                     className="absolute top-14 left-0 w-full bg-background border border-border rounded-xl shadow-xl overflow-hidden"
                   >
                     {searchSuggestions.map((item, index) => (
-                      <button
+                      <button type="button"
                         key={index}
                         className="w-full text-left px-4 py-3 hover:bg-muted transition-colors text-sm text-foreground"
                       >
@@ -183,7 +183,7 @@ export default function Navbar() {
               onMouseEnter={() => setShowProductsDropdown(true)}
               onMouseLeave={() => setShowProductsDropdown(false)}
             >
-              <button
+              <button type="button"
                 className={`nav-link ${showProductsDropdown ? 'nav-link-active' : 'nav-link-inactive'}`}
               >
                 Products
@@ -253,7 +253,7 @@ export default function Navbar() {
             <AIProviderSelector />
 
             {/* Theme Toggle */}
-            <button
+            <button type="button"
               onClick={toggleTheme}
               className="p-2 rounded-xl bg-muted hover:bg-accent border border-border text-foreground transition-all"
               aria-label="Toggle theme"
@@ -278,7 +278,7 @@ export default function Navbar() {
             {user ? (
               <>
                 {/* Notification Bell */}
-                <button
+                <button type="button"
                   className="relative p-2 rounded-xl bg-muted border border-border hover:bg-accent transition-all"
                   aria-label="Notifications"
                 >
@@ -293,7 +293,7 @@ export default function Navbar() {
 
                 {/* User Dropdown */}
                 <div className="relative">
-                  <button
+                  <button type="button"
                     onClick={() => setShowDropdown(!showDropdown)}
                     className="flex items-center gap-2 px-3 py-2 bg-muted border border-border rounded-full hover:bg-accent transition-all"
                     aria-label="User menu"
@@ -338,7 +338,7 @@ export default function Navbar() {
                           Settings
                         </Link>
 
-                        <button
+                        <button type="button"
                           onClick={handleLogout}
                           className="flex items-center gap-2 w-full px-4 py-3 text-left hover:bg-destructive/10 text-destructive transition-colors text-sm"
                         >
@@ -372,7 +372,7 @@ export default function Navbar() {
           {/* Mobile Menu */}
           <div className="flex items-center gap-2 md:hidden">
             <AIProviderSelector />
-            <button
+            <button type="button"
               onClick={toggleTheme}
               className="p-2 rounded-xl bg-muted border border-border"
               aria-label="Toggle theme"
@@ -384,7 +384,7 @@ export default function Navbar() {
               )}
             </button>
 
-            <button
+            <button type="button"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className="p-2 rounded-lg hover:bg-muted transition-all"
               aria-label={mobileMenuOpen ? "Close main navigation menu" : "Open main navigation menu"}
@@ -468,7 +468,7 @@ export default function Navbar() {
 
 
               {user ? (
-                <button
+                <button type="button"
                   onClick={() => {
                     handleLogout()
                     setMobileMenuOpen(false)

--- a/frontend/src/components/NoteEditor.jsx
+++ b/frontend/src/components/NoteEditor.jsx
@@ -18,13 +18,13 @@ export default function NoteEditor({ notes = [], onAddNote }) {
             {/* Editor */}
             <div className="border border-border rounded-lg p-4 bg-card shadow-sm transition-colors duration-300">
                 <div className="flex gap-2 mb-2">
-                    <button
+                    <button type="button"
                         className={`text-sm px-3 py-1 rounded transition-colors ${!showPreview ? "bg-primary/10 text-primary font-medium" : "text-muted-foreground hover:text-foreground"}`}
                         onClick={() => setShowPreview(false)}
                     >
                         Write
                     </button>
-                    <button
+                    <button type="button"
                         className={`text-sm px-3 py-1 rounded transition-colors ${showPreview ? "bg-primary/10 text-primary font-medium" : "text-muted-foreground hover:text-foreground"}`}
                         onClick={() => setShowPreview(true)}
                     >
@@ -50,7 +50,7 @@ export default function NoteEditor({ notes = [], onAddNote }) {
                     </div>
                 )}
 
-                <button
+                <button type="button"
                     className="mt-4 px-4 py-1.5 bg-primary text-primary-foreground text-sm font-medium rounded-lg hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
                     onClick={handleSubmit}
                     disabled={!content.trim()}

--- a/frontend/src/components/NotificationCenter.jsx
+++ b/frontend/src/components/NotificationCenter.jsx
@@ -72,7 +72,7 @@ export default function NotificationCenter() {
   return (
     <div className="relative" ref={panelRef}>
       {/* Bell button */}
-      <button
+      <button type="button"
         onClick={() => setOpen((v) => !v)}
         className="relative flex items-center justify-center w-10 h-10 rounded-xl hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
         aria-label="Notifications"
@@ -103,7 +103,7 @@ export default function NotificationCenter() {
             <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
               <span className="font-bold text-foreground text-sm">Notifications</span>
               {unreadCount > 0 && (
-                <button
+                <button type="button"
                   onClick={markAllRead}
                   className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 font-medium transition-colors"
                 >
@@ -158,7 +158,7 @@ export default function NotificationCenter() {
                         <span className="w-2 h-2 rounded-full bg-primary shrink-0 mt-1.5" />
                       )}
                       {/* Dismiss */}
-                      <button
+                      <button type="button"
                         onClick={(e) => handleDismiss(e, notif.id)}
                         className="opacity-0 group-hover:opacity-100 absolute right-2 top-2 p-1 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-all"
                         aria-label="Dismiss notification"

--- a/frontend/src/components/OutreachDraftCard.jsx
+++ b/frontend/src/components/OutreachDraftCard.jsx
@@ -29,7 +29,7 @@ const OutreachDraftCard = ({ style, subjectLine, content }) => {
                 <span className={`px-3 py-1 text-xs font-medium uppercase tracking-wider rounded-full border ${styleBadge}`}>
                     {style}
                 </span>
-                <button 
+                <button type="button" 
                     onClick={handleCopy}
                     className="flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-indigo-600 transition-colors"
                 >

--- a/frontend/src/components/OutreachPanel.jsx
+++ b/frontend/src/components/OutreachPanel.jsx
@@ -144,7 +144,7 @@ export default function OutreachPanel({ companyName, companyUrl: initialCompanyU
                 <p className="text-xs text-muted-foreground">{companyName || 'Generate Outreach'}</p>
               </div>
             </div>
-            <button
+            <button type="button"
               onClick={onClose}
               className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition"
             >
@@ -218,7 +218,7 @@ export default function OutreachPanel({ companyName, companyUrl: initialCompanyU
                   <AlertCircle className="w-10 h-10 text-red-500 mx-auto mb-4" />
                   <h3 className="text-lg font-medium text-red-900 mb-2">Generation Failed</h3>
                   <p className="text-red-700 text-sm">{error}</p>
-                  <button
+                  <button type="button"
                     onClick={() => setStatus('idle')}
                     className="mt-4 px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 font-medium transition-colors text-sm"
                   >

--- a/frontend/src/components/PortfolioProjectCarousel.jsx
+++ b/frontend/src/components/PortfolioProjectCarousel.jsx
@@ -53,14 +53,14 @@ export default function PortfolioProjectCarousel() {
         </p>
 
         <div className="flex justify-center gap-4 mt-6">
-          <button
+          <button type="button"
             onClick={prevSlide}
             className="p-2 rounded-lg border"
           >
             <ChevronLeft size={18} />
           </button>
 
-          <button
+          <button type="button"
             onClick={nextSlide}
             className="p-2 rounded-lg border"
           >

--- a/frontend/src/components/PortfolioTemplatePreview.jsx
+++ b/frontend/src/components/PortfolioTemplatePreview.jsx
@@ -70,7 +70,7 @@ export default function PortfolioTemplatePreview() {
           </div>
 
 
-          <button
+          <button type="button"
             onClick={resetSettings}
             className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg"
           >

--- a/frontend/src/components/ReportBugModal.jsx
+++ b/frontend/src/components/ReportBugModal.jsx
@@ -55,7 +55,7 @@ export default function ReportBugModal({ isOpen, onClose }) {
                 <Bug className="w-5 h-5 text-red-500" />
                 <h2 className="text-lg font-bold">Report a Bug</h2>
               </div>
-              <button
+              <button type="button"
                 onClick={onClose}
                 className="p-2 rounded-xl hover:bg-muted text-muted-foreground transition-colors"
               >

--- a/frontend/src/components/ResumeBulletEnhancer.jsx
+++ b/frontend/src/components/ResumeBulletEnhancer.jsx
@@ -38,7 +38,7 @@ export default function ResumeBulletEnhancer() {
       />
 
       {/* Button */}
-      <button
+      <button type="button"
         onClick={enhanceBullet}
         className="mt-4 flex items-center gap-2 px-5 py-2 rounded-xl bg-primary text-primary-foreground font-bold hover:opacity-90 transition"
       >

--- a/frontend/src/components/ResumeScore.jsx
+++ b/frontend/src/components/ResumeScore.jsx
@@ -107,7 +107,7 @@ export default function ResumeScore({ data, onRescore }) {
           <p className={`text-2xl font-bold ${scoreText}`}>{label}</p>
           <p className="text-muted-foreground text-sm mt-1">Overall Resume Score</p>
           {onRescore && (
-            <button
+            <button type="button"
               onClick={onRescore}
               className="mt-3 text-sm text-primary hover:text-primary/80 flex items-center gap-1 mx-auto sm:mx-0"
             >

--- a/frontend/src/components/ResumeVersions.jsx
+++ b/frontend/src/components/ResumeVersions.jsx
@@ -183,7 +183,7 @@ export default function ResumeVersions({
           <h3 className="text-lg font-bold text-foreground">Resume Version Manager</h3>
           <p className="text-xs text-muted-foreground">Restore snapshots or review content changes over time</p>
         </div>
-        <button
+        <button type="button"
           onClick={() => {
             setSnapshotRole(currentJobRole || '')
             setShowSnapshotForm(true)
@@ -270,21 +270,21 @@ export default function ResumeVersions({
 
                     {/* Timeline Card Action Buttons */}
                     <div className="flex items-center gap-1.5 sm:self-start">
-                      <button
+                      <button type="button"
                         onClick={() => triggerCompare(version)}
                         title="Compare with another version"
                         className="p-2 rounded-xl bg-muted/40 hover:bg-primary/15 text-muted-foreground hover:text-primary transition-all cursor-pointer"
                       >
                         <GitPullRequest className="w-4 h-4" />
                       </button>
-                      <button
+                      <button type="button"
                         onClick={() => startEdit(version)}
                         title="Edit label & tags"
                         className="p-2 rounded-xl bg-muted/40 hover:bg-yellow-500/15 text-muted-foreground hover:text-yellow-400 transition-all cursor-pointer"
                       >
                         <Edit2 className="w-4 h-4" />
                       </button>
-                      <button
+                      <button type="button"
                         onClick={() => handleRestore(version)}
                         disabled={isActive}
                         title={isActive ? "Current active version" : "Restore this version"}
@@ -297,7 +297,7 @@ export default function ResumeVersions({
                         <RotateCcw className="w-4 h-4" />
                         <span>Restore</span>
                       </button>
-                      <button
+                      <button type="button"
                         onClick={() => handleDelete(version)}
                         title="Delete this version"
                         className="p-2 rounded-xl bg-destructive/10 hover:bg-destructive/25 text-destructive transition-all cursor-pointer"
@@ -332,7 +332,7 @@ export default function ResumeVersions({
             >
               <div className="flex justify-between items-center mb-4">
                 <h4 className="text-lg font-bold text-foreground">Create Resume Snapshot</h4>
-                <button onClick={() => setShowSnapshotForm(false)} className="text-muted-foreground hover:text-foreground">
+                <button type="button" onClick={() => setShowSnapshotForm(false)} className="text-muted-foreground hover:text-foreground">
                   <X className="w-5 h-5" />
                 </button>
               </div>
@@ -412,7 +412,7 @@ export default function ResumeVersions({
             >
               <div className="flex justify-between items-center mb-4">
                 <h4 className="text-lg font-bold text-foreground">Edit Version Details (v{editingVersion.versionNumber})</h4>
-                <button onClick={() => setEditingVersion(null)} className="text-muted-foreground hover:text-foreground">
+                <button type="button" onClick={() => setEditingVersion(null)} className="text-muted-foreground hover:text-foreground">
                   <X className="w-5 h-5" />
                 </button>
               </div>

--- a/frontend/src/components/RouteErrorBoundary.jsx
+++ b/frontend/src/components/RouteErrorBoundary.jsx
@@ -33,7 +33,7 @@ class RouteErrorBoundary extends React.Component {
               <pre className="text-amber-300 text-xs font-mono whitespace-pre-wrap">{this.state.errorInfo?.componentStack}</pre>
             </div>
 
-            <button
+            <button type="button"
               onClick={() => window.location.reload()}
               className="mt-6 px-6 py-3 bg-red-500 hover:bg-red-600 text-white rounded-xl font-semibold transition-colors"
             >

--- a/frontend/src/components/StepWizard.jsx
+++ b/frontend/src/components/StepWizard.jsx
@@ -77,7 +77,7 @@ export default function StepWizard({ steps = [], currentStep = 0, onStepChange }
 
       {/* Navigation */}
       <div className="flex justify-between">
-          <button
+          <button type="button"
             onClick={() => onStepChange?.(currentStep - 1)}
             disabled={isFirst}
             className={cn(
@@ -91,7 +91,7 @@ export default function StepWizard({ steps = [], currentStep = 0, onStepChange }
             Previous
           </button>
 
-          <button
+          <button type="button"
             onClick={() => onStepChange?.(currentStep + 1)}
             disabled={isLast}
             className={cn(

--- a/frontend/src/components/VersionCompareModal.jsx
+++ b/frontend/src/components/VersionCompareModal.jsx
@@ -60,7 +60,7 @@ export default function VersionCompareModal({ isOpen, onClose, versions, initial
               <p className="text-xs text-muted-foreground">Select two versions to inspect exact modifications</p>
             </div>
           </div>
-          <button 
+          <button type="button" 
             onClick={onClose}
             className="p-1.5 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-all"
           >
@@ -103,7 +103,7 @@ export default function VersionCompareModal({ isOpen, onClose, versions, initial
           </div>
 
           <div className="flex items-center bg-card border border-border rounded-xl p-0.5">
-            <button
+            <button type="button"
               onClick={() => setViewMode('split')}
               className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
                 viewMode === 'split' ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
@@ -111,7 +111,7 @@ export default function VersionCompareModal({ isOpen, onClose, versions, initial
             >
               Split View
             </button>
-            <button
+            <button type="button"
               onClick={() => setViewMode('unified')}
               className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
                 viewMode === 'unified' ? 'bg-primary text-primary-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'

--- a/frontend/src/components/__test__/AppSidebar.test.jsx
+++ b/frontend/src/components/__test__/AppSidebar.test.jsx
@@ -71,7 +71,7 @@ vi.mock("../ui/Sidebar", () => ({
   SidebarDivider: () => <hr />,
 
   SidebarLink: ({ link, onClick }) => (
-    <button onClick={onClick}>{link.label}</button>
+    <button type="button" onClick={onClick}>{link.label}</button>
   ),
 }));
 

--- a/frontend/src/components/__test__/FileExplorer.test.jsx
+++ b/frontend/src/components/__test__/FileExplorer.test.jsx
@@ -48,7 +48,7 @@ explainFile: mockExplainFile,
 }));
 
 vi.mock("../visualizer/CodeViewer", () => ({
-default: ({ fileName, onExplain }) => ( <div> <div>{fileName}</div> <button onClick={onExplain}>Explain</button> </div>
+default: ({ fileName, onExplain }) => ( <div> <div>{fileName}</div> <button type="button" onClick={onExplain}>Explain</button> </div>
 ),
 }));
 

--- a/frontend/src/components/ai/LinkedInHeadlineGenerator.jsx
+++ b/frontend/src/components/ai/LinkedInHeadlineGenerator.jsx
@@ -34,7 +34,7 @@ export default function LinkedInHeadlineGenerator() {
           LinkedIn Headline Generator
         </h2>
 
-        <button
+        <button type="button"
           onClick={regenerateHeadlines}
           className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 transition"
         >
@@ -42,7 +42,7 @@ export default function LinkedInHeadlineGenerator() {
         </button>
       </div>
 
-      <button className="w-full py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 transition font-medium">
+      <button type="button" className="w-full py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 transition font-medium">
         Generate Headlines
       </button>
 
@@ -63,7 +63,7 @@ export default function LinkedInHeadlineGenerator() {
                 </span>
               </div>
 
-              <button
+              <button type="button"
                 onClick={() => copyHeadline(headline)}
                 className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 text-sm"
               >

--- a/frontend/src/components/analyzer/FileDrawer.jsx
+++ b/frontend/src/components/analyzer/FileDrawer.jsx
@@ -14,7 +14,7 @@ export default function FileDrawer() {
           <Terminal className="w-4 h-4" />
           {selectedFile.relativePath}
         </div>
-        <button 
+        <button type="button" 
           onClick={() => setSelectedFile(null)}
           className="p-1 hover:bg-white/10 rounded-md transition-colors"
         >

--- a/frontend/src/components/community/ChannelList.jsx
+++ b/frontend/src/components/community/ChannelList.jsx
@@ -88,7 +88,7 @@ export default function ChannelList({
     <div className="py-2">
       {/* Create Channel Button */}
       <div className="px-3 mb-2">
-        <button
+        <button type="button"
           onClick={onCreateChannel}
           className="w-full flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:bg-muted rounded-lg transition-colors"
         >
@@ -101,7 +101,7 @@ export default function ChannelList({
       {Object.entries(groupedChannels).map(([category, categoryChannels]) => (
         <div key={category} className="mb-1">
           {/* Category Header */}
-          <button
+          <button type="button"
             onClick={() => toggleCategory(category)}
             className="w-full flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider hover:text-foreground"
           >
@@ -169,7 +169,7 @@ export default function ChannelList({
       {channels.length === 0 && !loading && (
         <div className="px-4 py-8 text-center text-muted-foreground">
           <p className="text-sm">No channels yet</p>
-          <button
+          <button type="button"
             onClick={onCreateChannel}
             className="mt-2 text-primary hover:text-primary/80 text-sm font-medium"
           >

--- a/frontend/src/components/community/ChatWindow.jsx
+++ b/frontend/src/components/community/ChatWindow.jsx
@@ -192,7 +192,7 @@ export default function ChatWindow({ channel, messages, currentUser, onOptimisti
         </div>
 
         <div className="flex items-center gap-2">
-          <button
+          <button type="button"
             onClick={() => setShowSearch(!showSearch)}
             className={`p-2 rounded-lg transition-colors ${
               showSearch ? 'bg-primary/20 text-primary' : 'text-muted-foreground hover:bg-muted'
@@ -200,13 +200,13 @@ export default function ChatWindow({ channel, messages, currentUser, onOptimisti
           >
             <Search className="w-5 h-5" />
           </button>
-          <button className="p-2 text-muted-foreground hover:bg-muted rounded-lg">
+          <button type="button" className="p-2 text-muted-foreground hover:bg-muted rounded-lg">
             <Pin className="w-5 h-5" />
           </button>
-          <button className="p-2 text-muted-foreground hover:bg-muted rounded-lg">
+          <button type="button" className="p-2 text-muted-foreground hover:bg-muted rounded-lg">
             <Users className="w-5 h-5" />
           </button>
-          <button
+          <button type="button"
             onClick={toggleTheme}
             className="p-2 text-muted-foreground hover:bg-muted rounded-lg transition-colors"
             title={theme === 'light' ? 'Switch to Dark Mode' : theme === 'dark' ? 'Switch to High Contrast' : 'Switch to Light Mode'}
@@ -215,7 +215,7 @@ export default function ChatWindow({ channel, messages, currentUser, onOptimisti
              theme === 'dark' ? <Contrast className="w-5 h-5" /> : 
              <Sun className="w-5 h-5" />}
           </button>
-          <button className="p-2 text-muted-foreground hover:bg-muted rounded-lg">
+          <button type="button" className="p-2 text-muted-foreground hover:bg-muted rounded-lg">
             <MoreVertical className="w-5 h-5" />
           </button>
         </div>

--- a/frontend/src/components/community/CommentSection.jsx
+++ b/frontend/src/components/community/CommentSection.jsx
@@ -85,7 +85,7 @@ function CommentItem({ comment, currentUser, onReply, onLike, depth = 0 }) {
 
           {/* Actions */}
           <div className="flex items-center gap-4 mt-2">
-            <button
+            <button type="button"
               onClick={() => onLike(comment.id)}
               className={`flex items-center gap-1 text-xs transition-colors ${
                 isLiked ? 'text-destructive' : 'text-muted-foreground hover:text-destructive'
@@ -96,7 +96,7 @@ function CommentItem({ comment, currentUser, onReply, onLike, depth = 0 }) {
             </button>
 
             {depth === 0 && (
-              <button
+              <button type="button"
                 onClick={() => setIsReplying(!isReplying)}
                 className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary"
               >
@@ -139,7 +139,7 @@ function CommentItem({ comment, currentUser, onReply, onLike, depth = 0 }) {
       {/* Replies */}
       {comment.replies?.length > 0 && (
         <div className="mt-1">
-          <button
+          <button type="button"
             onClick={() => setShowReplies(!showReplies)}
             className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 mb-2 ml-11"
           >
@@ -337,7 +337,7 @@ export default function CommentSection({ postId, currentUser, onCommentAdded }) 
         {/* Load More */}
         {hasMore && !loading && (
           <div className="p-4 text-center">
-            <button
+            <button type="button"
               onClick={() => fetchComments(true)}
               className="text-sm text-primary hover:text-primary/80 font-medium"
             >

--- a/frontend/src/components/community/DirectMessages.jsx
+++ b/frontend/src/components/community/DirectMessages.jsx
@@ -95,7 +95,7 @@ export default function DirectMessages() {
       {/* Header */}
       <div className="p-4 border-b border-border flex items-center justify-between">
         <h3 className="font-semibold text-foreground">Direct Messages</h3>
-        <button
+        <button type="button"
           onClick={() => setShowNewDM(true)}
           className="p-1.5 text-primary hover:bg-primary/20 rounded-lg"
         >
@@ -127,7 +127,7 @@ export default function DirectMessages() {
               const unreadCount = conv.unreadCount || 0;
 
               return (
-                <button
+                <button type="button"
                   key={convId}
                   onClick={() => handleSelectConversation(conv)}
                   className={`w-full flex items-center gap-3 px-4 py-3 hover:bg-muted transition-colors ${
@@ -184,7 +184,7 @@ export default function DirectMessages() {
         ) : (
           <div className="p-6 text-center text-muted-foreground">
             <p className="text-sm">No conversations yet</p>
-            <button
+            <button type="button"
               onClick={() => setShowNewDM(true)}
               className="mt-2 text-primary hover:text-primary/80 text-sm font-medium"
             >
@@ -200,7 +200,7 @@ export default function DirectMessages() {
           <div className="bg-card border border-border rounded-xl shadow-xl max-w-md w-full">
             <div className="flex items-center justify-between p-4 border-b border-border">
               <h3 className="font-semibold text-foreground">New Message</h3>
-              <button
+              <button type="button"
                 onClick={() => setShowNewDM(false)}
                 className="p-1 text-muted-foreground hover:text-foreground"
               >
@@ -229,7 +229,7 @@ export default function DirectMessages() {
                 {filteredUsers.length > 0 ? (
                   <div className="space-y-1">
                     {filteredUsers.map(u => (
-                      <button
+                      <button type="button"
                         key={u.uid}
                         onClick={() => handleStartConversation(u)}
                         className="w-full flex items-center gap-3 px-3 py-2 hover:bg-muted rounded-lg"

--- a/frontend/src/components/community/MessageBubble.jsx
+++ b/frontend/src/components/community/MessageBubble.jsx
@@ -172,13 +172,13 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
                 className="flex-1 px-3 py-1.5 bg-muted border border-border rounded-lg text-sm text-foreground focus:ring-2 focus:ring-primary"
                 autoFocus
               />
-              <button
+              <button type="button"
                 onClick={handleEdit}
                 className="px-3 py-1 bg-primary text-primary-foreground rounded-lg text-sm"
               >
                 Save
               </button>
-              <button
+              <button type="button"
                 onClick={() => setIsEditing(false)}
                 className="px-3 py-1 bg-muted-foreground/20 text-foreground rounded-lg text-sm"
               >
@@ -243,7 +243,7 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
           {message.reactions?.length > 0 && (
             <div className={`flex gap-1 mt-1 flex-wrap ${isOwn ? 'justify-end' : ''}`}>
               {message.reactions.map((reaction, index) => (
-                <button
+                <button type="button"
                   key={index}
                   onClick={() => handleReaction(reaction.emoji)}
                   className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs transition-colors ${
@@ -267,7 +267,7 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
               <div className="flex items-center gap-1 bg-card border border-border rounded-lg shadow-sm p-1">
                 {/* Quick Reaction */}
                 <div className="relative">
-                  <button
+                  <button type="button"
                     onClick={() => setShowReactions(!showReactions)}
                     className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
                   >
@@ -277,7 +277,7 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
                   {showReactions && (
                     <div className="absolute bottom-full mb-1 left-0 bg-card border border-border rounded-lg shadow-lg p-1 flex gap-1">
                       {QUICK_REACTIONS.map(emoji => (
-                        <button
+                        <button type="button"
                           key={emoji}
                           onClick={() => handleReaction(emoji)}
                           className="p-1 hover:bg-muted rounded text-lg"
@@ -290,7 +290,7 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
                 </div>
 
                 {/* Copy */}
-                <button 
+                <button type="button" 
                   onClick={handleCopy}
                   className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
                 >
@@ -300,7 +300,7 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
                 {/* Edit & Delete (only for own messages) */}
                 {isOwn && (
                   <>
-                    <button
+                    <button type="button"
                       onClick={() => setIsEditing(true)}
                       className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded"
                     >
@@ -308,13 +308,13 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
                     </button>
                     {showConfirmDelete ? (
                       <div className="flex items-center gap-1 bg-destructive/10 rounded p-0.5">
-                        <button
+                        <button type="button"
                           onClick={confirmDelete}
                           className="text-[10px] text-destructive hover:underline px-1"
                         >
                           Confirm
                         </button>
-                        <button
+                        <button type="button"
                           onClick={() => setShowConfirmDelete(false)}
                           className="text-[10px] text-muted-foreground hover:underline px-1"
                         >
@@ -322,7 +322,7 @@ export default function MessageBubble({ message, isOwn, showAvatar, channelId, o
                         </button>
                       </div>
                     ) : (
-                      <button
+                      <button type="button"
                         onClick={() => setShowConfirmDelete(true)}
                         className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded"
                       >

--- a/frontend/src/components/community/MessageInput.jsx
+++ b/frontend/src/components/community/MessageInput.jsx
@@ -149,7 +149,7 @@ export default function MessageInput({ channelId, channelName, onTyping, replyTo
             <span className="font-medium text-foreground">{replyTo.sender.name}</span>
             <p className="text-muted-foreground truncate">{replyTo.content}</p>
           </div>
-          <button
+          <button type="button"
             onClick={onCancelReply}
             className="p-1 text-muted-foreground hover:text-foreground cursor-pointer"
           >
@@ -174,7 +174,7 @@ export default function MessageInput({ channelId, channelName, onTyping, replyTo
               <span className="text-sm text-foreground max-w-[150px] truncate">
                 {file.name}
               </span>
-              <button
+              <button type="button"
                 onClick={() => removeAttachment(index)}
                 className="absolute -top-1 -right-1 w-4 h-4 bg-destructive text-destructive-foreground rounded-full opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center cursor-pointer"
               >

--- a/frontend/src/components/community/PostCard.jsx
+++ b/frontend/src/components/community/PostCard.jsx
@@ -219,7 +219,7 @@ export default function PostCard({
                 </span>
               </p>
 
-              <button
+              <button type="button"
                 onClick={() =>
                   onCancelSchedule(
                     post.id || post._id
@@ -256,7 +256,7 @@ export default function PostCard({
                 {previewText + '...'}
               </ReactMarkdown>
 
-              <button
+              <button type="button"
                 onClick={() =>
                   setShowFullContent(true)
                 }
@@ -279,7 +279,7 @@ export default function PostCard({
                 {post.content}
               </ReactMarkdown>
               {shouldTruncate && (
-                <button
+                <button type="button"
                   onClick={() => setShowFullContent(false)}
                   className="text-primary hover:text-primary/80 font-medium text-sm mt-2 block"
                 >
@@ -392,7 +392,7 @@ export default function PostCard({
       {/* Actions */}
       <div className="px-4 py-3 border-t border-border flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <button
+          <button type="button"
             onClick={() =>
               onLike(post.id || post._id)
             }
@@ -419,7 +419,7 @@ export default function PostCard({
           </button>
 
           {/* Comments */}
-          <button
+          <button type="button"
             onClick={() =>
               setShowComments(!showComments)
             }
@@ -447,7 +447,7 @@ export default function PostCard({
           </button>
 
           {/* Share */}
-          <button
+          <button type="button"
             onClick={handleShare}
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary"
           >
@@ -455,7 +455,7 @@ export default function PostCard({
           </button>
         </div>
 
-        <button
+        <button type="button"
           onClick={handleShare}
           className="p-1.5 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
           title="Share Post"

--- a/frontend/src/components/community/PostEditor.jsx
+++ b/frontend/src/components/community/PostEditor.jsx
@@ -189,7 +189,7 @@ const removePollOption = (index) => {
           <h2 className="text-xl font-semibold text-foreground">
             {editPost ? 'Edit Post' : 'Create New Post'}
           </h2>
-          <button 
+          <button type="button" 
             onClick={onClose}
             className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg"
           >

--- a/frontend/src/components/community/PostsFeed.jsx
+++ b/frontend/src/components/community/PostsFeed.jsx
@@ -303,7 +303,7 @@ const handleCreatePost = async (postData) => {
       <div className="bg-background border-b border-border px-6 py-4">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-xl font-bold text-foreground">Community Discussions</h2>
-          <button
+          <button type="button"
             onClick={() => setShowEditor(true)}
             className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
           >
@@ -316,7 +316,7 @@ const handleCreatePost = async (postData) => {
         <div className="flex flex-wrap gap-3 items-center">
           {/* Sort Options */}
           <div className="flex gap-1 bg-muted p-1 rounded-lg">
-            <button
+            <button type="button"
               onClick={() => setSortBy('latest')}
               className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                 sortBy === 'latest' ? 'bg-card shadow-sm text-primary' : 'text-muted-foreground hover:text-foreground'
@@ -325,7 +325,7 @@ const handleCreatePost = async (postData) => {
               <Clock className="w-4 h-4" />
               Latest
             </button>
-            <button
+            <button type="button"
               onClick={() => setSortBy('popular')}
               className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                 sortBy === 'popular' ? 'bg-card shadow-sm text-primary' : 'text-muted-foreground hover:text-foreground'
@@ -334,7 +334,7 @@ const handleCreatePost = async (postData) => {
               <Heart className="w-4 h-4" />
               Popular
             </button>
-            <button
+            <button type="button"
               onClick={() => setSortBy('trending')}
               className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                 sortBy === 'trending' ? 'bg-card shadow-sm text-primary' : 'text-muted-foreground hover:text-foreground'
@@ -356,7 +356,7 @@ const handleCreatePost = async (postData) => {
               className="w-full pl-10 pr-4 py-2 bg-muted border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-primary"
             />
             {searchQuery && (
-              <button
+              <button type="button"
                 onClick={() => setSearchQuery('')}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
               >
@@ -369,7 +369,7 @@ const handleCreatePost = async (postData) => {
         {/* Category Tabs */}
         <div className="flex gap-2 mt-4 overflow-x-auto pb-2">
           {CATEGORIES.map(cat => (
-            <button
+            <button type="button"
               key={cat.value}
               onClick={() => setSelectedCategory(cat.value)}
               className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm whitespace-nowrap transition-colors ${
@@ -391,7 +391,7 @@ const handleCreatePost = async (postData) => {
           {/* Scheduled posts section — only shown to the post author */}
           {scheduledPosts.length > 0 && (
             <div className="border border-sky-500/20 rounded-xl overflow-hidden">
-              <button
+              <button type="button"
                 onClick={() => setShowScheduled(prev => !prev)}
                 className="w-full flex items-center justify-between px-4 py-3 bg-sky-500/10 hover:bg-sky-500/15 transition-colors"
               >
@@ -479,7 +479,7 @@ const handleCreatePost = async (postData) => {
               <p className="text-4xl mb-3">📝</p>
               <h3 className="text-lg font-medium text-foreground">No posts yet</h3>
               <p className="text-muted-foreground mt-1">Be the first to share your thoughts!</p>
-              <button
+              <button type="button"
                 onClick={() => setShowEditor(true)}
                 className="mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
               >

--- a/frontend/src/components/community/SchedulePost.jsx
+++ b/frontend/src/components/community/SchedulePost.jsx
@@ -63,7 +63,7 @@ export default function SchedulePost({ onClose, onSchedule }) {
             <Clock className="w-5 h-5 text-indigo-400" />
             <h3 className="text-base font-semibold text-white">Schedule Post</h3>
           </div>
-          <button
+          <button type="button"
             onClick={onClose}
             aria-label="Close schedule picker"
             className="p-1.5 text-neutral-500 hover:text-white hover:bg-neutral-800 rounded-lg transition-colors"
@@ -119,13 +119,13 @@ export default function SchedulePost({ onClose, onSchedule }) {
 
         {/* Footer */}
         <div className="flex gap-2 px-5 pb-5">
-          <button
+          <button type="button"
             onClick={onClose}
             className="flex-1 px-4 py-2 border border-neutral-700 rounded-lg text-sm text-neutral-300 hover:bg-neutral-800 transition-colors"
           >
             Back
           </button>
-          <button
+          <button type="button"
             onClick={handleConfirm}
             disabled={!value}
             className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"

--- a/frontend/src/components/github/ReadmeGenerator.jsx
+++ b/frontend/src/components/github/ReadmeGenerator.jsx
@@ -382,14 +382,14 @@ Return ONLY the raw markdown content, no explanations.`
           <span className="header-title">README Generator</span>
         </div>
         <div style={{ display: "flex", gap: 8 }}>
-          <button className="btn btn-ghost" onClick={copyMarkdown}>
+          <button type="button" className="btn btn-ghost" onClick={copyMarkdown}>
             {copied ? (
               <><span>✓</span> Copied!</>
             ) : (
               <><span>⎘</span> Copy Markdown</>
             )}
           </button>
-          <button className="btn btn-ghost" onClick={downloadReadme}>
+          <button type="button" className="btn btn-ghost" onClick={downloadReadme}>
             <span>↓</span> Download .md
           </button>
         </div>
@@ -413,7 +413,7 @@ Return ONLY the raw markdown content, no explanations.`
             }}
             placeholder={SAMPLE_PROMPT_PLACEHOLDER}
           />
-          <button
+          <button type="button"
             className="btn btn-primary"
             onClick={generate}
             disabled={loading || !prompt.trim()}
@@ -441,7 +441,7 @@ Return ONLY the raw markdown content, no explanations.`
       }}>
         <div className="tab-bar">
           {["split", "editor", "preview"].map(t => (
-            <button key={t} className={`tab ${activeTab === t ? "active" : ""}`} onClick={() => setActiveTab(t)}>
+            <button type="button" key={t} className={`tab ${activeTab === t ? "active" : ""}`} onClick={() => setActiveTab(t)}>
               {t === "split" ? "⊟ Split" : t === "editor" ? "✎ Editor" : "👁 Preview"}
             </button>
           ))}

--- a/frontend/src/components/github/RepoCard.jsx
+++ b/frontend/src/components/github/RepoCard.jsx
@@ -46,7 +46,7 @@ const RepoCard = ({ owner, repo, name, description, language, stars, forks, isPr
       </div>
 
       {/* Analyze Button */}
-      <button
+      <button type="button"
         onClick={handleAnalyze}
         disabled={isScanning}
         aria-busy={isScanning}

--- a/frontend/src/components/jobs/MobileKanban.jsx
+++ b/frontend/src/components/jobs/MobileKanban.jsx
@@ -109,7 +109,7 @@ const JobCard = memo(function JobCard({
                   <h4 className="font-bold text-foreground text-sm leading-tight line-clamp-2">
                     {job.title || "Untitled Position"}
                   </h4>
-                  <button
+                  <button type="button"
                     onClick={() => onDelete(job.id)}
                     className="shrink-0 text-muted-foreground/50 hover:text-red-500 transition-colors p-1 -mr-1 -mt-1"
                     aria-label={`Remove ${job.title}`}

--- a/frontend/src/components/portfolio/AccessibilityReport.jsx
+++ b/frontend/src/components/portfolio/AccessibilityReport.jsx
@@ -50,7 +50,7 @@ const AccessibilityReport = ({ report, onRecheck, isLoading }) => {
           color contrast ratios, missing ARIA tags, screen reader compatibility, 
           and general semantic HTML structure.
         </p>
-        <button
+        <button type="button"
           onClick={onRecheck}
           className="inline-flex items-center px-5 py-2.5 bg-cyan-500 text-white font-medium rounded-lg hover:bg-cyan-600 transition-colors shadow-[0_0_15px_rgba(34,211,238,0.25)]"
         >
@@ -91,7 +91,7 @@ const AccessibilityReport = ({ report, onRecheck, isLoading }) => {
               </span>
             </div>
           </div>
-          <button
+          <button type="button"
             onClick={onRecheck}
             disabled={isLoading}
             className="p-2.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded-lg transition-colors disabled:opacity-50 flex items-center font-medium border border-transparent hover:border-border"

--- a/frontend/src/components/portfolio/ColorCustomizer.jsx
+++ b/frontend/src/components/portfolio/ColorCustomizer.jsx
@@ -90,7 +90,7 @@ const ColorCustomizer = ({ portfolioColors = {}, onColorsChange }) => {
 
       <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginBottom: "20px" }}>
         {PRESET_PALETTES.map((palette) => (
-          <button
+          <button type="button"
             key={palette.name}
             onClick={() => applyPreset(palette)}
             title={palette.name}

--- a/frontend/src/components/portfolio/DeployLogs.jsx
+++ b/frontend/src/components/portfolio/DeployLogs.jsx
@@ -32,7 +32,7 @@ export default function DeployLogs({ logs = [] }) {
           Deployment Logs
         </h2>
 
-        <button
+        <button type="button"
           onClick={copyLogs}
           className="px-3 py-1 rounded bg-gray-800 hover:bg-gray-700 text-white text-xs transition"
         >

--- a/frontend/src/components/portfolio/DeployModal.jsx
+++ b/frontend/src/components/portfolio/DeployModal.jsx
@@ -373,7 +373,7 @@ const seoScore = Math.round(
                 </p>
               </div>
             </div>
-            <button
+            <button type="button"
               onClick={handleClose}
               aria-label="Close Deploy Dialog"
               className="p-2 hover:bg-zinc-800/80 rounded-xl transition-colors cursor-pointer text-zinc-400 hover:text-zinc-200"
@@ -547,7 +547,7 @@ const seoScore = Math.round(
 </div>
 
                   {/* Submit Action */}
-                  <button
+                  <button type="button"
                     onClick={handleDeploy}
                     disabled={!isTokenValidated}
                     title={!isTokenValidated ? 'Verify your token first by clicking "Check"' : undefined}
@@ -670,7 +670,7 @@ const seoScore = Math.round(
                       </span>
                     </div>
 
-                    <button
+                    <button type="button"
                       onClick={handleCopyLink}
                       aria-label="Copy deployed link to clipboard"
                       className={`p-3 rounded-xl border transition-all duration-300 flex items-center justify-center shrink-0 cursor-pointer ${
@@ -695,7 +695,7 @@ const seoScore = Math.round(
                       View Live Site
                     </a>
 
-                    <button
+                    <button type="button"
                       onClick={handleClose}
                       className="py-3.5 px-4 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700/60 text-zinc-200 rounded-2xl font-semibold transition-colors cursor-pointer select-none active:scale-95"
                     >
@@ -736,14 +736,14 @@ const seoScore = Math.round(
 
                   {/* Actions */}
                   <div className="w-full flex gap-3 pt-1">
-                    <button
+                    <button type="button"
                       onClick={handleDeploy}
                       className="flex-1 py-3.5 bg-indigo-600 text-zinc-100 rounded-2xl font-semibold shadow-lg shadow-indigo-950/20 hover:bg-indigo-500 transition-all cursor-pointer active:scale-95"
                     >
                       Retry Build
                     </button>
 
-                    <button
+                    <button type="button"
                       onClick={() => setStep('select')}
                       className="flex-1 py-3.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700/60 text-zinc-200 rounded-2xl font-semibold transition-colors cursor-pointer active:scale-95"
                     >

--- a/frontend/src/components/portfolio/PreviewFrame.jsx
+++ b/frontend/src/components/portfolio/PreviewFrame.jsx
@@ -20,7 +20,7 @@ const PreviewFrame = ({ url, title = "Portfolio Preview" }) => {
     <div className="flex flex-col items-center w-full space-y-4">
       {/* Device Toggles */}
       <div className="flex items-center space-x-2 bg-secondary p-1 rounded-lg">
-        <button
+        <button type="button"
           onClick={() => setDevice('desktop')}
           className={`flex items-center px-4 py-2 rounded-md transition-colors ${
             device === 'desktop' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:bg-background/50'
@@ -30,7 +30,7 @@ const PreviewFrame = ({ url, title = "Portfolio Preview" }) => {
           <Monitor className="w-5 h-5 mr-2" />
           <span className="hidden sm:inline">Desktop</span>
         </button>
-        <button
+        <button type="button"
           onClick={() => setDevice('tablet')}
           className={`flex items-center px-4 py-2 rounded-md transition-colors ${
             device === 'tablet' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:bg-background/50'
@@ -40,7 +40,7 @@ const PreviewFrame = ({ url, title = "Portfolio Preview" }) => {
           <Tablet className="w-5 h-5 mr-2" />
           <span className="hidden sm:inline">Tablet</span>
         </button>
-        <button
+        <button type="button"
           onClick={() => setDevice('mobile')}
           className={`flex items-center px-4 py-2 rounded-md transition-colors ${
             device === 'mobile' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:bg-background/50'

--- a/frontend/src/components/portfolio/SectionEditor.jsx
+++ b/frontend/src/components/portfolio/SectionEditor.jsx
@@ -135,7 +135,7 @@ function ProjectsForm({ data, onChange }) {
     <div className="flex flex-col gap-4">
       {projects.map((project, i) => (
         <div key={project.id || i} className="p-4 rounded-xl border border-border bg-background/50 flex flex-col gap-3 relative">
-          <button
+          <button type="button"
             onClick={() => removeProject(i)}
             className="absolute top-3 right-3 text-muted-foreground hover:text-destructive transition"
           >
@@ -150,7 +150,7 @@ function ProjectsForm({ data, onChange }) {
           <Input label="Image URL" value={project.image} onChange={v => updateProject(i, 'image', v)} placeholder="https://..." />
         </div>
       ))}
-      <button
+      <button type="button"
         onClick={addProject}
         className="flex items-center justify-center gap-2 py-2 px-4 rounded-lg
           border border-dashed border-primary/40 text-primary text-sm font-medium
@@ -209,7 +209,7 @@ function SkillsForm({ data, onChange }) {
         <div key={group.id || gi} className="p-4 rounded-xl border border-border bg-background/50 flex flex-col gap-3">
           <div className="flex items-center justify-between">
             <Input label="Category" value={group.category} onChange={v => updateGroup(gi, 'category', v)} placeholder="e.g. Frontend" />
-            <button onClick={() => removeGroup(gi)} className="ml-3 mt-5 text-muted-foreground hover:text-destructive transition">
+            <button type="button" onClick={() => removeGroup(gi)} className="ml-3 mt-5 text-muted-foreground hover:text-destructive transition">
               <Trash2 className="w-4 h-4" />
             </button>
           </div>
@@ -221,12 +221,12 @@ function SkillsForm({ data, onChange }) {
               <div className="flex-1">
                 <Slider label="Level" value={skill.level} onChange={v => updateSkill(gi, si, 'level', v)} />
               </div>
-              <button onClick={() => removeSkill(gi, si)} className="mb-1 text-muted-foreground hover:text-destructive transition">
+              <button type="button" onClick={() => removeSkill(gi, si)} className="mb-1 text-muted-foreground hover:text-destructive transition">
                 <Trash2 className="w-4 h-4" />
               </button>
             </div>
           ))}
-          <button
+          <button type="button"
             onClick={() => addSkill(gi)}
             className="text-xs text-primary hover:underline text-left"
           >
@@ -234,7 +234,7 @@ function SkillsForm({ data, onChange }) {
           </button>
         </div>
       ))}
-      <button
+      <button type="button"
         onClick={addGroup}
         className="flex items-center justify-center gap-2 py-2 px-4 rounded-lg
           border border-dashed border-primary/40 text-primary text-sm font-medium
@@ -288,7 +288,7 @@ function ExperienceForm({ data, onChange }) {
     <div className="flex flex-col gap-4">
       {entries.map((entry, i) => (
         <div key={entry.id || i} className="p-4 rounded-xl border border-border bg-background/50 flex flex-col gap-3 relative">
-          <button onClick={() => removeEntry(i)} className="absolute top-3 right-3 text-muted-foreground hover:text-destructive transition">
+          <button type="button" onClick={() => removeEntry(i)} className="absolute top-3 right-3 text-muted-foreground hover:text-destructive transition">
             <Trash2 className="w-4 h-4" />
           </button>
           <p className="text-xs font-bold text-primary uppercase tracking-wider">Experience {i + 1}</p>
@@ -310,18 +310,18 @@ function ExperienceForm({ data, onChange }) {
                     text-sm text-foreground placeholder:text-muted-foreground
                     focus:outline-none focus:ring-2 focus:ring-primary/40 transition"
                 />
-                <button onClick={() => removeBullet(i, bi)} className="text-muted-foreground hover:text-destructive transition">
+                <button type="button" onClick={() => removeBullet(i, bi)} className="text-muted-foreground hover:text-destructive transition">
                   <Trash2 className="w-4 h-4" />
                 </button>
               </div>
             ))}
-            <button onClick={() => addBullet(i)} className="text-xs text-primary hover:underline text-left">
+            <button type="button" onClick={() => addBullet(i)} className="text-xs text-primary hover:underline text-left">
               + Add Bullet
             </button>
           </div>
         </div>
       ))}
-      <button
+      <button type="button"
         onClick={addEntry}
         className="flex items-center justify-center gap-2 py-2 px-4 rounded-lg
           border border-dashed border-primary/40 text-primary text-sm font-medium
@@ -341,7 +341,7 @@ function ContactForm({ data, onChange }) {
       <Input label="Location" value={data.location} onChange={v => onChange({ ...data, location: v })} placeholder="e.g. Bangalore, India" />
       <div className="flex items-center justify-between p-3 rounded-lg border border-border bg-background/50">
         <span className="text-sm font-medium text-foreground">Show Contact Form</span>
-        <button
+        <button type="button"
           onClick={() => onChange({ ...data, showForm: !data.showForm })}
           className={`w-11 h-6 rounded-full transition-colors ${data.showForm ? 'bg-primary' : 'bg-muted'}`}
         >
@@ -430,7 +430,7 @@ export default function SectionEditor({ portfolioId, sectionType, initialData = 
                 </p>
               </div>
             </div>
-            <button
+            <button type="button"
               onClick={handleCancel}
               className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition"
             >
@@ -445,14 +445,14 @@ export default function SectionEditor({ portfolioId, sectionType, initialData = 
 
           {/* Footer */}
           <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border bg-card">
-            <button
+            <button type="button"
               onClick={handleCancel}
               className="px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground
                 hover:text-foreground hover:bg-muted transition"
             >
               Cancel
             </button>
-            <button
+            <button type="button"
               onClick={handleSave}
               disabled={saving}
               className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold

--- a/frontend/src/components/portfolio/ThemeSelector.jsx
+++ b/frontend/src/components/portfolio/ThemeSelector.jsx
@@ -24,8 +24,8 @@ export default function ThemeSelector({ selectedTheme, onSelectTheme }) {
       <div className="flex items-center gap-2 mb-6">
         <span className="text-sm font-medium text-muted-foreground">Preview mode:</span>
         <div className="flex rounded-lg overflow-hidden border border-border bg-background/50 backdrop-blur-sm">
-          <button onClick={() => setIsDarkPreview(false)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${!isDarkPreview ? 'bg-cyan-500 text-white' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}`}>☀️ Light</button>
-          <button onClick={() => setIsDarkPreview(true)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${isDarkPreview ? 'bg-cyan-500 text-white' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}`}>🌙 Dark</button>
+          <button type="button" onClick={() => setIsDarkPreview(false)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${!isDarkPreview ? 'bg-cyan-500 text-white' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}`}>☀️ Light</button>
+          <button type="button" onClick={() => setIsDarkPreview(true)} className={`px-4 py-1.5 text-sm font-medium transition-colors ${isDarkPreview ? 'bg-cyan-500 text-white' : 'text-muted-foreground hover:bg-accent hover:text-foreground'}`}>🌙 Dark</button>
         </div>
       </div>
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 lg:grid-cols-5">

--- a/frontend/src/components/portfolio/templates/2D_Retro_8bit/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/2D_Retro_8bit/Projects.jsx
@@ -220,7 +220,7 @@ export default function Projects({
             <div className="flex flex-wrap items-center gap-3 w-full md:w-auto">
               <span className="font-retro-title text-[9px] text-[#ffde00] mr-2">STAGE SELECT:</span>
               {categories.map((cat, i) => (
-                <button
+                <button type="button"
                   key={cat}
                   onClick={() => setActiveCategory(cat)}
                   className={`font-retro-title text-[9px] px-3.5 py-2 border-2 border-black transition-all cursor-pointer relative
@@ -239,7 +239,7 @@ export default function Projects({
             <div className="flex flex-wrap items-center gap-6 self-end md:self-auto">
               {/* Insert Coin Slot & Coin Counter */}
               <div className="flex items-center gap-3">
-                <button
+                <button type="button"
                   onClick={handleInsertCoin}
                   disabled={isInserting}
                   className={`flex items-center gap-1.5 px-3 py-2 bg-[#ff007f] hover:bg-[#d8006c] text-white border-2 border-black font-retro-title text-[9px] shadow-[4px_4px_0px_0px_#000000] transition-all cursor-pointer active:translate-x-[2px] active:translate-y-[2px] active:shadow-[2px_2px_0px_0px_#000000] ${
@@ -258,7 +258,7 @@ export default function Projects({
               </div>
 
               {/* CRT Scanline Filter Toggle */}
-              <button
+              <button type="button"
                 onClick={() => setCrtFilter(!crtFilter)}
                 className={`flex items-center gap-1.5 px-3 py-2 border-2 border-black font-retro-title text-[9px] shadow-[4px_4px_0px_0px_#000000] active:translate-x-[2px] active:translate-y-[2px] active:shadow-[2px_2px_0px_0px_#000000] transition-colors cursor-pointer
                   ${
@@ -273,7 +273,7 @@ export default function Projects({
 
               {/* Toggle Game View Layout Mode */}
               <div className="flex rounded-md overflow-hidden border-2 border-black shadow-[4px_4px_0px_0px_#000000]">
-                <button
+                <button type="button"
                   onClick={() => setViewMode("grid")}
                   className={`p-2 transition-colors cursor-pointer ${
                     viewMode === "grid" ? "bg-[#00f0ff] text-black" : "bg-neutral-800 text-neutral-400 hover:text-white"
@@ -282,7 +282,7 @@ export default function Projects({
                 >
                   <Grid className="w-4 h-4" />
                 </button>
-                <button
+                <button type="button"
                   onClick={() => setViewMode("leaderboard")}
                   className={`p-2 transition-colors cursor-pointer ${
                     viewMode === "leaderboard" ? "bg-[#00f0ff] text-black" : "bg-neutral-800 text-neutral-400 hover:text-white"
@@ -552,7 +552,7 @@ export default function Projects({
               <p className="font-retro-body text-xl text-neutral-400 uppercase max-w-sm px-4">
                 No quests completed in this sector yet. Keep building!
               </p>
-              <button
+              <button type="button"
                 onClick={() => setActiveCategory("All")}
                 className="mt-6 font-retro-title text-[9px] px-4 py-2 border-2 border-black bg-[#00f0ff] hover:bg-[#00c5d3] text-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:translate-x-[2px] active:translate-y-[2px] active:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all cursor-pointer"
               >

--- a/frontend/src/components/portfolio/templates/2D_Retro_8bit/Skills.jsx
+++ b/frontend/src/components/portfolio/templates/2D_Retro_8bit/Skills.jsx
@@ -45,7 +45,7 @@ export default function Skills({ skills = [] }) {
           <div className="flex flex-wrap items-center justify-center gap-3 w-full">
             <span className="font-retro-title text-[9px] text-[#ffde00] mr-2">FILTER TYPE:</span>
             {categories.map((cat) => (
-              <button
+              <button type="button"
                 key={cat}
                 onClick={() => setActiveCategory(cat)}
                 className={`font-retro-title text-[9px] px-3.5 py-2 border-2 border-black transition-all cursor-pointer relative

--- a/frontend/src/components/portfolio/templates/2D_Retro_8bit/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/2D_Retro_8bit/Testimonials.jsx
@@ -87,13 +87,13 @@ export default function Testimonials({ testimonials = [] }) {
                   MSG {activeIndex + 1} / {testimonials.length}
                 </span>
                 <div className="flex gap-4">
-                  <button 
+                  <button type="button" 
                     onClick={prevTestimonial}
                     className="font-retro-title text-[10px] px-3 py-2 bg-neutral-900 border-2 border-black text-[#ffde00] hover:bg-neutral-800 active:translate-y-1 shadow-[2px_2px_0px_0px_#000000] cursor-pointer"
                   >
                     ◀ PREV
                   </button>
-                  <button 
+                  <button type="button" 
                     onClick={nextTestimonial}
                     className="font-retro-title text-[10px] px-3 py-2 bg-[#ffde00] border-2 border-black text-black hover:bg-[#ffea00] active:translate-y-1 shadow-[2px_2px_0px_0px_#000000] cursor-pointer"
                   >

--- a/frontend/src/components/portfolio/templates/ASCII_Art_Terminal_Code/NavBar.jsx
+++ b/frontend/src/components/portfolio/templates/ASCII_Art_Terminal_Code/NavBar.jsx
@@ -51,7 +51,7 @@ export default function NavBar() {
         <div className="max-w-6xl mx-auto px-4 h-12 flex items-center justify-between font-mono text-xs">
 
           {/* Logo */}
-          <button
+          <button type="button"
             onClick={() => scrollTo('hero')}
             id="nav-logo"
             aria-label="Go to top"
@@ -68,7 +68,7 @@ export default function NavBar() {
           {/* Desktop links */}
           <div className="hidden md:flex items-center gap-1" role="list">
             {NAV_LINKS.map(link => (
-              <button
+              <button type="button"
                 key={link.id}
                 id={`nav-${link.id}`}
                 onClick={() => scrollTo(link.id)}
@@ -104,7 +104,7 @@ export default function NavBar() {
                 theme:
               </span>
               {Object.values(TERMINAL_THEMES).map(t => (
-                <button
+                <button type="button"
                   key={t.id}
                   id={`theme-btn-${t.id}`}
                   onClick={() => setThemeId(t.id)}
@@ -129,7 +129,7 @@ export default function NavBar() {
             </div>
 
             {/* Mobile hamburger */}
-            <button
+            <button type="button"
               id="nav-mobile-toggle"
               onClick={() => setMobileOpen(o => !o)}
               className="md:hidden transition-colors p-1"
@@ -159,7 +159,7 @@ export default function NavBar() {
           >
             <div className="px-4 py-3 space-y-0.5">
               {NAV_LINKS.map(link => (
-                <button
+                <button type="button"
                   key={link.id}
                   id={`nav-mobile-${link.id}`}
                   onClick={() => scrollTo(link.id)}

--- a/frontend/src/components/portfolio/templates/ASCII_Art_Terminal_Code/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/ASCII_Art_Terminal_Code/Projects.jsx
@@ -15,7 +15,7 @@ function ProjectCard({ project, index, isOpen, onToggle }) {
       className="border border-green-900/40 bg-black/80 hover:border-green-700/60 transition-colors"
     >
       {/* File tree row */}
-      <button
+      <button type="button"
         onClick={onToggle}
         className="w-full flex items-center gap-2 px-4 py-2.5 font-mono text-sm text-left hover:bg-green-900/10 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-green-500"
         aria-expanded={isOpen}

--- a/frontend/src/components/portfolio/templates/ASCII_Art_Terminal_Code/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/ASCII_Art_Terminal_Code/Testimonials.jsx
@@ -145,7 +145,7 @@ export default function Testimonials() {
             transition={{ delay: 0.4, duration: 0.3 }}
             className="flex items-center gap-4 justify-center font-mono text-xs"
           >
-            <button
+            <button type="button"
               onClick={() => setPage(p => Math.max(0, p - 1))}
               disabled={page === 0}
               id="testimonials-prev"
@@ -160,7 +160,7 @@ export default function Testimonials() {
               page {page + 1}/{totalPages}
             </span>
 
-            <button
+            <button type="button"
               onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
               disabled={page === totalPages - 1}
               id="testimonials-next"

--- a/frontend/src/components/portfolio/templates/Abstract_Art/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Abstract_Art/Contact.jsx
@@ -65,7 +65,7 @@ export default function Contact({ data }) {
                   className="w-full bg-white/80 border-none rounded-2xl px-6 py-4 focus:ring-4 focus:ring-pink-100 outline-none transition-all placeholder:text-gray-400 text-gray-800 resize-none"
                 ></textarea>
               </div>
-              <button className="w-full py-4 rounded-2xl bg-gradient-to-r from-teal-500 to-purple-500 text-white font-bold text-lg hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2">
+              <button type="button" className="w-full py-4 rounded-2xl bg-gradient-to-r from-teal-500 to-purple-500 text-white font-bold text-lg hover:shadow-lg hover:scale-[1.02] transition-all flex items-center justify-center gap-2">
                 <span>Send Message</span>
                 <Send className="w-5 h-5" />
               </button>

--- a/frontend/src/components/portfolio/templates/Apple_Showcase/index.jsx
+++ b/frontend/src/components/portfolio/templates/Apple_Showcase/index.jsx
@@ -107,7 +107,7 @@ export default function AppleShowcase() {
           </div>
 
           {/* Mobile hamburger trigger */}
-          <button 
+          <button type="button" 
             onClick={() => setMobileMenuOpen(prev => !prev)}
             className="md:hidden text-neutral-400 hover:text-white transition-colors"
           >
@@ -365,7 +365,7 @@ export default function AppleShowcase() {
             {/* Category tabs */}
             <div className="flex justify-center gap-2 mt-8 flex-wrap">
               {categories.map((cat) => (
-                <button
+                <button type="button"
                   key={cat}
                   onClick={() => setActiveTab(cat)}
                   className={`text-xs px-4 py-2 rounded-full font-medium transition-all ${

--- a/frontend/src/components/portfolio/templates/AquaticBioluminescent/index.jsx
+++ b/frontend/src/components/portfolio/templates/AquaticBioluminescent/index.jsx
@@ -351,7 +351,7 @@ const Nav = ({ name }) => {
       borderBottom: scrolled ? `1px solid ${C.border}` : "none",
       transition: "all 0.4s ease",
     }}>
-      <button onClick={() => scrollTo("home")} style={{
+      <button type="button" onClick={() => scrollTo("home")} style={{
         background: "none", border: "none", cursor: "pointer",
         fontFamily: "'Syne', sans-serif", fontWeight: 800, fontSize: 20,
         color: C.cyan, letterSpacing: 1,
@@ -361,7 +361,7 @@ const Nav = ({ name }) => {
       </button>
       <div style={{ display: "flex", gap: "clamp(10px,2vw,28px)" }}>
         {sections.map((s) => (
-          <button key={s} onClick={() => scrollTo(s)} style={{
+          <button type="button" key={s} onClick={() => scrollTo(s)} style={{
             background: "none", border: "none", cursor: "pointer",
             fontFamily: "'Space Mono', monospace", fontSize: 11,
             letterSpacing: 1.5, textTransform: "uppercase",
@@ -453,13 +453,13 @@ const HeroSection = ({ data }) => {
         )}
 
         <div style={{ display: "flex", gap: 14, justifyContent: "center", flexWrap: "wrap", animation: "opm-rise 0.8s 1.0s both" }}>
-          <button onClick={() => document.getElementById("projects")?.scrollIntoView({ behavior: "smooth" })}
+          <button type="button" onClick={() => document.getElementById("projects")?.scrollIntoView({ behavior: "smooth" })}
             style={{ padding: "13px 34px", borderRadius: 2, cursor: "pointer", border: `1px solid ${C.cyan}`, background: "rgba(0,212,255,0.08)", color: C.cyan, fontFamily: "'Space Mono', monospace", fontSize: 12, letterSpacing: 2, textTransform: "uppercase", boxShadow: C.glow, transition: "all 0.3s" }}
             onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(0,212,255,0.18)"; e.currentTarget.style.boxShadow = C.glowStrong; }}
             onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(0,212,255,0.08)"; e.currentTarget.style.boxShadow = C.glow; }}>
             Explore Work
           </button>
-          <button onClick={() => document.getElementById("contact")?.scrollIntoView({ behavior: "smooth" })}
+          <button type="button" onClick={() => document.getElementById("contact")?.scrollIntoView({ behavior: "smooth" })}
             style={{ padding: "13px 34px", borderRadius: 2, cursor: "pointer", border: `1px solid ${C.border}`, background: "transparent", color: C.muted, fontFamily: "'Space Mono', monospace", fontSize: 12, letterSpacing: 2, textTransform: "uppercase", transition: "all 0.3s" }}
             onMouseEnter={(e) => { e.currentTarget.style.borderColor = C.cyan; e.currentTarget.style.color = C.cyan; }}
             onMouseLeave={(e) => { e.currentTarget.style.borderColor = C.border; e.currentTarget.style.color = C.muted; }}>
@@ -470,7 +470,7 @@ const HeroSection = ({ data }) => {
         {socials.length > 0 && (
           <div style={{ display: "flex", gap: 12, justifyContent: "center", marginTop: 40, animation: "opm-rise 0.8s 1.1s both" }}>
             {socials.map((s, i) => (
-              <button key={i} onClick={() => safeOpen(s.url)} title={s.platform}
+              <button type="button" key={i} onClick={() => safeOpen(s.url)} title={s.platform}
                 style={{ width: 38, height: 38, borderRadius: "50%", border: `1px solid ${C.border}`, background: C.surface, color: C.muted, fontFamily: "'Space Mono', monospace", fontSize: 9, cursor: "pointer", transition: "all 0.3s", display: "flex", alignItems: "center", justifyContent: "center" }}
                 onMouseEnter={(e) => { e.currentTarget.style.borderColor = C.cyan; e.currentTarget.style.color = C.cyan; e.currentTarget.style.boxShadow = C.glow; }}
                 onMouseLeave={(e) => { e.currentTarget.style.borderColor = C.border; e.currentTarget.style.color = C.muted; e.currentTarget.style.boxShadow = "none"; }}>
@@ -662,13 +662,13 @@ const ProjectCard = ({ project, index }) => {
 
       <div style={{ display: "flex", gap: 14 }}>
         {project.liveUrl && (
-          <button onClick={() => safeOpen(project.liveUrl)}
+          <button type="button" onClick={() => safeOpen(project.liveUrl)}
             style={{ background: "none", border: "none", cursor: "pointer", fontFamily: "'Space Mono', monospace", fontSize: 10, color: hov ? col : C.muted, letterSpacing: 1, transition: "color 0.3s", padding: 0 }}>
             Live ↗
           </button>
         )}
         {project.githubUrl && (
-          <button onClick={() => safeOpen(project.githubUrl)}
+          <button type="button" onClick={() => safeOpen(project.githubUrl)}
             style={{ background: "none", border: "none", cursor: "pointer", fontFamily: "'Space Mono', monospace", fontSize: 10, color: hov ? col : C.muted, letterSpacing: 1, transition: "color 0.3s", padding: 0 }}>
             GitHub ↗
           </button>
@@ -709,7 +709,7 @@ const ExperienceSection = ({ data }) => {
         <div style={{ display: "grid", gridTemplateColumns: "260px 1fr", gap: 36 }}>
           <div style={{ display: "flex", flexDirection: "column" }}>
             {experience.map((e, i) => (
-              <button key={i} onClick={() => setActiveIdx(i)}
+              <button type="button" key={i} onClick={() => setActiveIdx(i)}
                 style={{
                   background: "none", border: "none", cursor: "pointer",
                   padding: "16px 0 16px 22px", textAlign: "left",
@@ -796,7 +796,7 @@ const ContactSection = ({ data }) => {
               onChange={(e) => setFields((f) => ({ ...f, message: e.target.value }))}
               onFocus={() => setFocused("message")} onBlur={() => setFocused(null)}
               rows={5} style={{ ...inputStyle("message"), resize: "vertical" }} />
-            <button onClick={() => { if (fields.name && fields.email) setSent(true); }}
+            <button type="button" onClick={() => { if (fields.name && fields.email) setSent(true); }}
               style={{ padding: "15px 0", borderRadius: 4, cursor: "pointer", border: `1px solid ${C.cyan}`, background: "rgba(0,212,255,0.08)", color: C.cyan, fontFamily: "'Space Mono', monospace", fontSize: 12, letterSpacing: 2, textTransform: "uppercase", boxShadow: C.glow, transition: "all 0.3s" }}
               onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(0,212,255,0.18)"; e.currentTarget.style.boxShadow = C.glowStrong; }}
               onMouseLeave={(e) => { e.currentTarget.style.background = "rgba(0,212,255,0.08)"; e.currentTarget.style.boxShadow = C.glow; }}>
@@ -815,7 +815,7 @@ const ContactSection = ({ data }) => {
             </a>
           )}
           {socialLinks.slice(0, 3).map((s, i) => (
-            <button key={i} onClick={() => safeOpen(s.url)}
+            <button type="button" key={i} onClick={() => safeOpen(s.url)}
               style={{ background: "none", border: "none", cursor: "pointer", fontFamily: "'Space Mono', monospace", fontSize: 11, color: C.muted, transition: "color 0.3s", letterSpacing: 1, padding: 0 }}
               onMouseEnter={(e) => { e.target.style.color = C.cyan; }}
               onMouseLeave={(e) => { e.target.style.color = C.muted; }}>

--- a/frontend/src/components/portfolio/templates/Architecture_Blueprint/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Architecture_Blueprint/Hero.jsx
@@ -81,7 +81,7 @@ export default function Hero() {
 
           {/* CTA Buttons */}
           <div className="flex flex-wrap gap-6 pt-4">
-            <button className="group relative px-8 py-4 bg-cyan-950/40 border border-cyan-500 text-cyan-300 font-semibold uppercase tracking-widest overflow-hidden hover:bg-cyan-900/60 transition-all duration-300">
+            <button type="button" className="group relative px-8 py-4 bg-cyan-950/40 border border-cyan-500 text-cyan-300 font-semibold uppercase tracking-widest overflow-hidden hover:bg-cyan-900/60 transition-all duration-300">
               <span className="relative z-10 flex items-center gap-3">
                 Examine Blueprints
                 <ArrowRight className="w-5 h-5 group-hover:translate-x-1.5 transition-transform" />
@@ -93,7 +93,7 @@ export default function Hero() {
               <div className="absolute top-0 left-0 w-full h-px bg-cyan-400/50 -translate-y-full group-hover:translate-y-[60px] transition-transform duration-1000 ease-in-out"></div>
             </button>
 
-            <button className="px-8 py-4 text-cyan-500/80 font-medium uppercase tracking-widest hover:text-cyan-300 transition-colors flex items-center gap-3 border border-transparent hover:border-cyan-800/50">
+            <button type="button" className="px-8 py-4 text-cyan-500/80 font-medium uppercase tracking-widest hover:text-cyan-300 transition-colors flex items-center gap-3 border border-transparent hover:border-cyan-800/50">
               <Compass className="w-5 h-5" />
               Begin Draft
             </button>

--- a/frontend/src/components/portfolio/templates/Astronaut_Spacesuit_Helmet_HUD/index.jsx
+++ b/frontend/src/components/portfolio/templates/Astronaut_Spacesuit_Helmet_HUD/index.jsx
@@ -1196,8 +1196,8 @@ export default function AstronautSpacesuitHelmetHUD() {
                 <p className="hero-title">{personal.title ?? 'Full Stack Developer'}</p>
                 <p className="hero-bio">{personal.bio}</p>
                 <div className="hero-actions">
-                  <button className="btn-primary" onClick={() => scrollTo('missions')}>VIEW MISSIONS</button>
-                  <button className="btn-secondary" onClick={() => scrollTo('trajectory')}>TRAJECTORY LOG</button>
+                  <button type="button" className="btn-primary" onClick={() => scrollTo('missions')}>VIEW MISSIONS</button>
+                  <button type="button" className="btn-secondary" onClick={() => scrollTo('trajectory')}>TRAJECTORY LOG</button>
                 </div>
               </div>
 
@@ -1266,7 +1266,7 @@ export default function AstronautSpacesuitHelmetHUD() {
               <div style={{ flex: 1 }}>
                 <div className="cat-filters">
                   {categories.map(c => (
-                    <button key={c} className={`cat-pill ${activeCat===c?'active':''}`} onClick={() => setActiveCat(c)}>
+                    <button type="button" key={c} className={`cat-pill ${activeCat===c?'active':''}`} onClick={() => setActiveCat(c)}>
                       {c}
                     </button>
                   ))}

--- a/frontend/src/components/portfolio/templates/Audio_First_Sonar_Navigation/index.jsx
+++ b/frontend/src/components/portfolio/templates/Audio_First_Sonar_Navigation/index.jsx
@@ -343,8 +343,8 @@ export default function AudioFirstSonarNavigation() {
           </motion.p>
           <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.55 }}
             style={{ display: "flex", flexWrap: "wrap", gap: 16, justifyContent: "center", marginBottom: 52 }}>
-            <button className="asn-btn asn-btn-primary" onClick={() => scrollTo("projects")}><Music size={14} />View Work</button>
-            <button className="asn-btn asn-btn-ghost" onClick={() => scrollTo("contact")}><Radio size={14} />Get In Touch</button>
+            <button type="button" className="asn-btn asn-btn-primary" onClick={() => scrollTo("projects")}><Music size={14} />View Work</button>
+            <button type="button" className="asn-btn asn-btn-ghost" onClick={() => scrollTo("contact")}><Radio size={14} />Get In Touch</button>
           </motion.div>
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.7 }}
             style={{

--- a/frontend/src/components/portfolio/templates/Audio_Visualizer_Frequency/index.jsx
+++ b/frontend/src/components/portfolio/templates/Audio_Visualizer_Frequency/index.jsx
@@ -159,7 +159,7 @@ export default function Audio_Visualizer_Frequency({ portfolioData }) {
 
         <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
           {SECTIONS.map(s => (
-            <button
+            <button type="button"
               key={s}
               onClick={() => setActive(s)}
               style={{
@@ -182,7 +182,7 @@ export default function Audio_Visualizer_Frequency({ portfolioData }) {
             </button>
           ))}
 
-          <button
+          <button type="button"
             onClick={() => setPlaying(p => !p)}
             style={{
               width: "36px",
@@ -292,7 +292,7 @@ export default function Audio_Visualizer_Frequency({ portfolioData }) {
               </div>
 
               <div style={{ display: "flex", gap: "16px" }}>
-                <button
+                <button type="button"
                   onClick={() => setActive("projects")}
                   style={{
                     padding: "14px 32px",
@@ -308,7 +308,7 @@ export default function Audio_Visualizer_Frequency({ portfolioData }) {
                 >
                   See My Work ◆
                 </button>
-                <button
+                <button type="button"
                   onClick={() => setActive("contact")}
                   style={{
                     padding: "14px 32px",

--- a/frontend/src/components/portfolio/templates/Blank_Canvas_Scratch_to_Reveal/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Blank_Canvas_Scratch_to_Reveal/Hero.jsx
@@ -63,7 +63,7 @@ export default function Hero() {
           className="flex flex-wrap items-center justify-center gap-4"
         >
           {/* Premium White/Black luxury button */}
-          <button 
+          <button type="button" 
             onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
             className="px-8 py-3.5 rounded-xl bg-white hover:bg-slate-200 text-black font-semibold transition-all shadow-[0_0_20px_rgba(255,255,255,0.1)] hover:shadow-[0_0_35px_rgba(255,255,255,0.25)] flex items-center gap-2 cursor-pointer group"
           >

--- a/frontend/src/components/portfolio/templates/Blank_Canvas_Scratch_to_Reveal/index.jsx
+++ b/frontend/src/components/portfolio/templates/Blank_Canvas_Scratch_to_Reveal/index.jsx
@@ -625,7 +625,7 @@ const featuredProjects = projects.filter(
                 </div>
 
                 {/* Skip button (Pointer events enabled) */}
-                <button
+                <button type="button"
                   onClick={revealAll}
                   className="pointer-events-auto px-6 py-2.5 rounded-lg bg-black border border-slate-800 hover:border-white text-[10px] font-mono tracking-widest uppercase text-slate-300 hover:text-white transition-all duration-300 cursor-pointer flex items-center gap-2 shadow-2xl"
                   aria-label="Skip scratching and reveal portfolio immediately"

--- a/frontend/src/components/portfolio/templates/Book_Page_Flip_3D_Render/index.jsx
+++ b/frontend/src/components/portfolio/templates/Book_Page_Flip_3D_Render/index.jsx
@@ -102,7 +102,7 @@ export default function Book_Page_Flip_3D_Render({ data: localData, portfolioDat
         </div>
         
         {bookState === 'open' && (
-          <button 
+          <button type="button" 
             onClick={handleCloseBook}
             className="flex items-center gap-2 border border-[#c5a059]/40 bg-black/30 hover:bg-[#c5a059]/10 text-[#c5a059] px-3.5 py-1.5 rounded-sm font-mono text-[10px] uppercase tracking-widest transition-all duration-300 active:scale-95"
           >
@@ -305,7 +305,7 @@ export default function Book_Page_Flip_3D_Render({ data: localData, portfolioDat
 
             {/* Quick action overlay page-turn buttons */}
             {currentPage > 0 && (
-              <button 
+              <button type="button" 
                 onClick={prevFlip}
                 className="absolute left-[-60px] top-1/2 -translate-y-1/2 w-11 h-11 rounded-full border border-[#c5a059]/40 bg-black/40 hover:bg-[#c5a059]/20 text-[#c5a059] flex items-center justify-center transition-all duration-300 active:scale-90 z-40"
               >
@@ -313,7 +313,7 @@ export default function Book_Page_Flip_3D_Render({ data: localData, portfolioDat
               </button>
             )}
             {currentPage < 13 && (
-              <button 
+              <button type="button" 
                 onClick={nextFlip}
                 className="absolute right-[-60px] top-1/2 -translate-y-1/2 w-11 h-11 rounded-full border border-[#c5a059]/40 bg-black/40 hover:bg-[#c5a059]/20 text-[#c5a059] flex items-center justify-center transition-all duration-300 active:scale-90 z-40"
               >
@@ -343,7 +343,7 @@ export default function Book_Page_Flip_3D_Render({ data: localData, portfolioDat
                 // Determine if this tab matches the current page spread
                 const isActive = (currentPage === tab.page || currentPage === tab.page + 1 || (tab.page === 0 && currentPage === 0));
                 return (
-                  <button
+                  <button type="button"
                     key={idx}
                     onClick={() => turnTo(tab.page)}
                     className={`px-3 py-1 font-mono text-[9px] uppercase tracking-wider rounded-sm transition-all duration-300 ${

--- a/frontend/src/components/portfolio/templates/Bouncing_DVD_Logo/index.jsx
+++ b/frontend/src/components/portfolio/templates/Bouncing_DVD_Logo/index.jsx
@@ -303,7 +303,7 @@ export default function Bouncing_DVD_Logo({ data: propData }) {
         <span style={styles.navBrand}>{data.name || defaultData.name}</span>
         <div style={styles.navLinks}>
           {SECTIONS.map(s => (
-            <button key={s} style={styles.navLink(activeSection === s)} onClick={() => setActiveSection(s)}>
+            <button type="button" key={s} style={styles.navLink(activeSection === s)} onClick={() => setActiveSection(s)}>
               {s}
             </button>
           ))}

--- a/frontend/src/components/portfolio/templates/Captcha_Solver_Portfolio_Gate/index.jsx
+++ b/frontend/src/components/portfolio/templates/Captcha_Solver_Portfolio_Gate/index.jsx
@@ -648,10 +648,10 @@ function CaptchaGate({ onVerified }) {
         </div>
 
         <div className="cpg-actions">
-          <button className="cpg-refresh-btn" onClick={refresh} title="Get new challenge">
+          <button type="button" className="cpg-refresh-btn" onClick={refresh} title="Get new challenge">
             <RefreshCw size={13} /> Refresh
           </button>
-          <button
+          <button type="button"
             className="cpg-verify-btn"
             onClick={verify}
             disabled={feedback === "success"}

--- a/frontend/src/components/portfolio/templates/Cartographer_Antiquity_Map_Room/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Cartographer_Antiquity_Map_Room/Contact.jsx
@@ -87,7 +87,7 @@ export default function Contact({ data }) {
                     className="w-full bg-[#f4ebd8] border border-[#c4a482] px-4 py-3 text-[#3e2723] font-serif focus:outline-none focus:border-[#5d4037] transition-colors resize-none"
                   ></textarea>
                 </div>
-                <button className="w-full py-4 border-2 border-[#5d4037] text-[#5d4037] font-bold tracking-widest uppercase hover:bg-[#5d4037] hover:text-[#f4ebd8] transition-colors flex items-center justify-center gap-2">
+                <button type="button" className="w-full py-4 border-2 border-[#5d4037] text-[#5d4037] font-bold tracking-widest uppercase hover:bg-[#5d4037] hover:text-[#f4ebd8] transition-colors flex items-center justify-center gap-2">
                   <span>Dispatch</span>
                   <Send className="w-4 h-4" />
                 </button>

--- a/frontend/src/components/portfolio/templates/Casino_Vegas/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Casino_Vegas/Hero.jsx
@@ -39,12 +39,12 @@ export default function Hero({ data }) {
         </p>
 
         <div className="flex flex-col items-center justify-center gap-6 sm:flex-row">
-          <button className="group flex items-center gap-3 rounded-full bg-gradient-to-r from-yellow-400 to-red-500 px-8 py-4 font-black uppercase tracking-wider text-black transition-all hover:scale-105 hover:shadow-[0_0_40px_rgba(250,204,21,0.6)]">
+          <button type="button" className="group flex items-center gap-3 rounded-full bg-gradient-to-r from-yellow-400 to-red-500 px-8 py-4 font-black uppercase tracking-wider text-black transition-all hover:scale-105 hover:shadow-[0_0_40px_rgba(250,204,21,0.6)]">
             See Projects
             <ArrowRight size={20} className="transition-transform group-hover:translate-x-1" />
           </button>
           
-          <button className="group flex items-center gap-3 rounded-full border-2 border-yellow-500/50 bg-black/50 px-8 py-4 font-black uppercase tracking-wider text-yellow-400 backdrop-blur-md transition-all hover:bg-yellow-500/10 hover:shadow-[0_0_30px_rgba(250,204,21,0.2)]">
+          <button type="button" className="group flex items-center gap-3 rounded-full border-2 border-yellow-500/50 bg-black/50 px-8 py-4 font-black uppercase tracking-wider text-yellow-400 backdrop-blur-md transition-all hover:bg-yellow-500/10 hover:shadow-[0_0_30px_rgba(250,204,21,0.2)]">
             Download CV
             <Download size={20} className="transition-transform group-hover:translate-y-1" />
           </button>

--- a/frontend/src/components/portfolio/templates/Casino_Vegas/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Casino_Vegas/Projects.jsx
@@ -105,12 +105,12 @@ export default function Projects() {
 
                 {/* Buttons */}
                 <div className="flex items-center gap-4">
-                  <button className="flex items-center gap-2 rounded-full bg-yellow-400 px-5 py-2 font-semibold text-black transition hover:scale-105 hover:bg-yellow-300">
+                  <button type="button" className="flex items-center gap-2 rounded-full bg-yellow-400 px-5 py-2 font-semibold text-black transition hover:scale-105 hover:bg-yellow-300">
                     Live Demo
                     <ExternalLink size={18} />
                   </button>
 
-                  <button className="flex items-center gap-2 rounded-full border border-yellow-400 px-5 py-2 font-semibold text-yellow-300 transition hover:bg-yellow-400 hover:text-black">
+                  <button type="button" className="flex items-center gap-2 rounded-full border border-yellow-400 px-5 py-2 font-semibold text-yellow-300 transition hover:bg-yellow-400 hover:text-black">
                     Code
                     <Github size={18} />
                   </button>

--- a/frontend/src/components/portfolio/templates/Casino_Vegas/ResumeCTA.jsx
+++ b/frontend/src/components/portfolio/templates/Casino_Vegas/ResumeCTA.jsx
@@ -72,7 +72,7 @@ export default function ResumeCTA() {
 
           {/* CTA Buttons */}
           <div className="mt-16 flex flex-col items-center justify-center gap-5 sm:flex-row">
-            <button className="group flex items-center gap-3 rounded-full bg-gradient-to-r from-yellow-400 via-orange-500 to-red-500 px-9 py-4 text-lg font-black uppercase tracking-wide text-black transition-all duration-300 hover:scale-105 hover:shadow-[0_0_35px_rgba(250,204,21,0.6)]">
+            <button type="button" className="group flex items-center gap-3 rounded-full bg-gradient-to-r from-yellow-400 via-orange-500 to-red-500 px-9 py-4 text-lg font-black uppercase tracking-wide text-black transition-all duration-300 hover:scale-105 hover:shadow-[0_0_35px_rgba(250,204,21,0.6)]">
               Download Resume
               <Download
                 size={22}
@@ -80,7 +80,7 @@ export default function ResumeCTA() {
               />
             </button>
 
-            <button className="group flex items-center gap-3 rounded-full border border-yellow-400/40 bg-white/5 px-9 py-4 text-lg font-black uppercase tracking-wide text-yellow-300 backdrop-blur-md transition-all duration-300 hover:border-yellow-300 hover:bg-yellow-400 hover:text-black">
+            <button type="button" className="group flex items-center gap-3 rounded-full border border-yellow-400/40 bg-white/5 px-9 py-4 text-lg font-black uppercase tracking-wide text-yellow-300 backdrop-blur-md transition-all duration-300 hover:border-yellow-300 hover:bg-yellow-400 hover:text-black">
               Explore Portfolio
               <ArrowRight
                 size={22}

--- a/frontend/src/components/portfolio/templates/Casino_Vegas/SlotMachine.jsx
+++ b/frontend/src/components/portfolio/templates/Casino_Vegas/SlotMachine.jsx
@@ -453,7 +453,7 @@ export default function SlotMachine() {
                 
                 {/* Audio and Cheat Controls inside cabinet */}
                 <div className="flex items-center gap-3">
-                  <button
+                  <button type="button"
                     onClick={() => {
                       setVolumeOn(!volumeOn);
                       playRetroSound("tick");
@@ -464,7 +464,7 @@ export default function SlotMachine() {
                     {volumeOn ? <Volume2 size={18} /> : <VolumeX size={18} />}
                   </button>
 
-                  <button
+                  <button type="button"
                     onClick={() => {
                       setIsCheatMode(!isCheatMode);
                       playRetroSound("tick");
@@ -579,7 +579,7 @@ export default function SlotMachine() {
                 </div>
 
                 {/* Big Spin Button */}
-                <button
+                <button type="button"
                   onClick={handleSpin}
                   disabled={isSpinning.some(Boolean) || credits <= 0}
                   className={`w-full md:w-auto min-w-[180px] h-14 rounded-2xl flex items-center justify-center gap-3.5 text-base font-black uppercase tracking-widest text-black transition-all cursor-pointer relative overflow-hidden select-none ${

--- a/frontend/src/components/portfolio/templates/Cassette_Mixtape/index.jsx
+++ b/frontend/src/components/portfolio/templates/Cassette_Mixtape/index.jsx
@@ -368,7 +368,7 @@ function Nav() {
             Hire Me ▶
           </a>
 
-          <button onClick={() => setOpen(o => !o)} className="flex md:hidden"
+          <button type="button" onClick={() => setOpen(o => !o)} className="flex md:hidden"
             style={{ background: 'none', border: `1px solid ${C.tape}`, color: C.cream,
               cursor: 'pointer', padding: '5px 7px', display: 'flex' }}>
             {open ? <X size={20} /> : <Menu size={20} />}
@@ -772,7 +772,7 @@ function Projects() {
                 transition={{ delay: i * 0.07, duration: 0.45 }}>
 
                 {/* Track row — clickable to expand */}
-                <button
+                <button type="button"
                   onClick={() => setActiveTrack(isActive ? null : i)}
                   style={{ width: '100%', background: isActive ? '#FFF4E0' : (i % 2 === 0 ? '#FFF8EC' : '#FFF3E8'),
                     border: 'none', borderBottom: `1px solid ${C.light}44`,
@@ -1043,7 +1043,7 @@ function Contact() {
                   <p style={{ color: C.light, fontFamily: C.mono, fontSize: '0.84rem' }}>
                     I'll play it back soon. ▶
                   </p>
-                  <button onClick={() => { setStatus('idle'); setForm({ name:'',email:'',message:'' }); }}
+                  <button type="button" onClick={() => { setStatus('idle'); setForm({ name:'',email:'',message:'' }); }}
                     className="cm-btn" style={{ background: C.orange, color: '#FAF0E0',
                       marginTop: 24 }}>
                     Record Another ◉

--- a/frontend/src/components/portfolio/templates/Chalkboard_Education/ResumeCTA.jsx
+++ b/frontend/src/components/portfolio/templates/Chalkboard_Education/ResumeCTA.jsx
@@ -34,7 +34,7 @@ export default function ResumeCTA() {
         {/* CTA Buttons */}
         <div className="mt-12 flex flex-col items-center justify-center gap-5 sm:flex-row">
           
-          <button className="group flex items-center gap-3 rounded-2xl border-2 border-green-300 bg-green-200 px-8 py-4 text-lg font-bold text-[#1b1b1b] transition-all duration-300 hover:scale-105 hover:shadow-[0_0_25px_rgba(134,239,172,0.45)]">
+          <button type="button" className="group flex items-center gap-3 rounded-2xl border-2 border-green-300 bg-green-200 px-8 py-4 text-lg font-bold text-[#1b1b1b] transition-all duration-300 hover:scale-105 hover:shadow-[0_0_25px_rgba(134,239,172,0.45)]">
             <Download
               size={22}
               className="transition-transform duration-300 group-hover:-translate-y-1"
@@ -42,7 +42,7 @@ export default function ResumeCTA() {
             Download Resume
           </button>
 
-          <button className="group flex items-center gap-3 rounded-2xl border-2 border-dashed border-white/40 bg-white/5 px-8 py-4 text-lg font-semibold text-white transition-all duration-300 hover:scale-105 hover:bg-white/10">
+          <button type="button" className="group flex items-center gap-3 rounded-2xl border-2 border-dashed border-white/40 bg-white/5 px-8 py-4 text-lg font-semibold text-white transition-all duration-300 hover:scale-105 hover:bg-white/10">
             <FileText
               size={22}
               className="transition-transform duration-300 group-hover:rotate-6"

--- a/frontend/src/components/portfolio/templates/Chatbot_Portfolio/index.jsx
+++ b/frontend/src/components/portfolio/templates/Chatbot_Portfolio/index.jsx
@@ -257,7 +257,7 @@ export default function ChatbotPortfolio() {
       {/* FIX: SUGGESTIONS (added spacing + visual separation) */}
       <div className="px-4 py-3 border-t border-gray-800 bg-gray-950/60 backdrop-blur flex flex-wrap gap-2">
         {suggestions.map((s, i) => (
-          <button
+          <button type="button"
             key={i}
             onClick={() => setInput(s)}
             className="text-xs px-3 py-1 bg-gray-800 rounded-full hover:bg-gray-700 transition"
@@ -276,7 +276,7 @@ export default function ChatbotPortfolio() {
           placeholder="Ask about me..."
           className="flex-1 px-4 py-2 rounded-xl bg-gray-900 border border-gray-700"
         />
-        <button
+        <button type="button"
           onClick={handleSend}
           className="bg-cyan-600 px-4 py-2 rounded-xl hover:bg-cyan-700"
         >

--- a/frontend/src/components/portfolio/templates/ChiragChrg_Theme/index.jsx
+++ b/frontend/src/components/portfolio/templates/ChiragChrg_Theme/index.jsx
@@ -100,7 +100,7 @@ const ChiragChrg_Theme = () => {
 
           {/* Theme Switcher */}
           <div className="relative">
-            <button 
+            <button type="button" 
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               className="flex items-center gap-2 px-3 py-1.5 bg-white/5 hover:bg-white/10 border border-white/10 rounded-md transition-colors"
             >
@@ -112,7 +112,7 @@ const ChiragChrg_Theme = () => {
             {isDropdownOpen && (
               <div className="absolute top-full right-0 mt-2 w-40 bg-[#18181b] border border-white/10 rounded-lg shadow-xl overflow-hidden py-1 z-50">
                 {themes.map(t => (
-                  <button
+                  <button type="button"
                     key={t.name}
                     onClick={() => {
                       setThemeName(t.name);

--- a/frontend/src/components/portfolio/templates/Choose_Adventure/StoryEngine.jsx
+++ b/frontend/src/components/portfolio/templates/Choose_Adventure/StoryEngine.jsx
@@ -20,7 +20,7 @@ export default function StoryEngine({ node, onChoice, onReset, history = [] }) {
 
       <div className="relative z-10 w-full max-w-2xl">
         {history.length > 0 && (
-          <button
+          <button type="button"
             onClick={onReset}
             className="mb-8 flex items-center gap-2 text-xs text-violet-400 hover:text-violet-200 transition-colors"
           >

--- a/frontend/src/components/portfolio/templates/Choose_Adventure/index.jsx
+++ b/frontend/src/components/portfolio/templates/Choose_Adventure/index.jsx
@@ -105,7 +105,7 @@ export default function ChooseAdventurePortfolio() {
           </span>
           <div className="hidden sm:flex items-center gap-1">
             {['about', 'skills', 'projects', 'experience', 'testimonials', 'contact'].map((s) => (
-              <button
+              <button type="button"
                 key={s}
                 onClick={() => navigate(s)}
                 className={`px-3 py-1 rounded-lg text-xs transition-colors capitalize ${scene === s ? 'bg-violet-800/50 text-white' : 'text-slate-500 hover:text-slate-200'}`}
@@ -114,7 +114,7 @@ export default function ChooseAdventurePortfolio() {
               </button>
             ))}
           </div>
-          <button
+          <button type="button"
             onClick={reset}
             className="text-xs text-slate-600 hover:text-slate-400 transition-colors"
           >
@@ -137,7 +137,7 @@ export default function ChooseAdventurePortfolio() {
         <div className="fixed bottom-4 right-4 z-50 font-mono">
           <div className="flex gap-1">
             {['about', 'skills', 'projects', 'experience', 'testimonials', 'contact'].map((s) => (
-              <button
+              <button type="button"
                 key={s}
                 onClick={() => navigate(s)}
                 aria-label={`Go to ${s}`}

--- a/frontend/src/components/portfolio/templates/Choose_Adventure/sections/ContactSection.jsx
+++ b/frontend/src/components/portfolio/templates/Choose_Adventure/sections/ContactSection.jsx
@@ -163,7 +163,7 @@ export default function ContactSection({ data, onReset }) {
               <p className="text-slate-400 text-sm mb-6">
                 Thanks, {form.name}. The adventure continues — I'll be in touch soon.
               </p>
-              <button
+              <button type="button"
                 onClick={() => { setSubmitted(false); setForm({ name: '', email: '', message: '' }); }}
                 className="text-xs text-violet-400 hover:text-violet-200 transition-colors flex items-center gap-1 mx-auto"
               >

--- a/frontend/src/components/portfolio/templates/Choose_Adventure/sections/ProjectsSection.jsx
+++ b/frontend/src/components/portfolio/templates/Choose_Adventure/sections/ProjectsSection.jsx
@@ -116,7 +116,7 @@ export default function ProjectsSection({ data, onChoice }) {
           </div>
 
           <div className="flex items-center justify-between px-6 pb-5">
-            <button
+            <button type="button"
               onClick={() => setActiveIndex((p) => Math.max(0, p - 1))}
               disabled={activeIndex === 0}
               className="flex items-center gap-1 text-xs text-slate-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
@@ -126,7 +126,7 @@ export default function ProjectsSection({ data, onChoice }) {
             </button>
             <div className="flex gap-1.5">
               {projects.map((p, i) => (
-                <button
+                <button type="button"
                   key={i}
                   onClick={() => setActiveIndex(i)}
                   aria-label={`View project: ${p.title}`}
@@ -135,7 +135,7 @@ export default function ProjectsSection({ data, onChoice }) {
                 />
               ))}
             </div>
-            <button
+            <button type="button"
               onClick={() => setActiveIndex((p) => Math.min(projects.length - 1, p + 1))}
               disabled={activeIndex === projects.length - 1}
               className="flex items-center gap-1 text-xs text-slate-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors"

--- a/frontend/src/components/portfolio/templates/Choose_Adventure/sections/TestimonialsSection.jsx
+++ b/frontend/src/components/portfolio/templates/Choose_Adventure/sections/TestimonialsSection.jsx
@@ -83,7 +83,7 @@ export default function TestimonialsSection({ data, onChoice }) {
           </AnimatePresence>
 
           <div className="flex items-center justify-between mt-8 pt-6 border-t border-violet-800/30">
-            <button
+            <button type="button"
               onClick={prev}
               className="flex items-center gap-1 text-xs text-slate-400 hover:text-white transition-colors"
             >
@@ -92,7 +92,7 @@ export default function TestimonialsSection({ data, onChoice }) {
             </button>
             <div className="flex gap-1.5">
               {testimonials.map((t, i) => (
-                <button
+                <button type="button"
                   key={i}
                   onClick={() => setActive(i)}
                   aria-label={`View testimonial from ${t.name}`}
@@ -101,7 +101,7 @@ export default function TestimonialsSection({ data, onChoice }) {
                 />
               ))}
             </div>
-            <button
+            <button type="button"
               onClick={next}
               className="flex items-center gap-1 text-xs text-slate-400 hover:text-white transition-colors"
             >

--- a/frontend/src/components/portfolio/templates/Chromatic_Glitch/index.jsx
+++ b/frontend/src/components/portfolio/templates/Chromatic_Glitch/index.jsx
@@ -351,15 +351,15 @@ export default function ChromaticGlitch() {
 
       {/* ── Navbar ── */}
       <nav className="cg-nav">
-        <button className="cg-nav-link" onClick={() => scrollTo("hero")} style={{ fontSize: 15, fontWeight: 700 }}>
+        <button type="button" className="cg-nav-link" onClick={() => scrollTo("hero")} style={{ fontSize: 15, fontWeight: 700 }}>
           <span className="cg-gradient-text">GLITCH</span>
         </button>
         <div className="cg-nav-links-desktop">
           {sections.map((s) => (
-            <button key={s} className="cg-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
+            <button type="button" key={s} className="cg-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
           ))}
         </div>
-        <button
+        <button type="button"
           className="cg-hamburger"
           onClick={() => setMenuOpen(!menuOpen)}
           style={{ background: "none", border: "none", color: "#e0e0ff", cursor: "pointer", padding: 4 }}
@@ -377,7 +377,7 @@ export default function ChromaticGlitch() {
             initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }}
             style={{ position: "fixed", top: 60, left: 0, right: 0, zIndex: 49 }}>
             {sections.map((s) => (
-              <button key={s} className="cg-nav-link" onClick={() => scrollTo(s.toLowerCase())}
+              <button type="button" key={s} className="cg-nav-link" onClick={() => scrollTo(s.toLowerCase())}
                 style={{ textAlign: "left", padding: "10px 0", fontSize: 12, color: "#e0e0ff" }}>
                 <span style={{ color: "#00ffff", marginRight: 8 }}>//</span>{s}
               </button>
@@ -415,10 +415,10 @@ export default function ChromaticGlitch() {
 
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.4 }}
               style={{ display: "flex", flexWrap: "wrap", gap: 16, marginBottom: 48 }}>
-              <button className="cg-btn cg-btn-primary" onClick={() => scrollTo("projects")}>
+              <button type="button" className="cg-btn cg-btn-primary" onClick={() => scrollTo("projects")}>
                 <Zap size={14} /><span>View Work</span>
               </button>
-              <button className="cg-btn cg-btn-secondary" onClick={() => scrollTo("contact")}>
+              <button type="button" className="cg-btn cg-btn-secondary" onClick={() => scrollTo("contact")}>
                 <span>Contact</span>
               </button>
             </motion.div>

--- a/frontend/src/components/portfolio/templates/Cinematic/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Cinematic/Hero.jsx
@@ -92,13 +92,13 @@ export default function Hero({ data }) {
 
           {/* Actions */}
           <div className="animate-cinematic flex flex-col sm:flex-row gap-4 sm:gap-6 items-center w-full sm:w-auto px-4" style={{ animationDelay: '2.2s' }}>
-            <button className="group relative flex items-center justify-center gap-3 px-10 py-4 bg-white text-black font-bold uppercase tracking-[0.2em] text-xs sm:text-sm rounded-sm hover:bg-neutral-200 transition-all duration-500 overflow-hidden w-full sm:w-auto shadow-[0_0_30px_rgba(255,255,255,0.1)] hover:shadow-[0_0_40px_rgba(255,255,255,0.2)]">
+            <button type="button" className="group relative flex items-center justify-center gap-3 px-10 py-4 bg-white text-black font-bold uppercase tracking-[0.2em] text-xs sm:text-sm rounded-sm hover:bg-neutral-200 transition-all duration-500 overflow-hidden w-full sm:w-auto shadow-[0_0_30px_rgba(255,255,255,0.1)] hover:shadow-[0_0_40px_rgba(255,255,255,0.2)]">
               <div className="absolute inset-0 bg-neutral-900/10 translate-y-full group-hover:translate-y-0 transition-transform duration-500 ease-out"></div>
               <Play size={16} className="fill-black group-hover:scale-110 transition-transform duration-500" />
               <span className="relative z-10">Play Showreel</span>
             </button>
             
-            <button className="group flex items-center justify-center gap-2 px-10 py-4 bg-transparent border border-neutral-700 text-white font-bold uppercase tracking-[0.2em] text-xs sm:text-sm rounded-sm hover:border-neutral-400 hover:text-white transition-all duration-500 w-full sm:w-auto">
+            <button type="button" className="group flex items-center justify-center gap-2 px-10 py-4 bg-transparent border border-neutral-700 text-white font-bold uppercase tracking-[0.2em] text-xs sm:text-sm rounded-sm hover:border-neutral-400 hover:text-white transition-all duration-500 w-full sm:w-auto">
               <span className="group-hover:translate-x-1 transition-transform duration-500">View Credits</span>
               <ChevronRight size={16} className="group-hover:translate-x-2 transition-transform duration-500 text-neutral-500 group-hover:text-white" />
             </button>

--- a/frontend/src/components/portfolio/templates/Coffee_Shop/MenuBoard.jsx
+++ b/frontend/src/components/portfolio/templates/Coffee_Shop/MenuBoard.jsx
@@ -286,7 +286,7 @@ export default function MenuBoard({ data }) {
             {/* Menu Category Selection Tags - styled like hanging chalkboard tags */}
             <div className="flex gap-2.5 mb-0 overflow-x-auto pb-2 scrollbar-hide select-none">
               {categories.map((cat) => (
-                <button
+                <button type="button"
                   key={cat.id}
                   onClick={() => setActiveCategory(cat.id)}
                   className={`flex items-center gap-2 px-6 py-3.5 rounded-t-2xl font-serif text-sm tracking-wider uppercase transition-all duration-300 relative border-b-0 ${
@@ -418,7 +418,7 @@ export default function MenuBoard({ data }) {
                                   <ExternalLink className="w-3.5 h-3.5" />
                                 </a>
                               )}
-                              <button
+                              <button type="button"
                                 onClick={() => addToOrder(item)}
                                 disabled={isAdded}
                                 className={`flex items-center gap-1.5 text-xs font-mono font-extrabold px-3.5 py-2 rounded-xl transition-all cursor-pointer ${
@@ -610,7 +610,7 @@ export default function MenuBoard({ data }) {
                       <p className="text-xs text-stone-200 leading-relaxed mb-4 font-semibold">{brewedCup.desc}</p>
                       
                       <div className="flex flex-wrap gap-2.5 items-center justify-center md:justify-start">
-                        <button
+                        <button type="button"
                           onClick={() => {
                             addToOrder({
                               id: `custom-brew-${Date.now()}`,
@@ -627,7 +627,7 @@ export default function MenuBoard({ data }) {
                           Add custom brew to order
                         </button>
                         
-                        <button
+                        <button type="button"
                           onClick={() => setBrewedCup(null)}
                           className="border border-stone-600 hover:bg-stone-800 text-stone-200 font-mono text-xs px-4 py-2.5 rounded-xl font-bold flex items-center gap-1.5 transition-all cursor-pointer"
                         >
@@ -642,7 +642,7 @@ export default function MenuBoard({ data }) {
                     <p className="text-xs text-amber-100 font-semibold max-w-md leading-relaxed mb-5">
                       Select a Base, Flavor Syrup, and Sweetener in the panel above, then activate the brewer to generate a custom project card recipe.
                     </p>
-                    <button
+                    <button type="button"
                       onClick={handleBrew}
                       disabled={!brewBase || !brewFlavor || !brewSweetener}
                       className={`font-mono text-sm px-6 py-3 rounded-xl font-black uppercase tracking-wider transition-all duration-300 cursor-pointer ${
@@ -725,7 +725,7 @@ export default function MenuBoard({ data }) {
                             </div>
                             <div className="flex items-center gap-2 font-mono">
                               <span className="font-extrabold text-[#2c1a11]">{item.price}</span>
-                              <button 
+                              <button type="button" 
                                 onClick={() => removeFromOrder(item.id)}
                                 className="text-stone-400 hover:text-red-700 hover:bg-stone-200/50 p-1 rounded transition-colors cursor-pointer"
                                 title="Remove item"
@@ -763,7 +763,7 @@ export default function MenuBoard({ data }) {
 
                 {/* Receipt Footer Action - Highly visible buttons */}
                 <div className="mt-8">
-                  <button
+                  <button type="button"
                     disabled={orderItems.length === 0}
                     onClick={() => setShowInquiryModal(true)}
                     className="w-full font-mono text-xs font-black uppercase tracking-widest py-3.5 rounded-xl flex items-center justify-center gap-2 transition-all duration-300 cursor-pointer bg-amber-900 text-white hover:bg-[#522b13] shadow-md shadow-amber-900/20 active:translate-y-[1px] disabled:bg-stone-300 disabled:text-stone-600 disabled:border disabled:border-stone-400/60 disabled:shadow-none disabled:cursor-not-allowed"

--- a/frontend/src/components/portfolio/templates/Color_Block/index.jsx
+++ b/frontend/src/components/portfolio/templates/Color_Block/index.jsx
@@ -303,12 +303,12 @@ export default function ColorBlock() {
 
       {/* ── Navbar ── */}
       <nav className="cb-nav">
-        <button className="cb-nav-brand" onClick={() => scrollTo("hero")}>
+        <button type="button" className="cb-nav-brand" onClick={() => scrollTo("hero")}>
           {data.personal.name.split(" ")[0]}
         </button>
         <div className="cb-nav-links">
           {sections.map((s, i) => (
-            <button key={s} className="cb-nav-link"
+            <button type="button" key={s} className="cb-nav-link"
               style={{ background: i === 0 ? M.red : i === 1 ? M.blue : "none", color: (i === 0 || i === 1) ? M.white : M.black }}
               onClick={() => scrollTo(s.toLowerCase())}>
               {s}
@@ -316,7 +316,7 @@ export default function ColorBlock() {
           ))}
           <div className="cb-nav-spacer" />
         </div>
-        <button className="cb-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+        <button type="button" className="cb-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
           {[0,1,2].map(i => <div key={i} style={{ width: 22, height: 3, background: M.black, margin: "3px 0", transition: "all .2s",
             transform: menuOpen ? (i === 0 ? "rotate(45deg) translate(4px,4px)" : i === 2 ? "rotate(-45deg) translate(4px,-4px)" : "none") : "none",
             opacity: menuOpen && i === 1 ? 0 : 1,
@@ -328,7 +328,7 @@ export default function ColorBlock() {
         {menuOpen && (
           <motion.div className="cb-mobile-menu" initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}>
             {sections.map((s, i) => (
-              <button key={s} className="cb-mobile-link"
+              <button type="button" key={s} className="cb-mobile-link"
                 style={{ background: [M.red, M.blue, M.yellow, M.white, M.red, M.blue][i] || M.white,
                          color: [M.white, M.white, M.black, M.black, M.white, M.white][i] }}
                 onClick={() => scrollTo(s.toLowerCase())}>
@@ -349,7 +349,7 @@ export default function ColorBlock() {
               {data.personal.name}
             </h1>
             <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
-              <button className="cb-btn cb-btn-red" onClick={() => scrollTo("projects")}><span>View Work</span></button>
+              <button type="button" className="cb-btn cb-btn-red" onClick={() => scrollTo("projects")}><span>View Work</span></button>
               <a href={resumeUrl} className="cb-btn cb-btn-black"><span>Resume</span></a>
             </div>
           </motion.div>

--- a/frontend/src/components/portfolio/templates/Comic_Book/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Comic_Book/Contact.jsx
@@ -55,7 +55,7 @@ export default function Contact({ personal, socials }) {
                 <label className="font-black uppercase text-black text-lg tracking-wider">Transmission</label>
                 <textarea rows={4} placeholder="We need your help!" className="w-full border-4 border-black p-4 font-bold text-black focus:outline-none focus:ring-4 focus:ring-sky-400 bg-gray-50 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] resize-none" />
               </div>
-              <button className="bg-red-500 hover:bg-red-600 text-white font-black uppercase text-xl px-8 py-4 border-4 border-black shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:translate-y-1 hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all flex justify-center items-center gap-3">
+              <button type="button" className="bg-red-500 hover:bg-red-600 text-white font-black uppercase text-xl px-8 py-4 border-4 border-black shadow-[6px_6px_0px_0px_rgba(0,0,0,1)] hover:translate-y-1 hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-all flex justify-center items-center gap-3">
                 <Send className="w-6 h-6" /> Send Message
               </button>
             </form>

--- a/frontend/src/components/portfolio/templates/Commercial_Pilot_Cockpit/index.jsx
+++ b/frontend/src/components/portfolio/templates/Commercial_Pilot_Cockpit/index.jsx
@@ -1077,7 +1077,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                     { id: 'nd', label: 'ND / WORK' },
                     { id: 'cdu', label: 'CDU / COMMS' }
                   ].map((tab) => (
-                    <button
+                    <button type="button"
                       key={tab.id}
                       onClick={() => setActiveTab(tab.id)}
                       className={`font-mono text-[9px] font-bold px-2.5 py-1 rounded transition-all cursor-pointer ${activeTab === tab.id
@@ -1091,7 +1091,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <button
+                  <button type="button"
                     onClick={handleReplay}
                     className="flex items-center justify-center w-6 h-6 rounded bg-slate-900 border border-slate-800 text-slate-400 hover:text-white hover:bg-slate-800 cursor-pointer"
                     title="Replay Flight Intro"
@@ -1226,7 +1226,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                   <div className="col-span-4 flex flex-col justify-center gap-2 border-r border-slate-800/80 pr-2">
                     <span className="font-mono text-[8px] text-slate-500 uppercase tracking-widest mb-1">Radar Targets</span>
                     {projects.map((proj, idx) => (
-                      <button
+                      <button type="button"
                         key={idx}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1326,7 +1326,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                   <div className="h-[22%] bg-black/40 border border-slate-800/80 rounded p-2 flex items-center justify-around relative overflow-hidden">
                     <div className="absolute w-[80%] h-0.5 bg-dashed border-t border-sky-500/30 top-1/2 left-10 -translate-y-1/2 pointer-events-none" />
                     {experience.map((exp, idx) => (
-                      <button
+                      <button type="button"
                         key={idx}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1447,7 +1447,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                 {/* FMC Left side line select keys */}
                 <div className="col-span-2 flex flex-col gap-1.5 justify-around h-full py-1">
                   {[1, 2, 3, 4].map((i) => (
-                    <button
+                    <button type="button"
                       key={i}
                       onClick={() => setActiveTab(i === 1 ? 'pfd' : i === 2 ? 'mfd' : i === 3 ? 'nd' : 'cdu')}
                       className="w-8 h-4 bg-slate-900 border border-slate-700 rounded-sm hover:bg-[#00d2ff]/20 transition-all cursor-pointer"
@@ -1458,7 +1458,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                 {/* Main letter pad buttons */}
                 <div className="col-span-8 h-full grid grid-cols-6 gap-1.5 p-1 bg-slate-950 border border-slate-800 rounded">
                   {['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X'].map((char) => (
-                    <button
+                    <button type="button"
                       key={char}
                       onClick={() => {
                         if (char === 'B') setActiveTab('pfd');
@@ -1476,7 +1476,7 @@ export default function Commercial_Pilot_Cockpit({ data: localData, portfolioDat
                 {/* FMC Right side function select keys */}
                 <div className="col-span-2 flex flex-col gap-1.5 justify-around h-full py-1">
                   {['INIT', 'RTE', 'DEP', 'ARR'].map((fn, idx) => (
-                    <button
+                    <button type="button"
                       key={fn}
                       onClick={() => setActiveTab(idx === 0 ? 'pfd' : idx === 1 ? 'mfd' : idx === 2 ? 'nd' : 'cdu')}
                       className="h-4 bg-[#2a303a] border border-slate-700 rounded-sm text-[7px] font-bold font-mono text-slate-400 hover:text-white flex items-center justify-center active:scale-95 transition-transform cursor-pointer"

--- a/frontend/src/components/portfolio/templates/Culinary_Restaurant/About.jsx
+++ b/frontend/src/components/portfolio/templates/Culinary_Restaurant/About.jsx
@@ -216,7 +216,7 @@ export default function About() {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
             {VALUES.map(({ icon: Icon, title, desc }, i) => (
-             <button
+             <button type="button"
                 key={title}
                 onClick={() => setActiveValue(i)}
                 aria-pressed={activeValue === i}

--- a/frontend/src/components/portfolio/templates/Culinary_Restaurant/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Culinary_Restaurant/Contact.jsx
@@ -167,7 +167,7 @@ export default function Contact({ personal, socials }) {
                 </div>
 
                 <div className="pt-6">
-                  <button className="w-full py-4 bg-[#c5a880] hover:bg-[#d4b896] text-[#0a0a0a] font-bold text-sm tracking-[0.2em] uppercase transition-colors duration-300">
+                  <button type="button" className="w-full py-4 bg-[#c5a880] hover:bg-[#d4b896] text-[#0a0a0a] font-bold text-sm tracking-[0.2em] uppercase transition-colors duration-300">
                     Request Booking
                   </button>
                 </div>

--- a/frontend/src/components/portfolio/templates/Culinary_Restaurant/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Culinary_Restaurant/Hero.jsx
@@ -98,12 +98,12 @@ export default function Hero() {
 
             {/* CTA Buttons */}
             <div className="flex flex-col sm:flex-row gap-4 pt-2">
-              <button className="group flex items-center justify-center gap-2 px-8 py-4 bg-amber-500 hover:bg-amber-400 text-black font-semibold text-sm tracking-wide rounded-full transition-all duration-300"
+              <button type="button" className="group flex items-center justify-center gap-2 px-8 py-4 bg-amber-500 hover:bg-amber-400 text-black font-semibold text-sm tracking-wide rounded-full transition-all duration-300"
                 style={{ fontFamily: 'sans-serif' }}>
                 View Signature Menu
                 <ArrowRight size={16} />
               </button>
-              <button className="flex items-center justify-center gap-2 px-8 py-4 border border-white/15 hover:border-amber-500/50 text-white/80 hover:text-white font-medium text-sm tracking-wide rounded-full transition-all duration-300 hover:bg-white/5"
+              <button type="button" className="flex items-center justify-center gap-2 px-8 py-4 border border-white/15 hover:border-amber-500/50 text-white/80 hover:text-white font-medium text-sm tracking-wide rounded-full transition-all duration-300 hover:bg-white/5"
                 style={{ fontFamily: 'sans-serif' }}>
                 Book a Private Event
               </button>

--- a/frontend/src/components/portfolio/templates/Culinary_Restaurant/RecipeCards.jsx
+++ b/frontend/src/components/portfolio/templates/Culinary_Restaurant/RecipeCards.jsx
@@ -96,7 +96,7 @@ export default function RecipeCards() {
                   </div>
                 </div>
 
-                <button className="flex items-center gap-3 text-[#c5a880] font-medium tracking-widest uppercase text-xs group/btn w-fit overflow-hidden">
+                <button type="button" className="flex items-center gap-3 text-[#c5a880] font-medium tracking-widest uppercase text-xs group/btn w-fit overflow-hidden">
                   <span className="relative z-10">View Recipe</span>
                   <ArrowRight className="w-4 h-4 group-hover/btn:translate-x-2 transition-transform duration-300 relative z-10" />
                 </button>

--- a/frontend/src/components/portfolio/templates/CyberSecurity_Hacker/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/CyberSecurity_Hacker/Contact.jsx
@@ -260,7 +260,7 @@ export default function Contact() {
                 </div>
                 <p style={{ color: '#00ff41', fontWeight: 700, letterSpacing: '0.2em', fontSize: 16 }}>TRANSMISSION COMPLETE</p>
                 <p style={{ color: '#00ff4166', fontSize: 12, fontFamily: "'Courier New',monospace" }}>Message encrypted and delivered.<br />Operator will respond via secure channel.</p>
-                <button
+                <button type="button"
                   onClick={() => { setStatus('idle'); setForm({ name: '', email: '', message: '' }); setLog([]); }}
                   style={{ marginTop: 8, border: '1px solid #00ff4155', color: '#00ff41', background: 'transparent', padding: '8px 20px', borderRadius: 4, cursor: 'pointer', fontFamily: "'Courier New',monospace", fontSize: 12 }}
                 >

--- a/frontend/src/components/portfolio/templates/CyberSecurity_Hacker/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/CyberSecurity_Hacker/Hero.jsx
@@ -214,7 +214,7 @@ export default function Hero() {
 
         {/* Buttons */}
         <div className="flex flex-col sm:flex-row gap-3 w-full max-w-lg justify-center">
-          <button
+          <button type="button"
             className="group relative px-7 py-3 font-mono font-bold text-[12px] tracking-[0.12em] uppercase overflow-hidden transition-all w-full sm:w-auto"
             style={{ background: '#00ff41', color: '#000', border: '2px solid #00ff41' }}
             onMouseEnter={e => { e.currentTarget.style.background = '#fff'; e.currentTarget.style.borderColor = '#fff'; }}
@@ -227,7 +227,7 @@ export default function Hero() {
             <div className="absolute inset-0 pointer-events-none"
               style={{ background: 'linear-gradient(90deg,transparent,rgba(255,255,255,0.35),transparent)', transform: 'skewX(-20deg)', animation: 'sweep 3s ease-in-out infinite 1s' }} />
           </button>
-          <button
+          <button type="button"
             className="px-7 py-3 font-mono text-[12px] tracking-[0.12em] uppercase transition-all w-full sm:w-auto"
             style={{ background: 'transparent', color: '#ff0040', border: '2px solid #ff0040' }}
             onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,0,64,0.15)'; e.currentTarget.style.color = '#ff4d77'; }}

--- a/frontend/src/components/portfolio/templates/Cyber_Security_Red_Team/Arsenal.jsx
+++ b/frontend/src/components/portfolio/templates/Cyber_Security_Red_Team/Arsenal.jsx
@@ -150,7 +150,7 @@ export function Arsenal() {
             {/* MODIFIED: Removed the extreme mt-10/lg:mt-4 hacks since the grid structure now handles spacing automatically */}
             <div className="flex flex-wrap gap-2 border border-[#1A1A1A] p-1.5 self-start bg-[rgba(11,11,11,0.6)]">
               {categories.map((cat) => (
-                <button
+                <button type="button"
                   key={cat}
                   onClick={() => setActive(cat)}
                   className="relative px-4 py-2 tracking-[0.15em] transition-all duration-300 font-mono text-[0.6rem]"

--- a/frontend/src/components/portfolio/templates/Cyber_Security_Red_Team/NavBar.jsx
+++ b/frontend/src/components/portfolio/templates/Cyber_Security_Red_Team/NavBar.jsx
@@ -136,7 +136,7 @@ export function NavBar() {
           <span className="text-[#FF2B2B] opacity-0 group-hover:opacity-100 animate-pulse font-bold">_</span>
         </a>
 
-        <button className="lg:hidden text-[#9A9A9A] hover:text-[#FF2B2B] transition-colors" onClick={() => setOpen(!open)}>
+        <button type="button" className="lg:hidden text-[#9A9A9A] hover:text-[#FF2B2B] transition-colors" onClick={() => setOpen(!open)}>
           {open ? <X size={20} /> : <Menu size={20} />}
         </button>
       </div>

--- a/frontend/src/components/portfolio/templates/Cyberpunk/ResumeCTA.jsx
+++ b/frontend/src/components/portfolio/templates/Cyberpunk/ResumeCTA.jsx
@@ -36,7 +36,7 @@ export default function ResumeCTA() {
         {/* CTA Buttons */}
         <div className="mt-12 flex flex-col items-center justify-center gap-5 sm:flex-row">
           
-          <button className="group flex items-center gap-3 rounded-2xl bg-gradient-to-r from-cyan-500 to-pink-500 px-8 py-4 text-lg font-bold text-black transition-all duration-300 hover:scale-105 hover:shadow-[0_0_30px_rgba(0,255,255,0.45)]">
+          <button type="button" className="group flex items-center gap-3 rounded-2xl bg-gradient-to-r from-cyan-500 to-pink-500 px-8 py-4 text-lg font-bold text-black transition-all duration-300 hover:scale-105 hover:shadow-[0_0_30px_rgba(0,255,255,0.45)]">
             <Download
               size={22}
               className="transition-transform duration-300 group-hover:-translate-y-1"
@@ -44,7 +44,7 @@ export default function ResumeCTA() {
             Download Resume
           </button>
 
-          <button className="group flex items-center gap-3 rounded-2xl border border-pink-400/30 bg-white/5 px-8 py-4 text-lg font-semibold text-pink-300 transition-all duration-300 hover:scale-105 hover:bg-pink-500/10 hover:shadow-[0_0_25px_rgba(255,0,200,0.25)]">
+          <button type="button" className="group flex items-center gap-3 rounded-2xl border border-pink-400/30 bg-white/5 px-8 py-4 text-lg font-semibold text-pink-300 transition-all duration-300 hover:scale-105 hover:bg-pink-500/10 hover:shadow-[0_0_25px_rgba(255,0,200,0.25)]">
             <Eye
               size={22}
               className="transition-transform duration-300 group-hover:scale-110"

--- a/frontend/src/components/portfolio/templates/Dark_Mesh_Gradient/index.jsx
+++ b/frontend/src/components/portfolio/templates/Dark_Mesh_Gradient/index.jsx
@@ -108,7 +108,7 @@ export default function DarkMeshGradient() {
       <header className="fixed top-0 left-0 right-0 z-50 bg-gray-950/40 backdrop-blur-md border-b border-white/5">
         <div className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
 
-          <button
+          <button type="button"
             onClick={() => scrollToSection('home')}
             className="text-xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent"
           >
@@ -118,7 +118,7 @@ export default function DarkMeshGradient() {
           {/* Desktop Nav */}
           <nav className="hidden md:flex items-center gap-1">
             {navItems.map((item) => (
-              <button
+              <button type="button"
                 key={item.id}
                 onClick={() => scrollToSection(item.id)}
                 className={`px-4 py-2 rounded-full text-sm font-semibold transition-all duration-300 ${
@@ -133,7 +133,7 @@ export default function DarkMeshGradient() {
           </nav>
 
           {/* Mobile Button */}
-          <button
+          <button type="button"
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             aria-label="Toggle menu"
             aria-expanded={isMobileMenuOpen}
@@ -156,7 +156,7 @@ export default function DarkMeshGradient() {
             className="fixed top-20 left-0 right-0 z-40 bg-gray-950/95 border-b border-white/10 py-6 px-6 md:hidden flex flex-col gap-3"
           >
             {navItems.map((item) => (
-              <button
+              <button type="button"
                 key={item.id}
                 onClick={() => scrollToSection(item.id)}
                 className="w-full text-left px-5 py-3 rounded-xl text-base font-semibold text-gray-300 hover:text-white hover:bg-white/5"

--- a/frontend/src/components/portfolio/templates/Deep_Ocean/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Deep_Ocean/Contact.jsx
@@ -112,7 +112,7 @@ export default function Contact() {
             {/* Social Icons */}
             <div className="mt-10 flex gap-4">
               {[Linkedin, Github, Twitter].map((Icon, idx) => (
-                <button
+                <button type="button"
                   key={idx}
                   className="rounded-2xl border border-cyan-400/20 bg-cyan-500/10 p-3 text-cyan-300 transition-all duration-300 hover:-translate-y-1 hover:border-cyan-300 hover:bg-cyan-400/20"
                 >

--- a/frontend/src/components/portfolio/templates/Deep_Ocean/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Deep_Ocean/Projects.jsx
@@ -337,7 +337,7 @@ export default function Projects({ projects = DEFAULT_PROJECTS }) {
               <div className="text-base font-bold text-cyan-300 tracking-widest">{sysTime || '09:14:26'}</div>
             </div>
             <div className="h-8 w-px bg-cyan-500/20" />
-            <button 
+            <button type="button" 
               onClick={() => { setSoundEnabled(!soundEnabled); playSonarPing(soundEnabled ? 440 : 880, 0.8); }}
               className={`p-2.5 rounded-lg transition-all border ${
                 soundEnabled 
@@ -363,7 +363,7 @@ export default function Projects({ projects = DEFAULT_PROJECTS }) {
             const Icon = zone.icon;
             const isSelected = activeZone === zone.id;
             return (
-              <button
+              <button type="button"
                 key={zone.id}
                 onClick={() => { setActiveZone(zone.id); playSonarPing(isSelected ? 600 : 780, 1.0); }}
                 className={`flex-1 min-w-[140px] flex items-center gap-3 px-4 py-3 rounded-xl transition-all border font-mono text-left cursor-pointer ${
@@ -579,7 +579,7 @@ export default function Projects({ projects = DEFAULT_PROJECTS }) {
                   </div>
                 </div>
               ) : (
-                <button
+                <button type="button"
                   onClick={handlePRTransmission}
                   className="w-full bg-gradient-to-r from-cyan-500 to-blue-600 hover:from-cyan-400 hover:to-blue-500 text-slate-950 hover:text-black py-4 px-6 rounded-xl font-mono font-bold text-xs tracking-[0.18em] flex items-center justify-center gap-3 transition-all shadow-[0_0_15px_rgba(34,211,238,0.2)] hover:shadow-[0_0_25px_rgba(34,211,238,0.4)] hover:scale-[1.01] cursor-pointer uppercase"
                 >

--- a/frontend/src/components/portfolio/templates/Deep_Ocean/SubmarineSonar.jsx
+++ b/frontend/src/components/portfolio/templates/Deep_Ocean/SubmarineSonar.jsx
@@ -287,7 +287,7 @@ export default function SubmarineSonar() {
               <div className="text-lg font-bold text-cyan-300 tracking-wider">{sysTime || '18:10:02'}</div>
             </div>
             <div className="h-8 w-px bg-cyan-500/20" />
-            <button 
+            <button type="button" 
               onClick={() => { setSoundEnabled(!soundEnabled); playSonarPing(soundEnabled ? 440 : 880); }}
               className={`p-2 rounded-lg transition-all border ${
                 soundEnabled 
@@ -374,7 +374,7 @@ export default function SubmarineSonar() {
                     <div className={`absolute -inset-3 rounded-full border border-cyan-400 bg-cyan-500/5 radar-ping-ring pointer-events-none ${isSelected ? '[animation-duration:1.2s] border-cyan-300 bg-cyan-400/10' : ''}`} />
                     
                     {/* Interactive central blip element */}
-                    <button
+                    <button type="button"
                       onClick={() => selectContact(contact)}
                       className={`relative w-3.5 h-3.5 rounded-full border transition-all duration-300 cursor-pointer ${
                         isSelected 
@@ -454,7 +454,7 @@ export default function SubmarineSonar() {
                 { id: 'projects', label: 'PROJ', icon: FolderGit2 },
                 { id: 'milestones', label: 'MILE', icon: Layers },
               ].map(({ id, label, icon: Icon }) => (
-                <button
+                <button type="button"
                   key={id}
                   onClick={() => { setActiveCategory(id); playSonarPing(700); }}
                   className={`flex flex-col items-center justify-center gap-1.5 py-3.5 px-1 rounded-xl text-center font-mono transition-all border cursor-pointer ${
@@ -547,7 +547,7 @@ export default function SubmarineSonar() {
 
                   {/* Pull Request Mock Button */}
                   <div className="mt-8 border-t border-cyan-500/10 pt-6">
-                    <button
+                    <button type="button"
                       onClick={() => { 
                         playSonarPing(980); 
                         setTimeout(() => {

--- a/frontend/src/components/portfolio/templates/Desert_Dunes/index.jsx
+++ b/frontend/src/components/portfolio/templates/Desert_Dunes/index.jsx
@@ -375,7 +375,7 @@ function Nav() {
           {/* Desktop */}
           <div className="hidden md:flex items-center gap-8">
             {links.map((link) => (
-              <button
+              <button type="button"
                 key={link}
                 onClick={() => scrollTo(link)}
                 style={{
@@ -423,7 +423,7 @@ function Nav() {
           </div>
 
           {/* Hamburger */}
-          <button
+          <button type="button"
             className="md:hidden"
             onClick={() => setOpen(!open)}
             aria-label="Toggle menu"

--- a/frontend/src/components/portfolio/templates/Developer_IDE/About.jsx
+++ b/frontend/src/components/portfolio/templates/Developer_IDE/About.jsx
@@ -163,7 +163,7 @@ export default function About({
           {tabs.map((tab) => {
             const isActive = activeTab === tab;
             return (
-              <button
+              <button type="button"
                 key={tab}
                 onClick={() => setActiveTab(tab)}
                 className="flex items-center gap-1.5 px-4 py-2.5 text-xs transition-all duration-150"
@@ -190,7 +190,7 @@ export default function About({
             style={{ background: "#161b22", borderRight: "1px solid #21262d", width: 48 }}
           >
             {sideIcons.map((Icon, i) => (
-              <button
+              <button type="button"
                 key={i}
                 className="p-1.5 rounded transition-colors"
                 style={{ color: i === 0 ? "#4ade80" : "#6e7681" }}

--- a/frontend/src/components/portfolio/templates/Developer_IDE/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Developer_IDE/Contact.jsx
@@ -41,7 +41,7 @@ export default function Contact({ personal, socials }) {
           <div className="mt-8 mb-4 border-t border-[#30363d] pt-8 flex flex-col items-center font-sans">
             <p className="text-[#8b949e] mb-6 text-center">{"// Run the command above or reach out directly:"}</p>
             <div className="flex gap-4">
-              <button 
+              <button type="button" 
                 onClick={handleCopy}
                 className="px-6 py-2 rounded-md bg-[#21262d] border border-[#30363d] hover:border-[#8b949e] transition-colors text-[#e6edf3] font-medium"
               >

--- a/frontend/src/components/portfolio/templates/Digital_Manifesto_Scroll/index.jsx
+++ b/frontend/src/components/portfolio/templates/Digital_Manifesto_Scroll/index.jsx
@@ -717,19 +717,19 @@ export default function DigitalManifestoScroll() {
       {/* ── Navigation ── */}
       <nav className={`dms-nav${scrollY > 80 ? " dms-nav-scrolled" : ""}`}>
         <div className="dms-nav-inner">
-          <button className="dms-nav-brand" onClick={() => scrollTo("hero")}>
+          <button type="button" className="dms-nav-brand" onClick={() => scrollTo("hero")}>
             {personal.name?.split(" ")[0] || "Manifesto"}
           </button>
           <ul className="dms-nav-links">
             {navLinks.map((l) => (
               <li key={l.id}>
-                <button className="dms-nav-link" onClick={() => scrollTo(l.id)}>
+                <button type="button" className="dms-nav-link" onClick={() => scrollTo(l.id)}>
                   {l.label}
                 </button>
               </li>
             ))}
           </ul>
-          <button className="dms-nav-toggle" onClick={() => setMenuOpen(true)} aria-label="Open menu">
+          <button type="button" className="dms-nav-toggle" onClick={() => setMenuOpen(true)} aria-label="Open menu">
             <Menu size={24} />
           </button>
         </div>
@@ -745,7 +745,7 @@ export default function DigitalManifestoScroll() {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.25 }}
           >
-            <button className="dms-mobile-close" onClick={() => setMenuOpen(false)} aria-label="Close menu">
+            <button type="button" className="dms-mobile-close" onClick={() => setMenuOpen(false)} aria-label="Close menu">
               <X size={28} />
             </button>
             {navLinks.map((l, i) => (
@@ -783,8 +783,8 @@ export default function DigitalManifestoScroll() {
           )}
           
           <div className="dms-hero-actions">
-            <button className="dms-btn dms-btn-primary" onClick={() => scrollTo("projects")}>View Portfolio</button>
-            <button className="dms-btn dms-btn-outline" onClick={() => scrollTo("contact")}>Get In Touch</button>
+            <button type="button" className="dms-btn dms-btn-primary" onClick={() => scrollTo("projects")}>View Portfolio</button>
+            <button type="button" className="dms-btn dms-btn-outline" onClick={() => scrollTo("contact")}>Get In Touch</button>
           </div>
 
           <div className="dms-hero-stats">

--- a/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
+++ b/frontend/src/components/portfolio/templates/Discord_Server/ChatHeader.jsx
@@ -5,7 +5,7 @@ export default function ChatHeader({ channelName, onToggleMobile }) {
   return (
     <div className="h-12 min-h-[48px] px-2 sm:px-4 flex items-center border-b border-[#1F2023] shadow-sm bg-[#313338] select-none">
       {/* Mobile hamburger */}
-      <button onClick={onToggleMobile} aria-label="Toggle mobile menu" className="md:hidden mr-2 text-[#B5BAC1] hover:text-white cursor-pointer">
+      <button type="button" onClick={onToggleMobile} aria-label="Toggle mobile menu" className="md:hidden mr-2 text-[#B5BAC1] hover:text-white cursor-pointer">
         <Menu className="w-5 h-5" />
       </button>
 

--- a/frontend/src/components/portfolio/templates/Doctor_Medical/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Doctor_Medical/Contact.jsx
@@ -49,7 +49,7 @@ export default function Contact({ data }) {
               <h3 className="text-xl font-bold text-white mb-6">Send a Message</h3>
               <div className="space-y-4">
                 <input type="text" placeholder="Your Name" className="w-full bg-white/5 border border-white/10 text-white text-sm rounded-xl px-4 py-3 focus:outline-none" />
-                <button className="w-full bg-blue-600 text-white font-semibold text-sm px-6 py-3.5 rounded-xl">Send Message</button>
+                <button type="button" className="w-full bg-blue-600 text-white font-semibold text-sm px-6 py-3.5 rounded-xl">Send Message</button>
               </div>
             </div>
           </div>

--- a/frontend/src/components/portfolio/templates/Drag_Portfolio/index.jsx
+++ b/frontend/src/components/portfolio/templates/Drag_Portfolio/index.jsx
@@ -104,7 +104,7 @@ export default function DragPortfolio() {
           </AnimatePresence>
 
           {!isMobile && (
-            <button
+            <button type="button"
               onClick={handleReset}
               className="flex items-center gap-2 px-4 py-2 text-xs font-mono font-bold uppercase tracking-wider text-slate-200 bg-white/5 border border-white/10 hover:bg-cyan-500 hover:border-cyan-400 hover:text-black rounded-xl transition-all duration-300 shadow-sm shadow-black"
             >
@@ -301,7 +301,7 @@ export default function DragPortfolio() {
                   <div className="flex justify-between items-center pt-2 border-t border-white/5">
                     <div className="flex gap-1.5">
                       {projects.map((_, idx) => (
-                        <button
+                        <button type="button"
                           key={idx}
                           onClick={() => setActiveProjectIdx(idx)}
                           className={`w-2.5 h-2.5 rounded-full transition-all duration-300 ${

--- a/frontend/src/components/portfolio/templates/Dribbble_Shots/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Dribbble_Shots/Projects.jsx
@@ -126,7 +126,7 @@ export default function Projects() {
 
                 {/* Like / save / views — Dribbble style */}
                 <div className="flex items-center gap-4 pt-3 border-t border-[#f5f5f5]">
-                  <button
+                  <button type="button"
                     onClick={() => setLiked(p => ({ ...p, [i]: !p[i] }))}
                     className="flex items-center gap-1.5"
                   >
@@ -139,7 +139,7 @@ export default function Projects() {
                     <span className="text-[#ccc] text-[10px]">{(42 + i * 11) + (liked[i] ? 1 : 0)}</span>
                   </button>
 
-                  <button
+                  <button type="button"
                     onClick={() => setSaved(p => ({ ...p, [i]: !p[i] }))}
                     className="flex items-center gap-1.5"
                   >

--- a/frontend/src/components/portfolio/templates/Duotone_Bold/index.jsx
+++ b/frontend/src/components/portfolio/templates/Duotone_Bold/index.jsx
@@ -253,15 +253,15 @@ export default function DuotoneBold() {
 
       {/* ── Navbar ── */}
       <nav className="dt-nav">
-        <button className="dt-nav-link" onClick={() => scrollTo("hero")} style={{ color: C.orange, fontSize: 16, fontWeight: 800, letterSpacing: 4 }}>
+        <button type="button" className="dt-nav-link" onClick={() => scrollTo("hero")} style={{ color: C.orange, fontSize: 16, fontWeight: 800, letterSpacing: 4 }}>
           {data.personal.name.split(" ")[0].toUpperCase()}
         </button>
         <div className="dt-nav-desktop">
           {sections.map((s) => (
-            <button key={s} className="dt-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
+            <button type="button" key={s} className="dt-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
           ))}
         </div>
-        <button className="dt-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+        <button type="button" className="dt-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
           {[0,1,2].map(i => (
             <div key={i} style={{ width: 24, height: 2, background: i === 1 ? C.orange : C.white, margin: "4px 0", transition: "all .2s",
               transform: menuOpen ? (i === 0 ? "rotate(45deg) translate(4px,5px)" : i === 2 ? "rotate(-45deg) translate(4px,-5px)" : "none") : "none",
@@ -275,7 +275,7 @@ export default function DuotoneBold() {
           <motion.div className="dt-mobile-menu" initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}
             style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             {sections.map((s) => (
-              <button key={s} className="dt-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
+              <button type="button" key={s} className="dt-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
                 <span style={{ color: C.orange, marginRight: 8 }}>→</span>{s}
               </button>
             ))}
@@ -312,10 +312,10 @@ export default function DuotoneBold() {
             </motion.p>
             <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.4 }}
               style={{ display: "flex", flexWrap: "wrap", gap: 16, marginBottom: 48 }}>
-              <button className="dt-btn dt-btn-primary" onClick={() => scrollTo("projects")}>
+              <button type="button" className="dt-btn dt-btn-primary" onClick={() => scrollTo("projects")}>
                 <span>View Work</span><ArrowRight size={14} />
               </button>
-              <button className="dt-btn dt-btn-outline" onClick={() => scrollTo("contact")}>
+              <button type="button" className="dt-btn dt-btn-outline" onClick={() => scrollTo("contact")}>
                 <span>Get In Touch</span>
               </button>
             </motion.div>

--- a/frontend/src/components/portfolio/templates/Ecommerce_Style/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Ecommerce_Style/Contact.jsx
@@ -99,7 +99,7 @@ export default function Contact({ data }) {
                 />
               </div>
               
-              <button className="w-full mt-4 flex items-center justify-center gap-2 bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-400 hover:to-red-400 text-white font-bold py-4 rounded-xl transition-all shadow-lg hover:shadow-orange-500/25">
+              <button type="button" className="w-full mt-4 flex items-center justify-center gap-2 bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-400 hover:to-red-400 text-white font-bold py-4 rounded-xl transition-all shadow-lg hover:shadow-orange-500/25">
                 Subscribe & Send <Send size={18} />
               </button>
             </form>

--- a/frontend/src/components/portfolio/templates/Ecommerce_Style/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Ecommerce_Style/Projects.jsx
@@ -170,7 +170,7 @@ export default function Projects() {
                   </span>
 
                   {/* Wishlist */}
-                  <button 
+                  <button type="button" 
                     aria-label="Add to wishlist"
                     onClick={() => {/* implement wishlist toggle */}}
                     className="absolute top-5 right-5 w-10 h-10 rounded-full bg-white/80 backdrop-blur-xl flex items-center justify-center shadow-md hover:scale-110 transition"
@@ -308,7 +308,7 @@ export default function Projects() {
                     </div>
 
                     {/* CTA */}
-                    <button
+                    <button type="button"
                       onClick={() => toggle(p.id)}
                       className="w-full flex items-center justify-center gap-2 py-3 rounded-2xl text-sm font-bold transition-all duration-300 active:scale-95 hover:scale-[1.02] shadow-xl"
                       style={{
@@ -327,7 +327,7 @@ export default function Projects() {
                     </button>
 
                     {/* Secondary CTA */}
-                    <button
+                    <button type="button"
                       onClick={() => alert("Project preview coming soon")}
                       className="w-full flex items-center justify-center gap-2 mt-3 text-sm font-semibold text-stone-500 hover:text-stone-900 transition-all group/arrow"
                       style={{ fontFamily: "sans-serif" }}
@@ -358,7 +358,7 @@ export default function Projects() {
           Showing {projects.length} premium featured projects
         </p>
 
-        <button  
+        <button type="button"  
         onClick={() => alert("Collection coming soon")}
         className="group flex items-center gap-2 text-sm font-bold text-stone-900 hover:text-orange-500 transition">
 

--- a/frontend/src/components/portfolio/templates/Ecommerce_Style/Skills.jsx
+++ b/frontend/src/components/portfolio/templates/Ecommerce_Style/Skills.jsx
@@ -27,7 +27,7 @@ export default function Skills({ data }) {
               Technical <span className="bg-gradient-to-r from-orange-500 to-red-500 bg-clip-text text-transparent">Capabilities</span>
             </h2>
           </div>
-          <button className="hidden md:flex items-center gap-2 text-sm font-bold text-stone-500 hover:text-stone-900 transition">
+          <button type="button" className="hidden md:flex items-center gap-2 text-sm font-bold text-stone-500 hover:text-stone-900 transition">
             View All Categories &rarr;
           </button>
         </div>
@@ -60,7 +60,7 @@ export default function Skills({ data }) {
 
                 {/* Quick Add Button Reveal */}
                 <div className="absolute inset-x-0 bottom-0 p-4 opacity-0 group-hover:opacity-100 transform translate-y-2 group-hover:translate-y-0 transition-all duration-300">
-                  <button className="w-full py-2 bg-stone-900 text-white text-xs font-bold rounded-xl shadow-lg">
+                  <button type="button" className="w-full py-2 bg-stone-900 text-white text-xs font-bold rounded-xl shadow-lg">
                     Quick View
                   </button>
                 </div>

--- a/frontend/src/components/portfolio/templates/Ecommerce_Style/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Ecommerce_Style/Testimonials.jsx
@@ -30,7 +30,7 @@ export default function Testimonials({ data }) {
               Based on {totalReviews} reviews
             </p>
             
-            <button className="w-full md:w-auto px-8 py-3 bg-white border-2 border-stone-900 text-stone-900 font-bold rounded-full hover:bg-stone-900 hover:text-white transition-colors">
+            <button type="button" className="w-full md:w-auto px-8 py-3 bg-white border-2 border-stone-900 text-stone-900 font-bold rounded-full hover:bg-stone-900 hover:text-white transition-colors">
               Write a Review
             </button>
           </div>
@@ -67,11 +67,11 @@ export default function Testimonials({ data }) {
                 </p>
 
                 <div className="flex items-center gap-4 text-sm font-semibold text-stone-400 border-t border-stone-100 pt-4">
-                  <button className="flex items-center gap-1.5 hover:text-stone-900 transition-colors">
+                  <button type="button" className="flex items-center gap-1.5 hover:text-stone-900 transition-colors">
                     <ThumbsUp size={16} /> Helpful ({Math.floor(Math.random() * 50) + 5})
                   </button>
                   <div className="w-1 h-1 bg-stone-300 rounded-full"></div>
-                  <button className="flex items-center gap-1.5 hover:text-stone-900 transition-colors">
+                  <button type="button" className="flex items-center gap-1.5 hover:text-stone-900 transition-colors">
                     <MessageSquare size={16} /> Comment
                   </button>
                 </div>

--- a/frontend/src/components/portfolio/templates/Elevator_Pitch/index.jsx
+++ b/frontend/src/components/portfolio/templates/Elevator_Pitch/index.jsx
@@ -65,7 +65,7 @@ export default function ElevatorPitchPortfolio() {
 
           <div className="flex gap-1.5 md:gap-2 pr-1 md:pr-2">
              {[1, 2, 3, 4, 5].map(floor => (
-                <button
+                <button type="button"
                   key={floor}
                   onClick={() => scrollToFloor(floor)}
                   className={`w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center font-bold text-xs md:text-sm transition-all duration-300 relative

--- a/frontend/src/components/portfolio/templates/Endless_Runner_Minigame/index.jsx
+++ b/frontend/src/components/portfolio/templates/Endless_Runner_Minigame/index.jsx
@@ -634,7 +634,7 @@ function Skills() {
       <SectionHeader label="// CHAR.STATS" title="Skills" />
       <div className="erm-skills-cats">
         {categories.map(cat => (
-          <button key={cat} className={`erm-cat-btn${active === cat ? ' active' : ''}`} onClick={() => handleCat(cat)}>
+          <button type="button" key={cat} className={`erm-cat-btn${active === cat ? ' active' : ''}`} onClick={() => handleCat(cat)}>
             {cat}
           </button>
         ))}
@@ -809,13 +809,13 @@ export default function EndlessRunnerMinigame() {
                 <div className="erm-hero-sub">{personal.title || 'Developer'}</div>
                 
                 {gameState === 'idle' && (
-                    <button className="erm-start-btn" onClick={handleStartGame}>
+                    <button type="button" className="erm-start-btn" onClick={handleStartGame}>
                         START BACKGROUND GAME
                     </button>
                 )}
 
                 {gameState === 'dead' && (
-                    <button className="erm-start-btn" style={{ borderColor: '#ff2d78', color: '#ff2d78' }} onClick={handleStartGame}>
+                    <button type="button" className="erm-start-btn" style={{ borderColor: '#ff2d78', color: '#ff2d78' }} onClick={handleStartGame}>
                         GAME OVER // RETRY
                     </button>
                 )}

--- a/frontend/src/components/portfolio/templates/F1_Racing/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/F1_Racing/Hero.jsx
@@ -297,7 +297,7 @@ export default function F1Hero({ data }) {
 
           {/* Reset button inside grid light panel */}
           {isRaceStarted && (
-            <button 
+            <button type="button" 
               onClick={restartSequence} 
               className="ml-4 p-1.5 rounded-full hover:bg-neutral-800 border border-neutral-800 text-neutral-400 hover:text-white transition-colors duration-150 group"
               title="Restart Lights Sequence"
@@ -584,7 +584,7 @@ export default function F1Hero({ data }) {
                 </div>
 
                 {/* DRS and Control Buttons */}
-                <button 
+                <button type="button" 
                   onClick={() => setIsTimerRunning(prev => !prev)}
                   className="px-3 py-1.5 border border-neutral-800 hover:border-neutral-600 bg-neutral-900 text-[10px] font-mono font-bold tracking-wider rounded-md transition-colors hover:text-white uppercase"
                   disabled={!isRaceStarted}

--- a/frontend/src/components/portfolio/templates/Fake_WebOS_Operating_System/index.jsx
+++ b/frontend/src/components/portfolio/templates/Fake_WebOS_Operating_System/index.jsx
@@ -56,7 +56,7 @@ function TrafficLights({ onClose, onMinimize, onMaximize }) {
         { color: C.yellow, Icon: Minus,     action: onMinimize },
         { color: C.green,  Icon: Maximize2, action: onMaximize },
       ].map(({ color, Icon, action }) => (
-        <button key={color} onClick={action} style={{
+        <button type="button" key={color} onClick={action} style={{
           width: 13, height: 13, borderRadius: "50%",
           background: color, border: "none", cursor: "pointer",
           display: "flex", alignItems: "center", justifyContent: "center",
@@ -248,7 +248,7 @@ function ProjectsApp({ data }) {
       <div style={{ width: 200, background: C.sidebar, borderRight: `1px solid ${C.border}`, overflowY: "auto", flexShrink: 0 }}>
         <div style={{ padding: "12px 14px 8px", fontSize: 10, fontWeight: 700, letterSpacing: "0.3em", textTransform: "uppercase", color: C.dim }}>All Projects</div>
         {projects.map((pr, i) => (
-          <button key={i} onClick={() => setActive(i)} style={{
+          <button type="button" key={i} onClick={() => setActive(i)} style={{
             width: "100%", textAlign: "left", padding: "10px 14px",
             background: active === i ? `${C.accent}18` : "transparent",
             border: "none", borderLeft: active === i ? `2px solid ${C.accent}` : "2px solid transparent",
@@ -289,7 +289,7 @@ function SkillsApp({ data }) {
       <div style={{ width: 160, background: C.sidebar, borderRight: `1px solid ${C.border}`, padding: "12px 0", flexShrink: 0 }}>
         <div style={{ padding: "0 14px 8px", fontSize: 10, fontWeight: 700, letterSpacing: "0.3em", textTransform: "uppercase", color: C.dim }}>Category</div>
         {categories.map((c) => (
-          <button key={c} onClick={() => setCat(c)} style={{
+          <button type="button" key={c} onClick={() => setCat(c)} style={{
             width: "100%", textAlign: "left", padding: "9px 14px",
             background: cat === c ? `${C.accent}18` : "transparent",
             border: "none", borderLeft: cat === c ? `2px solid ${C.accent}` : "2px solid transparent",

--- a/frontend/src/components/portfolio/templates/Fantasy_RPG/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Fantasy_RPG/Projects.jsx
@@ -376,7 +376,7 @@ export default function Projects({
                 </div>
 
                 <div className="relative">
-                  <button
+                  <button type="button"
                     onClick={() => setShowInventory(!showInventory)}
                     className="flex flex-col items-center justify-center p-2.5 bg-amber-900/30 hover:bg-amber-900/60 border border-amber-700/60 rounded-lg text-amber-400 hover:text-amber-200 transition-all shadow-[2px_2px_4px_rgba(0,0,0,0.5)] cursor-pointer"
                   >
@@ -526,7 +526,7 @@ export default function Projects({
             <div className="flex flex-wrap items-center justify-center sm:justify-start gap-3 w-full sm:w-auto">
               <span className="font-fantasy-game text-[10px] text-amber-500 tracking-wider mr-2 uppercase">SELECT QUEST CLASS:</span>
               {categories.map((cat) => (
-                <button
+                <button type="button"
                   key={cat}
                   onClick={() => setActiveCategory(cat)}
                   className={`font-fantasy-game text-[10px] px-4 py-2 border rounded transition-all cursor-pointer relative uppercase
@@ -667,7 +667,7 @@ export default function Projects({
               <p className="font-fantasy-body text-xs text-amber-100/40 uppercase max-w-xs px-4">
                 No quests active in this realm sector yet. Explore other categories or level up!
               </p>
-              <button
+              <button type="button"
                 onClick={() => setActiveCategory("All")}
                 className="mt-6 font-fantasy-game text-[10px] px-6 py-2.5 border border-amber-500 bg-amber-950/30 hover:bg-amber-900/20 text-amber-300 rounded shadow-md transition-all cursor-pointer uppercase"
               >

--- a/frontend/src/components/portfolio/templates/Figma_Canvas/index.jsx
+++ b/frontend/src/components/portfolio/templates/Figma_Canvas/index.jsx
@@ -64,7 +64,7 @@ function ToolbarButton({ icon: Icon, label, isActive, onClick }) {
   const { portfolioData: data } = usePortfolio();
 
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       title={label}
       className={`p-1.5 rounded-md transition-colors ${
@@ -130,7 +130,7 @@ function LayerItem({ label, color, isSelected, isVisible, onClick, onToggleVisib
       onClick={onClick}
     >
       {hasChildren ? (
-        <button
+        <button type="button"
           onClick={(e) => { e.stopPropagation(); onToggleExpanded?.(); }}
           className="text-[#666] hover:text-[#ababab]"
         >
@@ -141,7 +141,7 @@ function LayerItem({ label, color, isSelected, isVisible, onClick, onToggleVisib
       )}
       <Frame size={10} style={{ color }} />
       <span className="flex-1 truncate text-[11px]">{label}</span>
-      <button
+      <button type="button"
         onClick={(e) => { e.stopPropagation(); onToggleVisibility(); }}
         className="opacity-0 group-hover:opacity-100 text-[#666] hover:text-[#ababab] transition-opacity"
       >
@@ -468,20 +468,20 @@ export default function FigmaCanvas() {
 
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1 bg-[#1e1e1e] rounded-md px-2 py-1">
-            <button
+            <button type="button"
               onClick={() => adjustZoom(-0.1)}
               className="text-[#ababab] hover:text-white transition-colors"
             >
               <ZoomOut size={14} />
             </button>
             <span className="text-xs text-[#ababab] w-8 sm:w-10 text-center">{zoomPercent}%</span>
-            <button
+            <button type="button"
               onClick={() => adjustZoom(0.1)}
               className="text-[#ababab] hover:text-white transition-colors"
             >
               <ZoomIn size={14} />
             </button>
-            <button
+            <button type="button"
               onClick={fitAll}
               className="text-[#ababab] hover:text-white transition-colors ml-1"
               title="Zoom to fit"
@@ -490,11 +490,11 @@ export default function FigmaCanvas() {
             </button>
           </div>
 
-          <button className="hidden sm:flex items-center gap-1.5 bg-[#0d99ff] hover:bg-[#0b87e0] text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-colors">
+          <button type="button" className="hidden sm:flex items-center gap-1.5 bg-[#0d99ff] hover:bg-[#0b87e0] text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-colors">
             <Play size={12} fill="white" />
             Present
           </button>
-          <button className="flex items-center gap-1.5 bg-[#0d99ff] hover:bg-[#0b87e0] text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-colors">
+          <button type="button" className="flex items-center gap-1.5 bg-[#0d99ff] hover:bg-[#0b87e0] text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-colors">
             <Share2 size={12} />
             Share
           </button>
@@ -525,10 +525,10 @@ export default function FigmaCanvas() {
                   Layers
                 </div>
                 <div className="flex items-center gap-1">
-                  <button className="text-[#ababab] hover:text-white p-0.5">
+                  <button type="button" className="text-[#ababab] hover:text-white p-0.5">
                     <Search size={12} />
                   </button>
-                  <button
+                  <button type="button"
                     onClick={() => setShowLayers(false)}
                     className="md:hidden text-[#ababab] hover:text-white p-0.5 ml-1"
                   >
@@ -599,7 +599,7 @@ export default function FigmaCanvas() {
         >
           {/* Layers toggle (mobile) */}
           {!showLayers && (
-            <button
+            <button type="button"
               onClick={() => setShowLayers(true)}
               className="md:hidden fixed top-14 left-2 z-30 bg-[#2c2c2c] border border-[#3c3c3c] rounded-md p-1.5 text-[#ababab]"
             >
@@ -1060,7 +1060,7 @@ export default function FigmaCanvas() {
                           rows={3}
                           className="w-full bg-[#1e1e2e] border border-[#3c3c3c] rounded-lg px-4 py-2.5 text-xs text-white placeholder-[#666] focus:outline-none focus:border-[#14ae5c] transition-colors resize-none"
                         />
-                        <button className="flex items-center gap-2 bg-[#14ae5c] hover:bg-[#12994f] text-white text-xs font-medium px-5 py-2.5 rounded-lg transition-colors w-full justify-center">
+                        <button type="button" className="flex items-center gap-2 bg-[#14ae5c] hover:bg-[#12994f] text-white text-xs font-medium px-5 py-2.5 rounded-lg transition-colors w-full justify-center">
                           <Send size={12} />
                           Send Message
                         </button>
@@ -1091,7 +1091,7 @@ export default function FigmaCanvas() {
       {/* ======= BOTTOM BAR ======= */}
       <div className="h-7 bg-[#2c2c2c] border-t border-[#3c3c3c] flex items-center justify-between px-3 shrink-0 text-[10px] text-[#666] z-50">
         <div className="flex items-center gap-3">
-          <button
+          <button type="button"
             onClick={() => setShowLayers(!showLayers)}
             className="hidden md:flex items-center gap-1 hover:text-[#ababab] transition-colors"
           >

--- a/frontend/src/components/portfolio/templates/Film_Director_Clapperboard/index.jsx
+++ b/frontend/src/components/portfolio/templates/Film_Director_Clapperboard/index.jsx
@@ -858,7 +858,7 @@ function Navbar() {
         </div>
         <div className="hidden md:flex items-center">
           {navItems.map((item) => (
-            <button
+            <button type="button"
               key={item}
               onClick={() => scrollTo(item)}
               className="relative px-3 py-1.5"
@@ -878,7 +878,7 @@ function Navbar() {
             </button>
           ))}
         </div>
-        <button className="md:hidden" onClick={() => setMobileOpen(!mobileOpen)} style={{ color: DIM }}>
+        <button type="button" className="md:hidden" onClick={() => setMobileOpen(!mobileOpen)} style={{ color: DIM }}>
           {mobileOpen ? <XIcon size={16} /> : <Menu size={16} />}
         </button>
       </div>
@@ -892,7 +892,7 @@ function Navbar() {
             style={{ backgroundColor: VOID, borderTop: `1px solid ${BORDER}` }}
           >
             {navItems.map((item) => (
-              <button
+              <button type="button"
                 key={item}
                 onClick={() => scrollTo(item)}
                 className="block w-full text-left px-8 py-3"
@@ -1543,7 +1543,7 @@ function Projects() {
               { d: "left", cls: "left-2 -translate-x-5" },
               { d: "right", cls: "right-2 translate-x-5" },
             ].map(({ d }) => (
-              <button
+              <button type="button"
                 key={d}
                 onClick={() => scroll(d)}
                 className="absolute w-9 h-9 rounded-full flex items-center justify-center z-30 transition-all duration-300 hover:scale-110 shadow-lg top-1/2 -translate-y-1/2"

--- a/frontend/src/components/portfolio/templates/Finance_Corporate/StockTicker.jsx
+++ b/frontend/src/components/portfolio/templates/Finance_Corporate/StockTicker.jsx
@@ -553,7 +553,7 @@ export default function StockTicker() {
             <Activity size={10} className="text-cyan-500" />
             <span className="text-[9px] text-cyan-600 tracking-[0.2em] uppercase font-semibold">Live Quotes</span>
             <div className="flex-1 h-px" style={{ background: "rgba(34,211,238,0.07)" }} />
-            <button
+            <button type="button"
               onClick={() => setPaused(p => !p)}
               className="text-[9px] text-slate-600 hover:text-cyan-400 tracking-widest uppercase transition-colors duration-200"
               aria-label={paused ? "Resume ticker" : "Pause ticker"}

--- a/frontend/src/components/portfolio/templates/Floating_Islands/index.jsx
+++ b/frontend/src/components/portfolio/templates/Floating_Islands/index.jsx
@@ -167,7 +167,7 @@ function MobileMenu({ navItems, scrolled }) {
 
   return (
     <div className="md:hidden">
-      <button
+      <button type="button"
         onClick={() => setOpen(!open)}
         className={`p-2 rounded-lg ${scrolled ? 'text-slate-600' : 'text-white'}`}
         aria-label="Toggle menu"

--- a/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/FluidCanvas.jsx
+++ b/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/FluidCanvas.jsx
@@ -393,7 +393,7 @@ export default function FluidCanvas() {
 
       {/* Floating Simulation Settings Panel (Interactive controls) */}
       <div className="absolute bottom-6 left-6 z-40 pointer-events-auto select-none font-sans text-xs">
-        <button
+        <button type="button"
           onClick={() => setIsOpen(!isOpen)}
           className="flex items-center gap-2 px-3 py-2 bg-slate-900/80 border border-slate-700/50 backdrop-blur-md rounded-lg text-slate-300 hover:text-white transition-all shadow-lg hover:shadow-cyan-500/10 cursor-pointer"
         >
@@ -408,7 +408,7 @@ export default function FluidCanvas() {
                 <Layers className="w-3.5 h-3.5 text-cyan-400" />
                 Flow Dynamics Solver
               </span>
-              <button 
+              <button type="button" 
                 onClick={() => setIsPaused(!isPaused)} 
                 className="p-1 hover:bg-slate-800 rounded transition"
                 title={isPaused ? "Play" : "Pause"}
@@ -514,7 +514,7 @@ export default function FluidCanvas() {
                   { id: 'magma', label: 'Magma', class: 'bg-orange-500 border-orange-400 text-orange-100' },
                   { id: 'acid', label: 'Acid', class: 'bg-emerald-500 border-emerald-400 text-emerald-100' }
                 ].map(mode => (
-                  <button
+                  <button type="button"
                     key={mode.id}
                     onClick={() => setColorMode(mode.id)}
                     className={`px-1 py-1 rounded text-[10px] border font-bold transition cursor-pointer text-center ${
@@ -541,7 +541,7 @@ export default function FluidCanvas() {
                 <span>Vector Grid</span>
               </label>
 
-              <button
+              <button type="button"
                 onClick={triggerReset}
                 className="flex items-center gap-1 hover:text-white transition cursor-pointer bg-slate-800 px-2 py-1 rounded"
               >

--- a/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/Hero.jsx
@@ -109,7 +109,7 @@ export default function Hero({ data }) {
             transition={{ delay: 0.6, duration: 0.8 }}
             className="flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-4 pt-4"
           >
-            <button
+            <button type="button"
               onClick={handleEnterFlow}
               onMouseEnter={triggerHoverBurst}
               className="px-8 py-3.5 bg-gradient-to-r from-cyan-500 to-teal-500 hover:from-cyan-400 hover:to-teal-400 text-slate-950 font-bold rounded-xl flex items-center gap-2.5 transition-all shadow-lg shadow-cyan-500/20 hover:scale-105 active:scale-95 cursor-pointer text-sm tracking-wide"

--- a/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/Skills.jsx
+++ b/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/Skills.jsx
@@ -133,7 +133,7 @@ export default function Skills({ data }) {
             const isActive = activeCategory === cat;
             const style = cat === 'All' ? categoryStyles.Other : getStyle(cat);
             return (
-              <button
+              <button type="button"
                 key={idx}
                 onClick={() => setActiveCategory(cat)}
                 className={`px-4 py-2 rounded-xl text-xs font-bold uppercase tracking-wider transition-all border cursor-pointer ${

--- a/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/index.jsx
+++ b/frontend/src/components/portfolio/templates/Fluid_Simulation_3D_WebGL/index.jsx
@@ -73,7 +73,7 @@ export default function FluidSimulation3DWebGL({ portfolioData: propData }) {
         <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
           
           {/* Logo Name */}
-          <button 
+          <button type="button" 
             onClick={() => handleNavClick('home')}
             onMouseEnter={handleNavHover}
             className="flex items-center gap-1.5 font-black text-sm tracking-wider uppercase bg-gradient-to-r from-cyan-400 to-indigo-500 bg-clip-text text-transparent cursor-pointer"
@@ -93,7 +93,7 @@ export default function FluidSimulation3DWebGL({ portfolioData: propData }) {
             ].map(item => {
               const active = activeSection === item.id;
               return (
-                <button
+                <button type="button"
                   key={item.id}
                   onClick={() => handleNavClick(item.id)}
                   onMouseEnter={handleNavHover}

--- a/frontend/src/components/portfolio/templates/Freelancer_Invoice/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Freelancer_Invoice/Hero.jsx
@@ -98,7 +98,7 @@ export default function Hero({ data }) {
               >
                 Hire Me
               </a>
-              <button
+              <button type="button"
                 onClick={() => setMenuOpen(!menuOpen)}
                 style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4, display: 'flex', flexDirection: 'column', gap: 5 }}
                 className="fi-hamburger"
@@ -347,7 +347,7 @@ export default function Hero({ data }) {
                     <span style={{ fontSize: 18, fontWeight: 900, color: '#2563EB' }}>${projTotal.toLocaleString()}</span>
                   </div>
 
-                  <button className="fi-btn-primary" style={{ width: '100%', padding: '10px', borderRadius: 8, fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, marginTop: 12 }}>
+                  <button type="button" className="fi-btn-primary" style={{ width: '100%', padding: '10px', borderRadius: 8, fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, marginTop: 12 }}>
                     <Download size={14} />
                     Download Invoice
                   </button>

--- a/frontend/src/components/portfolio/templates/Freelancer_Invoice/InvoiceSection.jsx
+++ b/frontend/src/components/portfolio/templates/Freelancer_Invoice/InvoiceSection.jsx
@@ -153,7 +153,7 @@ export default function InvoiceSection({ data }) {
 
               {/* Download Button */}
               <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 20 }}>
-                <button className="fi-btn-primary" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '10px 22px', borderRadius: 8, fontSize: 14, fontWeight: 600 }}>
+                <button type="button" className="fi-btn-primary" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, padding: '10px 22px', borderRadius: 8, fontSize: 14, fontWeight: 600 }}>
                   <Download size={16} />
                   Download Invoice
                 </button>
@@ -177,7 +177,7 @@ export default function InvoiceSection({ data }) {
 
               <div style={{ maxHeight: 300, overflowY: 'auto' }}>
                 {(projects || []).slice(0, 5).map((proj, i) => (
-                  <button
+                  <button type="button"
                     key={i}
                     onClick={() => setActiveProject(i)}
                     style={{
@@ -212,7 +212,7 @@ export default function InvoiceSection({ data }) {
                     <span style={{ fontSize: 12, fontWeight: 600, color: '#1E40AF' }}>{s.value}</span>
                   </div>
                 ))}
-                <button className="fi-btn-outline" style={{ width: '100%', marginTop: 12, padding: '8px', borderRadius: 8, fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+                <button type="button" className="fi-btn-outline" style={{ width: '100%', marginTop: 12, padding: '8px', borderRadius: 8, fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
                   <CheckCircle2 size={13} />
                   Request Quote
                 </button>

--- a/frontend/src/components/portfolio/templates/Freelancer_Invoice/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Freelancer_Invoice/Testimonials.jsx
@@ -135,7 +135,7 @@ export default function Testimonials({ data }) {
 
             {/* Navigation */}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'center' }}>
-              <button onClick={prev} style={{ width: 44, height: 44, borderRadius: '50%', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.2s' }}
+              <button type="button" onClick={prev} style={{ width: 44, height: 44, borderRadius: '50%', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.2s' }}
                 onMouseOver={e => e.currentTarget.style.background = 'rgba(37,99,235,0.5)'}
                 onMouseOut={e => e.currentTarget.style.background = 'rgba(255,255,255,0.1)'}
               >
@@ -144,7 +144,7 @@ export default function Testimonials({ data }) {
               <div style={{ fontSize: 12, color: '#64748B', fontWeight: 600 }}>
                 {active + 1}/{testimonials?.length}
               </div>
-              <button onClick={next} style={{ width: 44, height: 44, borderRadius: '50%', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.2s' }}
+              <button type="button" onClick={next} style={{ width: 44, height: 44, borderRadius: '50%', background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.2s' }}
                 onMouseOver={e => e.currentTarget.style.background = 'rgba(37,99,235,0.5)'}
                 onMouseOut={e => e.currentTarget.style.background = 'rgba(255,255,255,0.1)'}
               >
@@ -156,7 +156,7 @@ export default function Testimonials({ data }) {
           {/* Dots */}
           <div style={{ display: 'flex', justifyContent: 'center', gap: 8, marginTop: 24, position: 'relative', zIndex: 1 }}>
             {(testimonials || []).map((_, di) => (
-              <button
+              <button type="button"
                 key={di}
                 onClick={() => setActive(di)}
                 style={{ width: di === active ? 20 : 8, height: 8, borderRadius: 4, background: di === active ? '#2563EB' : 'rgba(255,255,255,0.2)', border: 'none', cursor: 'pointer', transition: 'all 0.3s ease', padding: 0 }}

--- a/frontend/src/components/portfolio/templates/Frosted_Panels/index.jsx
+++ b/frontend/src/components/portfolio/templates/Frosted_Panels/index.jsx
@@ -280,7 +280,7 @@ export default function FrostedPanels() {
 
           {/* Hamburger Mobile Menu Toggle Button */}
           <div className="md:hidden relative z-20">
-            <button
+            <button type="button"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className="p-2 rounded-full bg-white/50 border border-white/40 text-[#1b1435] hover:bg-white/80 transition-colors focus:outline-none"
               aria-label="Toggle navigation menu"

--- a/frontend/src/components/portfolio/templates/Geometric_Shapes/About.jsx
+++ b/frontend/src/components/portfolio/templates/Geometric_Shapes/About.jsx
@@ -72,12 +72,12 @@ const About = () => {
             </p>
 
             <div className="flex gap-4 flex-wrap">
-              <button className="px-8 py-4 bg-white text-black rounded-xl flex items-center gap-2 hover:scale-105 transition">
+              <button type="button" className="px-8 py-4 bg-white text-black rounded-xl flex items-center gap-2 hover:scale-105 transition">
                 Download Resume
                 <ArrowRight size={18} />
               </button>
 
-              <button className="px-8 py-4 border border-white/20 rounded-xl hover:bg-white hover:text-black transition">
+              <button type="button" className="px-8 py-4 border border-white/20 rounded-xl hover:bg-white hover:text-black transition">
                 Contact Me
               </button>
             </div>

--- a/frontend/src/components/portfolio/templates/Geometric_Shapes/PolygonMorph.jsx
+++ b/frontend/src/components/portfolio/templates/Geometric_Shapes/PolygonMorph.jsx
@@ -126,7 +126,7 @@ export default function PolygonMorph() {
 
         {/* Futuristic CTA Area */}
         <div className="mt-20 text-center">
-          <button className="group relative inline-flex items-center gap-3 px-8 py-3.5 bg-transparent rounded-lg font-mono text-sm tracking-wider text-cyan-400 font-medium transition-all duration-300 overflow-hidden border border-cyan-500/30 hover:border-cyan-400 hover:text-white">
+          <button type="button" className="group relative inline-flex items-center gap-3 px-8 py-3.5 bg-transparent rounded-lg font-mono text-sm tracking-wider text-cyan-400 font-medium transition-all duration-300 overflow-hidden border border-cyan-500/30 hover:border-cyan-400 hover:text-white">
             
             {/* Morphing background layer on hover */}
             <div className="absolute inset-0 bg-gradient-to-r from-cyan-600 to-fuchsia-600 opacity-0 group-hover:opacity-100 transition-opacity duration-500 -z-10" />

--- a/frontend/src/components/portfolio/templates/GitHub_Profile/index.jsx
+++ b/frontend/src/components/portfolio/templates/GitHub_Profile/index.jsx
@@ -73,7 +73,7 @@ export default function GitHubProfile() {
             <h1 className="text-2xl font-bold text-[#c9d1d9] leading-tight mt-2">{data.personal.name}</h1>
             <h2 className="text-xl text-[#8b949e] font-light mb-4">{data.personal.title}</h2>
             
-            <button className="w-full bg-[#21262d] border border-[#30363d] hover:bg-[#30363d] text-[#c9d1d9] font-medium py-1.5 px-3 rounded-md transition-colors mb-4 cursor-pointer">
+            <button type="button" className="w-full bg-[#21262d] border border-[#30363d] hover:bg-[#30363d] text-[#c9d1d9] font-medium py-1.5 px-3 rounded-md transition-colors mb-4 cursor-pointer">
               Follow
             </button>
             
@@ -125,7 +125,7 @@ export default function GitHubProfile() {
             {/* Tabs */}
             <div className="flex overflow-x-auto border-b border-[#30363d] mb-6 text-sm font-medium hide-scrollbar">
               {['Overview', 'Repositories', 'Projects', 'Packages', 'Stars'].map((tab) => (
-                <button 
+                <button type="button" 
                   key={tab}
                   onClick={() => setActiveTab(tab.toLowerCase())}
                   className={`flex items-center gap-2 px-4 py-3 border-b-2 transition-colors whitespace-nowrap cursor-pointer ${

--- a/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Contact.jsx
@@ -28,7 +28,7 @@ function RemoteRow({ name, url, type, icon: Icon, color, delay, inView }) {
           {url}
         </a>
       </span>
-      <button
+      <button type="button"
         onClick={handleCopy}
         aria-label={`Copy ${name} URL`}
         className="opacity-0 group-hover:opacity-100 transition-opacity text-[#8B949E] hover:text-white"

--- a/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Hero.jsx
@@ -73,7 +73,7 @@ function CloneCommand({ username }) {
     <div className="flex items-center gap-2 bg-[#161B22] border border-[#30363D] rounded-md px-3 py-2 font-mono text-xs text-[#8B949E] group">
       <span className="text-[#3FB950]">$</span>
       <span className="flex-1 truncate text-white">{cmd}</span>
-      <button
+      <button type="button"
         onClick={copy}
         aria-label="Copy clone command"
         id="clone-copy-btn"
@@ -272,7 +272,7 @@ export default function Hero() {
               transition={{ delay: 1.15, duration: 0.5 }}
               className="flex flex-wrap gap-3"
             >
-              <button
+              <button type="button"
                 id="hero-clone-btn"
                 onClick={() => document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })}
                 className="flex items-center gap-2 bg-[#238636] hover:bg-[#2EA043] border border-[#3FB950]/50 text-white rounded-md px-4 py-2 text-sm font-medium transition-all"

--- a/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/NavBar.jsx
+++ b/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/NavBar.jsx
@@ -83,7 +83,7 @@ export default function NavBar() {
         {/* Desktop tabs */}
         <div className="hidden md:flex items-center" role="tablist">
           {NAV_LINKS.map(link => (
-            <button
+            <button type="button"
               key={link.id}
               role="tab"
               aria-selected={active === link.id}
@@ -112,7 +112,7 @@ export default function NavBar() {
         </div>
 
         {/* Mobile menu button */}
-        <button
+        <button type="button"
           className="md:hidden p-2 text-[#8B949E] hover:text-white"
           onClick={() => setMenuOpen(v => !v)}
           aria-label="Toggle navigation menu"
@@ -133,7 +133,7 @@ export default function NavBar() {
             className="md:hidden bg-[#0D1117] border-t border-[#30363D]"
           >
             {NAV_LINKS.map(link => (
-              <button
+              <button type="button"
                 key={link.id}
                 onClick={() => { scrollTo(link.id); setMenuOpen(false); }}
                 className={`w-full flex items-center gap-3 px-4 py-3 text-sm text-left border-b border-[#21262D] transition-colors

--- a/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Projects.jsx
@@ -42,7 +42,7 @@ function ProjectCard({ project, index, inView }) {
         style={{ backgroundColor: theme.bg, borderColor: theme.border }}
       >
         {/* Branch name header */}
-        <button
+        <button type="button"
           onClick={() => setExpanded(v => !v)}
           className="w-full flex items-center gap-3 px-4 py-3 border-b text-left hover:opacity-90 transition-all"
           style={{ borderColor: theme.border }}

--- a/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Skills.jsx
+++ b/frontend/src/components/portfolio/templates/Git_Commit_History_Tree/Skills.jsx
@@ -51,7 +51,7 @@ function BranchGroup({ category, skills, meta, inView, globalIdx }) {
       className="bg-[#161B22] border border-[#30363D] rounded-lg overflow-hidden"
     >
       {/* Branch header / toggle */}
-      <button
+      <button type="button"
         onClick={() => setOpen(v => !v)}
         className="w-full flex items-center gap-3 px-4 py-3 border-b border-[#30363D] hover:bg-[#1C2128] transition-colors text-left"
         aria-expanded={open}

--- a/frontend/src/components/portfolio/templates/Glassmorphism/About.jsx
+++ b/frontend/src/components/portfolio/templates/Glassmorphism/About.jsx
@@ -66,7 +66,7 @@ export default function About() {
               ideas into impactful products that solve real-world problems.
             </p>
 
-            <button className="mt-8 rounded-2xl border border-white/20 bg-white/10 px-6 py-3 backdrop-blur-xl transition-all duration-300 hover:scale-105 hover:bg-white/20">
+            <button type="button" className="mt-8 rounded-2xl border border-white/20 bg-white/10 px-6 py-3 backdrop-blur-xl transition-all duration-300 hover:scale-105 hover:bg-white/20">
               Learn More
             </button>
           </div>

--- a/frontend/src/components/portfolio/templates/Glassmorphism/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Glassmorphism/Projects.jsx
@@ -66,12 +66,12 @@ export default function Projects() {
 
               <div className="flex gap-4">
 
-                <button className="flex items-center gap-2 px-4 py-2 rounded-xl bg-white/10 border border-white/20 text-white hover:bg-white/20 transition">
+                <button type="button" className="flex items-center gap-2 px-4 py-2 rounded-xl bg-white/10 border border-white/20 text-white hover:bg-white/20 transition">
                   <Github size={18} />
                   Code
                 </button>
 
-                <button className="flex items-center gap-2 px-4 py-2 rounded-xl bg-purple-500/30 border border-purple-300/20 text-white hover:bg-purple-500/40 transition">
+                <button type="button" className="flex items-center gap-2 px-4 py-2 rounded-xl bg-purple-500/30 border border-purple-300/20 text-white hover:bg-purple-500/40 transition">
                   <ExternalLink size={18} />
                   Live
                 </button>

--- a/frontend/src/components/portfolio/templates/Gradient_Mesh_Art/components/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Gradient_Mesh_Art/components/Hero.jsx
@@ -39,7 +39,7 @@ export default function Hero() {
           {/* BUTTONS */}
           <div className="flex flex-wrap justify-center lg:justify-start gap-4 mt-10">
 
-            <button
+            <button type="button"
               className="
                 px-7 py-4 rounded-2xl 
                 bg-linear-to-r from-pink-500 to-cyan-400
@@ -56,7 +56,7 @@ export default function Hero() {
               View Projects
             </button>
 
-            <button
+            <button type="button"
               className="
                 px-7 py-4 rounded-2xl
                 bg-white/5

--- a/frontend/src/components/portfolio/templates/Graffiti_StreetArt/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Graffiti_StreetArt/Hero.jsx
@@ -74,7 +74,7 @@ export default function Hero() {
         {/* CTA Buttons */}
         <div className="mt-12 flex flex-col gap-4 sm:flex-row">
           {/* Primary CTA */}
-          <button
+          <button type="button"
             onClick={handleExploreClick}
             className="group relative inline-flex cursor-pointer items-center overflow-hidden rounded-full bg-gradient-to-r from-pink-500 to-yellow-500 px-8 py-3 font-bold text-white transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:shadow-pink-500/50"
             aria-label="Explore portfolio work"
@@ -85,7 +85,7 @@ export default function Hero() {
           </button>
           
           {/* Secondary CTA */}
-          <button
+          <button type="button"
             onClick={handleContactClick}
             className="inline-flex cursor-pointer items-center gap-2 rounded-full border-2 border-white/30 bg-transparent px-8 py-3 font-semibold text-white backdrop-blur-sm transition-all duration-300 hover:border-pink-400 hover:bg-white/10"
             aria-label="Contact me"

--- a/frontend/src/components/portfolio/templates/Hidden_Easter_Egg_Scavenger_Hunt/index.jsx
+++ b/frontend/src/components/portfolio/templates/Hidden_Easter_Egg_Scavenger_Hunt/index.jsx
@@ -247,7 +247,7 @@ function VictoryModal({ onClose }) {
               animationDelay: `${EGGS.indexOf(e) * 0.15}s` }}>{e.emoji}</span>
           ))}
         </div>
-        <button onClick={onClose} className="eh-btn"
+        <button type="button" onClick={onClose} className="eh-btn"
           style={{ background: C.gold, color: C.bg }}>
           🎉 Thanks for Playing!
         </button>
@@ -387,7 +387,7 @@ function Nav({ foundCount }) {
             Hire Me 🌸
           </a>
 
-          <button onClick={() => setOpen(o => !o)} style={{
+          <button type="button" onClick={() => setOpen(o => !o)} style={{
             background: 'none', border: '1px solid #2A4A2A',
             color: C.cream, cursor: 'pointer', padding: '6px 8px',
             display: 'flex', borderRadius: 8,
@@ -1021,7 +1021,7 @@ function Contact({ foundEggs, onFind }) {
                   <p style={{ color: C.light, fontFamily: C.mono, fontSize: '0.88rem', lineHeight: 1.6 }}>
                     Thanks for reaching out! I'll get back to you soon 🐣
                   </p>
-                  <button onClick={() => { setStatus('idle'); setForm({ name:'', email:'', message:'' }); }}
+                  <button type="button" onClick={() => { setStatus('idle'); setForm({ name:'', email:'', message:'' }); }}
                     className="eh-btn" style={{ background: C.green, color: C.bg, marginTop: 24 }}>
                     🌸 Send Another
                   </button>
@@ -1162,7 +1162,7 @@ function Scoreboard({ foundEggs, show, onClose }) {
               letterSpacing: '0.15em', textTransform: 'uppercase', fontWeight: 700 }}>
               🥚 Egg Progress
             </div>
-            <button onClick={onClose} style={{ background: 'none', border: 'none',
+            <button type="button" onClick={onClose} style={{ background: 'none', border: 'none',
               color: C.muted, cursor: 'pointer' }}>
               <X size={16} />
             </button>

--- a/frontend/src/components/portfolio/templates/High_Fashion/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/High_Fashion/Testimonials.jsx
@@ -80,15 +80,15 @@ export default function Testimonials() {
 
         {/* Controls */}
         <div className="flex items-center gap-6 mt-16">
-          <button onClick={prev} className="w-12 h-12 flex items-center justify-center transition-all hover:bg-white/5" style={{ border: `1px solid rgba(255,255,255,0.2)` }}>
+          <button type="button" onClick={prev} className="w-12 h-12 flex items-center justify-center transition-all hover:bg-white/5" style={{ border: `1px solid rgba(255,255,255,0.2)` }}>
             <ChevronLeft size={16} />
           </button>
           <div className="flex gap-2">
             {data.testimonials.map((_, i) => (
-              <button key={i} onClick={() => setCurrent(i)} className="w-2 h-2 transition-all" style={{ background: i === current ? F.gold : 'rgba(255,255,255,0.2)' }} aria-label={`Go to testimonial ${i + 1}`} />
+              <button type="button" key={i} onClick={() => setCurrent(i)} className="w-2 h-2 transition-all" style={{ background: i === current ? F.gold : 'rgba(255,255,255,0.2)' }} aria-label={`Go to testimonial ${i + 1}`} />
             ))}
           </div>
-          <button onClick={next} className="w-12 h-12 flex items-center justify-center transition-all hover:bg-white/5" style={{ border: `1px solid rgba(255,255,255,0.2)` }}>
+          <button type="button" onClick={next} className="w-12 h-12 flex items-center justify-center transition-all hover:bg-white/5" style={{ border: `1px solid rgba(255,255,255,0.2)` }}>
             <ChevronRight size={16} />
           </button>
         </div>

--- a/frontend/src/components/portfolio/templates/High_Fashion/index.jsx
+++ b/frontend/src/components/portfolio/templates/High_Fashion/index.jsx
@@ -62,7 +62,7 @@ function NavBar({ active, onNav }) {
         {/* Desktop links */}
         <div className="hidden md:flex" style={{ gap: '1.75rem' }}>
           {NAV_LINKS.map(({ id, label }) => (
-            <button key={id} onClick={() => handleNav(id)}
+            <button type="button" key={id} onClick={() => handleNav(id)}
               style={{
                 background: 'none', border: 'none', cursor: 'pointer',
                 fontSize: '0.68rem', fontWeight: 700, letterSpacing: '0.15em',
@@ -77,7 +77,7 @@ function NavBar({ active, onNav }) {
         </div>
 
         {/* Hamburger */}
-        <button
+        <button type="button"
           className="md:hidden flex flex-col justify-center items-center gap-[5px] w-9 h-9"
           onClick={() => setOpen(o => !o)}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '4px' }}
@@ -103,7 +103,7 @@ function NavBar({ active, onNav }) {
               boxShadow: '0 8px 24px rgba(0,0,0,0.08)',
             }}>
             {NAV_LINKS.map(({ id, label }) => (
-              <button key={id} onClick={() => handleNav(id)}
+              <button type="button" key={id} onClick={() => handleNav(id)}
                 style={{
                   display: 'flex', alignItems: 'center', justifyContent: 'space-between',
                   width: '100%', padding: '1rem 1.5rem',

--- a/frontend/src/components/portfolio/templates/Holographic/Experience.jsx
+++ b/frontend/src/components/portfolio/templates/Holographic/Experience.jsx
@@ -96,7 +96,7 @@ export default function Experience() {
             }`}
           >
             {experienceData.map((exp) => (
-              <button
+              <button type="button"
                 key={exp.id}
                 onClick={() => setActiveId(exp.id)}
                 className={`relative flex flex-col items-start gap-2 rounded-2xl border p-5 text-left transition-all duration-300 ${

--- a/frontend/src/components/portfolio/templates/Holographic/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Holographic/Projects.jsx
@@ -310,7 +310,7 @@ function HoloCard({ project, index, isActive, onActivate }) {
 /* ─── Filter pill ─────────────────────── */
 function FilterPill({ label, active, onClick }) {
   return (
-    <button
+    <button type="button"
       onClick={onClick}
       aria-pressed={active}
       className={`px-4 py-1.5 rounded-full text-sm font-medium border transition-all duration-200 whitespace-nowrap
@@ -547,7 +547,7 @@ export default function HolographicProjects({
             <div className="flex flex-col items-center justify-center py-24 text-center">
               <Layers className="w-12 h-12 text-slate-600 mb-4" />
               <p className="text-slate-500 text-lg font-medium">No projects in this category yet</p>
-              <button
+              <button type="button"
                 onClick={() => setFilter("All")}
                 className="mt-4 text-sm text-cyan-400 hover:text-cyan-300 underline transition-colors"
               >

--- a/frontend/src/components/portfolio/templates/Infinite_Zoom_Mandelbrot_Set/index.jsx
+++ b/frontend/src/components/portfolio/templates/Infinite_Zoom_Mandelbrot_Set/index.jsx
@@ -279,7 +279,7 @@ export default function InfiniteZoomMandelbrotSet() {
           {/* Depth progress */}
           <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
             {SECTIONS.map((s, i) => (
-              <button
+              <button type="button"
                 key={s.id}
                 onClick={() => goTo(i)}
                 style={{
@@ -330,7 +330,7 @@ export default function InfiniteZoomMandelbrotSet() {
                     </div>
                   ))}
                 </div>
-                <button onClick={next} className="mbs-btn" style={{ background: C.accent, color: "#fff" }}>
+                <button type="button" onClick={next} className="mbs-btn" style={{ background: C.accent, color: "#fff" }}>
                   <ZoomIn size={14} /> Begin Zoom Journey
                 </button>
               </Panel>
@@ -493,7 +493,7 @@ export default function InfiniteZoomMandelbrotSet() {
                     </a>
                   ))}
                 </div>
-                <button onClick={() => goTo(0)} className="mbs-btn" style={{ background: "transparent", color: C.dim, border: `1px solid ${C.border}`, fontSize: 11 }}>
+                <button type="button" onClick={() => goTo(0)} className="mbs-btn" style={{ background: "transparent", color: C.dim, border: `1px solid ${C.border}`, fontSize: 11 }}>
                   ↑ Back to Surface
                 </button>
               </Panel>
@@ -507,7 +507,7 @@ export default function InfiniteZoomMandelbrotSet() {
           position: "absolute", bottom: 20, left: "50%", transform: "translateX(-50%)",
           display: "flex", alignItems: "center", gap: 14, zIndex: 40,
         }}>
-          <button
+          <button type="button"
             onClick={prev}
             disabled={sectionIdx === 0}
             style={{
@@ -529,7 +529,7 @@ export default function InfiniteZoomMandelbrotSet() {
             {sectionIdx + 1} / {SECTIONS.length} — {section.label}
           </div>
 
-          <button
+          <button type="button"
             onClick={next}
             disabled={sectionIdx === SECTIONS.length - 1}
             style={{

--- a/frontend/src/components/portfolio/templates/Inspired_Clyde_DSouza/components/TopNav.jsx
+++ b/frontend/src/components/portfolio/templates/Inspired_Clyde_DSouza/components/TopNav.jsx
@@ -7,7 +7,7 @@ const TopNav = ({ activeTab, setActiveTab }) => {
   return (
     <div className="flex flex-wrap gap-2 md:gap-3 mb-8">
       {tabs.map((tab) => (
-        <button
+        <button type="button"
           key={tab}
           onClick={() => setActiveTab(tab)}
           className={`relative px-5 py-2 rounded-full text-sm font-semibold transition-colors z-10

--- a/frontend/src/components/portfolio/templates/Inspired_Clyde_DSouza/index.jsx
+++ b/frontend/src/components/portfolio/templates/Inspired_Clyde_DSouza/index.jsx
@@ -41,7 +41,7 @@ const InspiredClydeDSouza = ({ portfolioData }) => {
           >
             {/* Chat Header */}
             <div className="bg-[#008f7a] p-6 text-white text-center relative">
-              <button 
+              <button type="button" 
                 onClick={() => setIsChatOpen(false)}
                 className="absolute top-3 right-3 text-white/80 hover:text-white"
               >
@@ -65,10 +65,10 @@ const InspiredClydeDSouza = ({ portfolioData }) => {
 
             {/* Chat Footer Tabs */}
             <div className="border-t border-gray-100 bg-white flex">
-              <button className="flex-1 py-3 flex items-center justify-center text-[#008f7a] hover:bg-gray-50">
+              <button type="button" className="flex-1 py-3 flex items-center justify-center text-[#008f7a] hover:bg-gray-50">
                 <Home size={20} />
               </button>
-              <button className="flex-1 py-3 flex items-center justify-center text-gray-400 hover:bg-gray-50 hover:text-gray-600">
+              <button type="button" className="flex-1 py-3 flex items-center justify-center text-gray-400 hover:bg-gray-50 hover:text-gray-600">
                 <MessageSquare size={20} />
               </button>
             </div>

--- a/frontend/src/components/portfolio/templates/Inspired_Dev_Jadiya/index.jsx
+++ b/frontend/src/components/portfolio/templates/Inspired_Dev_Jadiya/index.jsx
@@ -389,7 +389,7 @@ export default function InspiredDevJadiya() {
         <div className="flex items-center gap-2">
           <span className={`${style.textMuted}`}>Theme Mode:</span>
           {['tokyonight', 'matrix', 'dracula', 'monokai'].map((t) => (
-            <button
+            <button type="button"
               key={t}
               onClick={() => setTheme(t)}
               className={`px-1.5 py-0.5 border uppercase text-[10px] ${

--- a/frontend/src/components/portfolio/templates/Interactive_Table_of_Elements/index.jsx
+++ b/frontend/src/components/portfolio/templates/Interactive_Table_of_Elements/index.jsx
@@ -193,7 +193,7 @@ const DetailsPanel = ({ element, onClose }) => {
         boxShadow: `0 10px 40px -10px ${color}30`,
       }}
     >
-      <button 
+      <button type="button" 
         onClick={onClose}
         className="absolute top-4 right-4 p-2 rounded-full hover:bg-white/10 transition-colors"
         style={{ color: C.textMuted }}
@@ -314,7 +314,7 @@ export default function InteractiveTablePortfolio({ portfolioData }) {
           {/* Legend / Filters */}
           <div className="flex flex-wrap gap-3">
             {categories.map(cat => (
-              <button
+              <button type="button"
                 key={cat}
                 onClick={() => setActiveCategory(cat)}
                 className="px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest transition-all"

--- a/frontend/src/components/portfolio/templates/Liquid_Glass/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Liquid_Glass/Contact.jsx
@@ -74,7 +74,7 @@ export default function Contact({ data }) {
               placeholder="Your Message"
               className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/30 text-sm focus:outline-none focus:border-cyan-400/60 backdrop-blur-sm transition-all mb-4 resize-none"
             />
-            <button className="w-full py-3 rounded-xl bg-gradient-to-r from-cyan-500/40 to-purple-500/40 hover:from-cyan-500/60 hover:to-purple-500/60 border border-white/20 text-white font-semibold text-sm backdrop-blur-sm transition-all">
+            <button type="button" className="w-full py-3 rounded-xl bg-gradient-to-r from-cyan-500/40 to-purple-500/40 hover:from-cyan-500/60 hover:to-purple-500/60 border border-white/20 text-white font-semibold text-sm backdrop-blur-sm transition-all">
               Send Message
             </button>
           </GlassCard>

--- a/frontend/src/components/portfolio/templates/MacOS_Desktop/FinderWindow.jsx
+++ b/frontend/src/components/portfolio/templates/MacOS_Desktop/FinderWindow.jsx
@@ -38,19 +38,19 @@ export default function FinderWindow({ title, children, defaultOpen = true, icon
         className="h-10 flex items-center justify-between px-4 bg-gradient-to-b from-white/80 to-white/40 dark:from-white/10 dark:to-transparent border-b border-gray-200 dark:border-white/10 select-none cursor-default"
       >
         <div className="flex gap-2 w-16">
-          <button 
+          <button type="button" 
             onClick={(e) => { e.stopPropagation(); setIsOpen(false); }}
             className="w-3.5 h-3.5 rounded-full bg-red-500 hover:bg-red-600 shadow-inner flex items-center justify-center group"
           >
             <span className="opacity-0 group-hover:opacity-100 text-[8px] text-red-900 leading-none">✕</span>
           </button>
-          <button 
+          <button type="button" 
             onClick={(e) => { e.stopPropagation(); setIsMinimized(!isMinimized); }}
             className="w-3.5 h-3.5 rounded-full bg-yellow-500 hover:bg-yellow-600 shadow-inner flex items-center justify-center group"
           >
             <span className="opacity-0 group-hover:opacity-100 text-[8px] text-yellow-900 leading-none">−</span>
           </button>
-          <button 
+          <button type="button" 
             onClick={(e) => { e.stopPropagation(); setIsFullscreen(!isFullscreen); }}
             className="w-3.5 h-3.5 rounded-full bg-green-500 hover:bg-green-600 shadow-inner flex items-center justify-center group"
           >

--- a/frontend/src/components/portfolio/templates/Magazine_Editorial/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Magazine_Editorial/Hero.jsx
@@ -24,7 +24,7 @@ export default function Hero() {
             visual identity.
           </p>
 
-          <button className="group flex items-center gap-3 border border-black px-6 py-3 hover:bg-black hover:text-white transition-all duration-300">
+          <button type="button" className="group flex items-center gap-3 border border-black px-6 py-3 hover:bg-black hover:text-white transition-all duration-300">
             Explore Portfolio
 
             <ArrowRight

--- a/frontend/src/components/portfolio/templates/Magazine_Editorial/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Magazine_Editorial/Projects.jsx
@@ -375,7 +375,7 @@ export default function Projects() {
       }}
     >
       {/* ── Theme Toggle ─────────────────────────────────────────────────── */}
-      <button
+      <button type="button"
         onClick={() => setIsDark(!isDark)}
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         style={{

--- a/frontend/src/components/portfolio/templates/Mariana_Ocean_Trench/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Mariana_Ocean_Trench/Contact.jsx
@@ -243,7 +243,7 @@ export default function Contact({ personal, socials }) {
             )}
             
             {/* Return to Surface */}
-            <button 
+            <button type="button" 
               onClick={handleScrollToTop}
               className="flex-1 sm:flex-initial py-2.5 px-5 bg-cyan-950/20 border border-cyan-500/30 hover:border-cyan-400 rounded-lg flex items-center justify-center gap-2 text-cyan-300 hover:shadow-[0_0_15px_rgba(34,211,238,0.25)] transition-all cursor-pointer"
             >

--- a/frontend/src/components/portfolio/templates/Mariana_Ocean_Trench/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Mariana_Ocean_Trench/Hero.jsx
@@ -88,14 +88,14 @@ export default function Hero({ data }) {
           transition={{ duration: 0.8, ease: 'easeOut', delay: 0.4 }}
           className="flex flex-col sm:flex-row gap-4 mt-4 w-full sm:w-auto"
         >
-          <button 
+          <button type="button" 
             onClick={handleBeginDive}
             className="group px-8 py-4 bg-sky-100 hover:bg-white text-sky-950 font-bold rounded-full shadow-lg hover:shadow-sky-200/50 transition-all flex items-center justify-center gap-2 cursor-pointer border-2 border-transparent"
           >
             <span>🌊 Begin the Dive</span>
           </button>
           
-          <button 
+          <button type="button" 
             onClick={() => {
               const projectsSection = document.getElementById('midnight-zone');
               if (projectsSection) projectsSection.scrollIntoView({ behavior: 'smooth' });

--- a/frontend/src/components/portfolio/templates/Medical_Clean/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Medical_Clean/Contact.jsx
@@ -302,7 +302,7 @@ export default function Contact({ data = {} }) {
                     Thank you for reaching out. Our office will contact you within one
                     business day.
                   </p>
-                  <button
+                  <button type="button"
                     onClick={() => setStatus('idle')}
                     className="mt-6 text-xs font-semibold text-teal-600 hover:underline"
                   >

--- a/frontend/src/components/portfolio/templates/Mono_Elegant/index.jsx
+++ b/frontend/src/components/portfolio/templates/Mono_Elegant/index.jsx
@@ -440,7 +440,7 @@ export default function MonoElegant() {
         <div className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
           
           {/* Logo / Initials */}
-          <button 
+          <button type="button" 
             onClick={() => handleScrollTo("hero")}
             className="text-lg font-bold tracking-[0.25em] uppercase mono-font-sans flex items-center gap-2"
           >
@@ -459,7 +459,7 @@ export default function MonoElegant() {
               { id: "contact", label: "Contact" }
             ].map((item) => (
               <Magnetic key={item.id}>
-                <button
+                <button type="button"
                   onClick={() => handleScrollTo(item.id)}
                   className={`mono-nav-link text-xs uppercase tracking-widest text-neutral-400 dark:text-neutral-500 hover:text-current px-1 py-1 ${
                     activeSection === item.id ? "text-neutral-900 dark:text-neutral-100 font-semibold" : ""
@@ -474,7 +474,7 @@ export default function MonoElegant() {
           {/* Theme Toggler + Menu Toggle */}
           <div className="flex items-center gap-4">
             <Magnetic>
-              <button
+              <button type="button"
                 onClick={() => setIsNoir(!isNoir)}
                 className="px-3.5 py-1 text-[10px] tracking-widest uppercase border mono-border rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-900 transition-colors"
                 aria-label="Toggle monochrome theme"
@@ -484,7 +484,7 @@ export default function MonoElegant() {
             </Magnetic>
 
             {/* Mobile Menu Toggle */}
-            <button
+            <button type="button"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className="p-1 md:hidden hover:opacity-75 transition-opacity"
               aria-label="Toggle navigation menu"
@@ -515,7 +515,7 @@ export default function MonoElegant() {
                 { id: "testimonials", label: "Quotes" },
                 { id: "contact", label: "Contact" }
               ].map((item) => (
-                <button
+                <button type="button"
                   key={item.id}
                   onClick={() => handleScrollTo(item.id)}
                   className="text-left text-sm uppercase tracking-widest py-2 border-b mono-border last:border-0"
@@ -589,7 +589,7 @@ export default function MonoElegant() {
           {/* Calls to Action */}
           <motion.div variants={fadeUp} className="flex flex-wrap gap-4 justify-center">
             <Magnetic>
-              <button 
+              <button type="button" 
                 onClick={() => handleScrollTo("contact")}
                 className="mono-btn-primary px-9 py-4 text-xs uppercase tracking-widest flex items-center gap-2 border mono-border"
               >
@@ -598,7 +598,7 @@ export default function MonoElegant() {
               </button>
             </Magnetic>
             <Magnetic>
-              <button 
+              <button type="button" 
                 onClick={() => handleScrollTo("projects")}
                 className="mono-btn-secondary px-9 py-4 text-xs uppercase tracking-widest"
               >
@@ -1022,7 +1022,7 @@ export default function MonoElegant() {
           </p>
           <div className="flex gap-6 text-[10px] uppercase tracking-widest">
             <Magnetic>
-              <button onClick={() => handleScrollTo("hero")} className="hover:text-neutral-900 dark:hover:text-white transition-colors">Back to Top</button>
+              <button type="button" onClick={() => handleScrollTo("hero")} className="hover:text-neutral-900 dark:hover:text-white transition-colors">Back to Top</button>
             </Magnetic>
           </div>
         </div>
@@ -1051,7 +1051,7 @@ function ProjectsGrid({ projects }) {
         <span className="text-[10px] uppercase tracking-widest text-neutral-400 dark:text-neutral-500 mr-4">// Taxonomy:</span>
         {allTech.map((tech) => (
           <Magnetic key={tech}>
-            <button
+            <button type="button"
               onClick={() => setActiveFilter(tech)}
               className={`px-3 py-1.5 text-[10px] uppercase tracking-widest border transition-colors ${
                 activeFilter === tech
@@ -1211,7 +1211,7 @@ function TestimonialsCarousel({ testimonials }) {
       {/* Buttons */}
       <div className="flex justify-end gap-2 mt-8 md:mt-4">
         <Magnetic>
-          <button
+          <button type="button"
             onClick={handlePrev}
             className="p-2.5 border mono-border hover:bg-neutral-100 dark:hover:bg-neutral-900 transition-colors flex items-center justify-center"
             aria-label="Previous quote"
@@ -1220,7 +1220,7 @@ function TestimonialsCarousel({ testimonials }) {
           </button>
         </Magnetic>
         <Magnetic>
-          <button
+          <button type="button"
             onClick={handleNext}
             className="p-2.5 border mono-border hover:bg-neutral-100 dark:hover:bg-neutral-900 transition-colors flex items-center justify-center"
             aria-label="Next quote"

--- a/frontend/src/components/portfolio/templates/Morse_Code_Flashing_Decoder/index.jsx
+++ b/frontend/src/components/portfolio/templates/Morse_Code_Flashing_Decoder/index.jsx
@@ -748,19 +748,19 @@ export default function MorseCodeFlashingDecoder() {
 
       {/* ── Navigation ── */}
       <nav className={`mcd-nav${scrollY > 60 ? " mcd-nav-scrolled" : ""}`}>
-        <button className="mcd-nav-brand" onClick={() => scrollTo("hero")}>
+        <button type="button" className="mcd-nav-brand" onClick={() => scrollTo("hero")}>
           &gt; <span>{personal.name?.split(" ")[0] || "MORSE"}</span>.exe
         </button>
         <ul className="mcd-nav-links">
           {navLinks.map((l) => (
             <li key={l.id}>
-              <button className="mcd-nav-link" onClick={() => scrollTo(l.id)}>
+              <button type="button" className="mcd-nav-link" onClick={() => scrollTo(l.id)}>
                 {l.label}
               </button>
             </li>
           ))}
         </ul>
-        <button className="mcd-nav-toggle" onClick={() => setMenuOpen(true)} aria-label="Open menu">
+        <button type="button" className="mcd-nav-toggle" onClick={() => setMenuOpen(true)} aria-label="Open menu">
           <Menu size={22} />
         </button>
       </nav>
@@ -775,7 +775,7 @@ export default function MorseCodeFlashingDecoder() {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <button className="mcd-mobile-close" onClick={() => setMenuOpen(false)} aria-label="Close">
+            <button type="button" className="mcd-mobile-close" onClick={() => setMenuOpen(false)} aria-label="Close">
               <X size={26} />
             </button>
             {navLinks.map((l, i) => (
@@ -820,10 +820,10 @@ export default function MorseCodeFlashingDecoder() {
             <p className="mcd-hero-tagline">{personal.tagline}</p>
           )}
           <div className="mcd-hero-actions">
-            <button className="mcd-btn mcd-btn-primary" onClick={() => scrollTo("projects")}>
+            <button type="button" className="mcd-btn mcd-btn-primary" onClick={() => scrollTo("projects")}>
               VIEW PROJECTS
             </button>
-            <button className="mcd-btn mcd-btn-outline" onClick={() => scrollTo("contact")}>
+            <button type="button" className="mcd-btn mcd-btn-outline" onClick={() => scrollTo("contact")}>
               CONTACT
             </button>
           </div>

--- a/frontend/src/components/portfolio/templates/Music_Vinyl/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Music_Vinyl/Contact.jsx
@@ -51,7 +51,7 @@ export default function Contact({ personal, socials }) {
                   placeholder="What's on your mind?"
                 ></textarea>
               </div>
-              <button className="w-full bg-amber-600 hover:bg-amber-500 text-[#0a0502] font-bold uppercase tracking-widest py-3 px-6 rounded-lg flex items-center justify-center space-x-2 transition-colors">
+              <button type="button" className="w-full bg-amber-600 hover:bg-amber-500 text-[#0a0502] font-bold uppercase tracking-widest py-3 px-6 rounded-lg flex items-center justify-center space-x-2 transition-colors">
                 <span>Send Track</span>
                 <Send className="w-4 h-4" />
               </button>

--- a/frontend/src/components/portfolio/templates/Neon_Cityscape/index.jsx
+++ b/frontend/src/components/portfolio/templates/Neon_Cityscape/index.jsx
@@ -370,7 +370,7 @@ export default function NeonCityscape() {
           </motion.div>
           <div className="hidden md:flex items-center gap-1">
             {navLinks.map((link) => (
-              <button key={link.id} onClick={() => scrollTo(link.id)}
+              <button type="button" key={link.id} onClick={() => scrollTo(link.id)}
                 className="px-3 py-1.5 rounded text-xs font-bold uppercase tracking-widest transition-all font-mono"
                 style={{
                   color: activeSection === link.id ? NEON.cyan : NEON.muted,

--- a/frontend/src/components/portfolio/templates/Neon_Noir/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Neon_Noir/Contact.jsx
@@ -102,7 +102,7 @@ export default function Contact({ personal, socials }) {
                   rows="3"
                   className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-2 focus:outline-none focus:border-cyan-500/50 text-sm resize-none"
                 ></textarea>
-                <button 
+                <button type="button" 
                   className="w-full bg-white/10 hover:bg-white/20 border border-white/20 text-white font-medium py-2 rounded-lg transition-all"
                 >
                   Send Message

--- a/frontend/src/components/portfolio/templates/Neon_Sign/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Neon_Sign/Testimonials.jsx
@@ -171,7 +171,7 @@ export default function Testimonials({ data }) {
             {/* Dot indicators */}
             <div className="flex gap-2">
               {testimonials.map((_, i) => (
-                <button
+                <button type="button"
                   key={i}
                   onClick={() => setCurrent(i)}
                   className="transition-all duration-300 rounded-full cursor-pointer"

--- a/frontend/src/components/portfolio/templates/Neon_Sign/index.jsx
+++ b/frontend/src/components/portfolio/templates/Neon_Sign/index.jsx
@@ -193,7 +193,7 @@ function NeonNav({ menuOpen, setMenuOpen }) {
       </Motion.a>
 
       {/* Mobile hamburger */}
-      <button
+      <button type="button"
         className="md:hidden p-2 rounded border border-pink-500/40 text-pink-400 cursor-pointer"
         style={{ background: 'rgba(255,43,214,0.06)', boxShadow: '0 0 8px #ff2bd620' }}
         onClick={() => setMenuOpen((o) => !o)}
@@ -257,7 +257,7 @@ function MobileAccordion({ sectionId, label, color, children }) {
       className="border-b border-white/5"
       style={{ borderColor: `${color}20` }}
     >
-      <button
+      <button type="button"
         id={sectionId}
         onClick={() => setOpen((o) => !o)}
         className="w-full flex items-center justify-between px-5 py-4 cursor-pointer"

--- a/frontend/src/components/portfolio/templates/Netflix_Browse/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Netflix_Browse/Projects.jsx
@@ -22,14 +22,14 @@ export default function Projects({ projects }) {
           </span>
         </h2>
         <div className="flex gap-2">
-          <button
+          <button type="button"
             onClick={() => scroll(-1)}
             className="w-8 h-8 rounded-full bg-white/10 hover:bg-[#E50914] flex items-center justify-center transition-colors"
             aria-label="Scroll left"
           >
             <ChevronLeft className="w-4 h-4 text-white" />
           </button>
-          <button
+          <button type="button"
             onClick={() => scroll(1)}
             className="w-8 h-8 rounded-full bg-white/10 hover:bg-[#E50914] flex items-center justify-center transition-colors"
             aria-label="Scroll right"

--- a/frontend/src/components/portfolio/templates/OLED_Black/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/OLED_Black/Testimonials.jsx
@@ -59,7 +59,7 @@ const Testimonials = ({ testimonials }) => {
 
         <div className="absolute bottom-6 right-8 z-10 flex gap-2">
           {testimonials.map((_, index) => (
-            <button
+            <button type="button"
               key={index}
               onClick={() => setActiveIndex(index)}
               className={`h-1 transition-all duration-300 ${activeIndex === index ? 'w-8 bg-cyan-400' : 'w-2 bg-gray-700 hover:bg-gray-500'}`}

--- a/frontend/src/components/portfolio/templates/Obsidian_Vault/index.jsx
+++ b/frontend/src/components/portfolio/templates/Obsidian_Vault/index.jsx
@@ -552,7 +552,7 @@ function Contact() {
               placeholder="Your Message"
               className="w-full px-4 py-3 rounded-lg bg-purple-500/5 border border-purple-500/20 text-white placeholder-gray-500 text-sm focus:outline-none focus:border-purple-500/50 transition-all mb-4 resize-none"
             />
-            <button className="w-full py-3 rounded-lg bg-purple-600 hover:bg-purple-500 text-white font-medium transition-all hover:shadow-[0_0_20px_rgba(168,85,247,0.4)]">
+            <button type="button" className="w-full py-3 rounded-lg bg-purple-600 hover:bg-purple-500 text-white font-medium transition-all hover:shadow-[0_0_20px_rgba(168,85,247,0.4)]">
               <Send size={16} className="inline mr-2" />
               Send Message
             </button>

--- a/frontend/src/components/portfolio/templates/Ocean_Depths/index.jsx
+++ b/frontend/src/components/portfolio/templates/Ocean_Depths/index.jsx
@@ -390,7 +390,7 @@ export default function OceanDepths() {
           </motion.div>
           <div className="hidden md:flex items-center gap-1">
             {navLinks.map((link) => (
-              <button key={link.id} onClick={() => scrollTo(link.id)}
+              <button type="button" key={link.id} onClick={() => scrollTo(link.id)}
                 className="px-3 py-1.5 rounded-lg text-sm transition-all"
                 style={{ color: activeSection === link.id ? OCEAN.glow : '#5a8fa0', background: activeSection === link.id ? 'rgba(0,229,255,0.1)' : 'transparent' }}>
                 {link.label}

--- a/frontend/src/components/portfolio/templates/One_Page_Scroll/index.jsx
+++ b/frontend/src/components/portfolio/templates/One_Page_Scroll/index.jsx
@@ -239,7 +239,7 @@ export default function OnePageScroll() {
       {/* Side dot navigation */}
       <div className="ops-dot-nav">
         {SECTIONS.map(({ id, label }) => (
-          <button key={id} className={`ops-dot ${active === id ? "active" : ""}`} onClick={() => scrollTo(id)} title={label} aria-label={label}>
+          <button type="button" key={id} className={`ops-dot ${active === id ? "active" : ""}`} onClick={() => scrollTo(id)} title={label} aria-label={label}>
             <span className="ops-dot-tooltip">{label}</span>
           </button>
         ))}
@@ -247,11 +247,11 @@ export default function OnePageScroll() {
 
       {/* Top nav */}
       <nav className="ops-nav">
-        <button onClick={() => scrollTo("hero")} style={{ background: "none", border: "none", cursor: "pointer", fontSize: 16, fontWeight: 700, color: C.dark, fontFamily: "'Inter',sans-serif" }}>
+        <button type="button" onClick={() => scrollTo("hero")} style={{ background: "none", border: "none", cursor: "pointer", fontSize: 16, fontWeight: 700, color: C.dark, fontFamily: "'Inter',sans-serif" }}>
           {data.personal.name.split(" ")[0]}
         </button>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-          <button className="ops-btn ops-btn-outline" onClick={() => scrollTo("contact")} style={{ fontSize: 12, padding: "8px 16px" }}>Say Hi</button>
+          <button type="button" className="ops-btn ops-btn-outline" onClick={() => scrollTo("contact")} style={{ fontSize: 12, padding: "8px 16px" }}>Say Hi</button>
           <a href={resumeUrl} className="ops-btn ops-btn-primary" style={{ fontSize: 12, padding: "8px 16px" }}>Resume</a>
         </div>
       </nav>
@@ -276,8 +276,8 @@ export default function OnePageScroll() {
           </motion.p>
           <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.5 }}
             style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginBottom: 48 }}>
-            <button className="ops-btn ops-btn-primary" onClick={() => scrollTo("projects")}>View Projects</button>
-            <button className="ops-btn ops-btn-outline" onClick={() => scrollTo("contact")}>Get In Touch</button>
+            <button type="button" className="ops-btn ops-btn-primary" onClick={() => scrollTo("projects")}>View Projects</button>
+            <button type="button" className="ops-btn ops-btn-outline" onClick={() => scrollTo("contact")}>Get In Touch</button>
           </motion.div>
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.65 }}>
             <div className="ops-stats" style={{ margin: "0 auto" }}>
@@ -294,7 +294,7 @@ export default function OnePageScroll() {
             </div>
           </motion.div>
         </div>
-        <button onClick={() => scrollTo("about")} style={{ position: "absolute", bottom: 24, left: "50%", transform: "translateX(-50%)", background: "none", border: "none", cursor: "pointer" }}>
+        <button type="button" onClick={() => scrollTo("about")} style={{ position: "absolute", bottom: 24, left: "50%", transform: "translateX(-50%)", background: "none", border: "none", cursor: "pointer" }}>
           <motion.div animate={{ y: [0,6,0] }} transition={{ duration: 1.8, repeat: Infinity }}>
             <ChevronDown size={20} style={{ color: C.muted }} />
           </motion.div>

--- a/frontend/src/components/portfolio/templates/One_Pixel_Master/index.jsx
+++ b/frontend/src/components/portfolio/templates/One_Pixel_Master/index.jsx
@@ -187,7 +187,7 @@ export default function One_Pixel_Master({ portfolioData }) {
         </div>
         <div style={{ display: "flex", gap: "4px" }}>
           {SECTIONS.map(s => (
-            <button key={s} onClick={() => setActive(s)} style={{
+            <button type="button" key={s} onClick={() => setActive(s)} style={{
               padding: "8px 18px",
               borderRadius: "100px",
               border: "none",
@@ -263,7 +263,7 @@ export default function One_Pixel_Master({ portfolioData }) {
             </div>
 
             <div style={{ display: "flex", gap: "16px" }}>
-              <button onClick={() => setActive("projects")} style={{
+              <button type="button" onClick={() => setActive("projects")} style={{
                 padding: "16px 40px",
                 borderRadius: "100px",
                 border: `1px solid ${ACCENT}44`,
@@ -281,7 +281,7 @@ export default function One_Pixel_Master({ portfolioData }) {
               >
                 View My Work ◈
               </button>
-              <button onClick={() => setActive("contact")} style={{
+              <button type="button" onClick={() => setActive("contact")} style={{
                 padding: "16px 40px",
                 borderRadius: "100px",
                 border: "1px solid rgba(255,255,255,0.1)",

--- a/frontend/src/components/portfolio/templates/Origami_Paper/About.jsx
+++ b/frontend/src/components/portfolio/templates/Origami_Paper/About.jsx
@@ -191,7 +191,7 @@ export default function About() {
         {/* Tabs */}
         <div className="flex justify-center gap-0 mb-8">
           {tabs.map((tab, i) => (
-            <button
+            <button type="button"
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className="px-6 py-3 text-sm tracking-wider uppercase transition-all duration-200 relative"

--- a/frontend/src/components/portfolio/templates/Origami_Paper/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Origami_Paper/Projects.jsx
@@ -88,7 +88,7 @@ export default function Projects() {
                   {project.title}
                 </h3>
 
-                <button
+                <button type="button"
                   aria-label={`Open ${project.title}`}
                   className="h-10 w-10 flex items-center justify-center border-2 border-black bg-[#f7efe3] transition-transform group-hover:rotate-12"
                 >
@@ -121,7 +121,7 @@ export default function Projects() {
 
         {/* CTA */}
         <div className="mt-20 text-center">
-          <button className="border-2 border-black bg-black px-10 py-4 text-white font-bold shadow-[6px_6px_0px_#cbb89d] transition-all hover:-translate-y-1 hover:shadow-[10px_10px_0px_#cbb89d]">
+          <button type="button" className="border-2 border-black bg-black px-10 py-4 text-white font-bold shadow-[6px_6px_0px_#cbb89d] transition-all hover:-translate-y-1 hover:shadow-[10px_10px_0px_#cbb89d]">
             View All Projects
           </button>
         </div>
@@ -156,7 +156,7 @@ export default function Projects() {
               ))}
             </div>
 
-            <button
+            <button type="button"
               onClick={() => setActiveProject(null)}
               className="mt-6 border-2 border-black bg-black text-white px-4 py-2"
             >

--- a/frontend/src/components/portfolio/templates/Origami_Unfold_Step_Animation/index.jsx
+++ b/frontend/src/components/portfolio/templates/Origami_Unfold_Step_Animation/index.jsx
@@ -199,7 +199,7 @@ export default function Origami_Unfold_Step_Animation({ data: localData, portfol
       />
 
       <div className="absolute top-4 right-4 flex items-center gap-2 text-neutral-400 font-mono text-xs z-50">
-        <button 
+        <button type="button" 
           onClick={handleReplay} 
           className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-neutral-900/60 border border-neutral-800 hover:bg-neutral-800 hover:text-white transition-all pointer-events-auto cursor-pointer"
         >

--- a/frontend/src/components/portfolio/templates/Page_Turner/ExperiencePage.jsx
+++ b/frontend/src/components/portfolio/templates/Page_Turner/ExperiencePage.jsx
@@ -53,14 +53,14 @@ const ExperiencePage = React.forwardRef(function ExperiencePage(_, ref) {
           <div className="shrink-0 pt-4 border-t border-slate-800 flex justify-between items-center mt-auto">
             <span className="text-[9px] text-slate-600 font-mono">PAGE {currentPage + 1} / {totalPages || 1}</span>
             <div className="flex gap-2">
-              <button 
+              <button type="button" 
                 disabled={currentPage === 0} 
                 onClick={() => setCurrentPage(p => p - 1)} 
                 className="px-4 py-1.5 text-[9px] border border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/10 disabled:opacity-20 uppercase font-mono tracking-widest transition-colors"
               >
                 Prev
               </button>
-              <button 
+              <button type="button" 
                 disabled={currentPage >= totalPages - 1} 
                 onClick={() => setCurrentPage(p => p + 1)} 
                 className="px-4 py-1.5 text-[9px] border border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/10 disabled:opacity-20 uppercase font-mono tracking-widest transition-colors"

--- a/frontend/src/components/portfolio/templates/Page_Turner/ProjectsPage.jsx
+++ b/frontend/src/components/portfolio/templates/Page_Turner/ProjectsPage.jsx
@@ -56,8 +56,8 @@ const ProjectsPage = React.forwardRef(function ProjectsPage(_, ref) {
           <div className="shrink-0 pt-3 border-t border-slate-800 flex justify-between items-center">
             <span className="text-[9px] font-mono text-slate-600">PAGE {currentPage + 1} / {totalPages || 1}</span>
             <div className="flex gap-2">
-              <button disabled={currentPage === 0} onClick={() => setCurrentPage(p => p - 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Prev</button>
-              <button disabled={currentPage >= totalPages - 1} onClick={() => setCurrentPage(p => p + 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Next</button>
+              <button type="button" disabled={currentPage === 0} onClick={() => setCurrentPage(p => p - 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Prev</button>
+              <button type="button" disabled={currentPage >= totalPages - 1} onClick={() => setCurrentPage(p => p + 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Next</button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/portfolio/templates/Page_Turner/TestimonialsPage.jsx
+++ b/frontend/src/components/portfolio/templates/Page_Turner/TestimonialsPage.jsx
@@ -50,8 +50,8 @@ const TestimonialsPage = React.forwardRef(function TestimonialsPage(_, ref) {
           <div className="shrink-0 pt-3 border-t border-slate-800 flex justify-between items-center">
             <span className="text-[9px] text-slate-600 font-mono">PAGE {currentPage + 1} / {totalPages || 1}</span>
             <div className="flex gap-2">
-              <button disabled={currentPage === 0} onClick={() => setCurrentPage(p => p - 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Prev</button>
-              <button disabled={currentPage >= totalPages - 1} onClick={() => setCurrentPage(p => p + 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Next</button>
+              <button type="button" disabled={currentPage === 0} onClick={() => setCurrentPage(p => p - 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Prev</button>
+              <button type="button" disabled={currentPage >= totalPages - 1} onClick={() => setCurrentPage(p => p + 1)} className="px-3 py-1 text-[9px] border border-cyan-500/30 text-cyan-400 disabled:opacity-20 uppercase font-mono">Next</button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/portfolio/templates/Pastel_Soft/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Pastel_Soft/Hero.jsx
@@ -23,11 +23,11 @@ export default function Hero() {
         </p>
 
         <div className="mt-8 flex gap-4 flex-wrap">
-          <button className="px-6 py-3 rounded-full bg-purple-400 text-white font-medium hover:bg-purple-500 transition">
+          <button type="button" className="px-6 py-3 rounded-full bg-purple-400 text-white font-medium hover:bg-purple-500 transition">
             View Projects
           </button>
 
-          <button className="px-6 py-3 rounded-full border border-purple-400 text-purple-600 font-medium hover:bg-purple-100 transition">
+          <button type="button" className="px-6 py-3 rounded-full border border-purple-400 text-purple-600 font-medium hover:bg-purple-100 transition">
             Contact Me
           </button>
         </div>

--- a/frontend/src/components/portfolio/templates/Pinterest_Masonry/index.jsx
+++ b/frontend/src/components/portfolio/templates/Pinterest_Masonry/index.jsx
@@ -106,8 +106,8 @@ export default function PinterestMasonry({ data: propData }) {
           <div className="w-12 h-12 rounded-full flex items-center justify-center hover:bg-gray-100 cursor-pointer text-[#e60023]">
             <svg viewBox="0 0 24 24" className="w-6 h-6 fill-current"><path d="M12.017 0C5.396 0 .029 5.367.029 11.987c0 5.079 3.158 9.417 7.618 11.162-.105-.949-.199-2.403.041-3.439.219-.937 1.406-5.957 1.406-5.957s-.359-.72-.359-1.781c0-1.663.967-2.911 2.168-2.911 1.024 0 1.518.769 1.518 1.688 0 1.029-.653 2.567-.992 3.992-.285 1.193.6 2.165 1.775 2.165 2.128 0 3.768-2.245 3.768-5.487 0-2.861-2.063-4.869-5.008-4.869-3.41 0-5.409 2.562-5.409 5.199 0 1.033.394 2.143.889 2.741.099.12.112.225.085.345l-.288 1.178c-.046.19-.152.232-.344.143-1.282-.598-2.083-2.476-2.083-3.984 0-3.238 2.355-6.216 6.786-6.216 3.565 0 6.337 2.54 6.337 5.927 0 3.543-2.234 6.394-5.335 6.394-1.042 0-2.023-.542-2.357-1.18l-.64 2.438c-.231.884-.858 1.99-1.28 2.665 1.002.308 2.066.474 3.155.474 6.621 0 11.988-5.368 11.988-11.988C24 5.367 18.638 0 12.017 0z"/></svg>
           </div>
-          <button className="hidden md:block px-4 py-3 bg-[#111111] text-white rounded-full font-semibold text-[15px]">Home</button>
-          <button className="hidden md:flex px-4 py-3 hover:bg-gray-100 rounded-full font-semibold text-[15px] items-center gap-1">Create <ChevronDown size={20}/></button>
+          <button type="button" className="hidden md:block px-4 py-3 bg-[#111111] text-white rounded-full font-semibold text-[15px]">Home</button>
+          <button type="button" className="hidden md:flex px-4 py-3 hover:bg-gray-100 rounded-full font-semibold text-[15px] items-center gap-1">Create <ChevronDown size={20}/></button>
         </div>
 
         {/* Search */}
@@ -143,7 +143,7 @@ export default function PinterestMasonry({ data: propData }) {
         <div className="flex justify-center mb-8 overflow-x-auto hide-scrollbar py-2">
           <div className="flex gap-2">
             {categories.map(category => (
-              <button
+              <button type="button"
                 key={category}
                 onClick={() => setActiveCategory(category)}
                 className={`px-5 py-2.5 rounded-full font-semibold text-[15px] transition-colors whitespace-nowrap ${
@@ -233,10 +233,10 @@ function ProfilePin({ pin }) {
         </p>
 
         <div className="flex gap-4 w-full">
-          <button className="flex-1 py-3 bg-[#e60023] hover:bg-[#b50019] text-white rounded-full font-bold transition-colors">
+          <button type="button" className="flex-1 py-3 bg-[#e60023] hover:bg-[#b50019] text-white rounded-full font-bold transition-colors">
             Follow
           </button>
-          <button className="flex-1 py-3 bg-[#e9e9e9] hover:bg-[#e1e1e1] rounded-full font-bold transition-colors">
+          <button type="button" className="flex-1 py-3 bg-[#e9e9e9] hover:bg-[#e1e1e1] rounded-full font-bold transition-colors">
             Message
           </button>
         </div>
@@ -279,7 +279,7 @@ function ProjectPin({ pin, data }) {
         {/* Hover Overlay */}
         <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col justify-between p-4">
           <div className="flex justify-end">
-            <button className="bg-[#e60023] hover:bg-[#b50019] text-white font-bold px-4 py-3 rounded-full shadow-md text-[15px] transform translate-y-2 group-hover:translate-y-0 transition-transform duration-300">
+            <button type="button" className="bg-[#e60023] hover:bg-[#b50019] text-white font-bold px-4 py-3 rounded-full shadow-md text-[15px] transform translate-y-2 group-hover:translate-y-0 transition-transform duration-300">
               Save
             </button>
           </div>
@@ -290,10 +290,10 @@ function ProjectPin({ pin, data }) {
               </a>
             )}
             <div className="flex gap-2">
-              <button className="w-9 h-9 rounded-full bg-white/90 hover:bg-white flex items-center justify-center text-black backdrop-blur-sm transform translate-y-2 group-hover:translate-y-0 transition-transform duration-300 delay-100">
+              <button type="button" className="w-9 h-9 rounded-full bg-white/90 hover:bg-white flex items-center justify-center text-black backdrop-blur-sm transform translate-y-2 group-hover:translate-y-0 transition-transform duration-300 delay-100">
                 <Share size={18} />
               </button>
-              <button className="w-9 h-9 rounded-full bg-white/90 hover:bg-white flex items-center justify-center text-black backdrop-blur-sm transform translate-y-2 group-hover:translate-y-0 transition-transform duration-300 delay-150">
+              <button type="button" className="w-9 h-9 rounded-full bg-white/90 hover:bg-white flex items-center justify-center text-black backdrop-blur-sm transform translate-y-2 group-hover:translate-y-0 transition-transform duration-300 delay-150">
                 <MoreHorizontal size={18} />
               </button>
             </div>

--- a/frontend/src/components/portfolio/templates/Planetary_Orbit/index.jsx
+++ b/frontend/src/components/portfolio/templates/Planetary_Orbit/index.jsx
@@ -367,7 +367,7 @@ export default function PlanetaryOrbit() {
           </motion.div>
           <div className="hidden md:flex items-center gap-1">
             {PLANETS.map((p) => (
-              <button key={p.id} onClick={() => scrollTo(p.id)}
+              <button type="button" key={p.id} onClick={() => scrollTo(p.id)}
                 className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-all"
                 style={{ color: activeSection === p.id ? p.color : SPACE.muted,
                   background: activeSection === p.id ? `${p.color}12` : 'transparent' }}>

--- a/frontend/src/components/portfolio/templates/Playing_Cards/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Playing_Cards/Contact.jsx
@@ -42,7 +42,7 @@ const Contact = ({ data }) => {
               <p className="text-purple-600 text-sm mb-2">Email Me</p>
               <div className="flex items-center gap-2">
                 <Mail className="w-5 h-5 text-purple-600" /><span className="text-gray-900 flex-1">{socials.email}</span>
-                <button onClick={() => { navigator.clipboard.writeText(socials.email); setCopied(true); setTimeout(() => setCopied(false), 2000); }} className="p-2 bg-purple-100 rounded-lg hover:bg-purple-200">{copied ? <CheckCircle className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4 text-purple-600" />}</button>
+                <button type="button" onClick={() => { navigator.clipboard.writeText(socials.email); setCopied(true); setTimeout(() => setCopied(false), 2000); }} className="p-2 bg-purple-100 rounded-lg hover:bg-purple-200">{copied ? <CheckCircle className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4 text-purple-600" />}</button>
               </div>
             </div>
             <div className="flex flex-wrap gap-3">

--- a/frontend/src/components/portfolio/templates/Playing_Cards/Projects.jsx
+++ b/frontend/src/components/portfolio/templates/Playing_Cards/Projects.jsx
@@ -26,7 +26,7 @@ const Projects = ({ data }) => {
           <span className="text-purple-300 font-semibold">🃟 PROJECT DECK 🃟</span>
         </div>
         <h2 className="text-4xl md:text-5xl font-bold text-white mb-4">My Project Cards</h2>
-        <button onClick={handleShuffle} disabled={shuffling}
+        <button type="button" onClick={handleShuffle} disabled={shuffling}
           className="mt-4 px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-500 transition-all">
           {shuffling ? 'Shuffling...' : '🔀 Shuffle Deck'}
         </button>

--- a/frontend/src/components/portfolio/templates/Playing_Cards/Testimonials.jsx
+++ b/frontend/src/components/portfolio/templates/Playing_Cards/Testimonials.jsx
@@ -18,9 +18,9 @@ const Testimonials = ({ data }) => {
       </div>
 
       <div className="relative max-w-4xl mx-auto">
-        <button onClick={() => setCurrent((p) => (p - 1 + testimonials.length) % testimonials.length)}
+        <button type="button" onClick={() => setCurrent((p) => (p - 1 + testimonials.length) % testimonials.length)}
           className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-4 md:-translate-x-12 z-20 p-2 bg-purple-600 text-white rounded-full hover:bg-purple-500"><ChevronLeft className="w-6 h-6" /></button>
-        <button onClick={() => setCurrent((p) => (p + 1) % testimonials.length)}
+        <button type="button" onClick={() => setCurrent((p) => (p + 1) % testimonials.length)}
           className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-4 md:translate-x-12 z-20 p-2 bg-purple-600 text-white rounded-full hover:bg-purple-500"><ChevronRight className="w-6 h-6" /></button>
 
         <AnimatePresence mode="wait">

--- a/frontend/src/components/portfolio/templates/Playing_Cards/index.jsx
+++ b/frontend/src/components/portfolio/templates/Playing_Cards/index.jsx
@@ -104,7 +104,7 @@ const PlayingCardsPortfolio = ({ portfolioData }) => {
       <nav className="sticky top-4 z-50 max-w-7xl mx-auto px-4">
         <div className="bg-white/10 backdrop-blur-md rounded-full shadow-xl p-2 flex flex-wrap justify-center gap-1 md:gap-2 border border-white/20">
           {sections.map((section) => (
-            <button
+            <button type="button"
               key={section.id}
               onClick={() => {
                 const element = document.getElementById(section.id);

--- a/frontend/src/components/portfolio/templates/Pokemon_Pokedex_Classic/index.jsx
+++ b/frontend/src/components/portfolio/templates/Pokemon_Pokedex_Classic/index.jsx
@@ -437,7 +437,7 @@ const PokemonPokedexClassic = ({ portfolioData }) => {
 
           {/* D-Pad Navigation */}
           <div className="dpad">
-            <button
+            <button type="button"
               className="dpad-btn"
               onClick={() =>
                 setSelectedIndex((prev) =>
@@ -446,12 +446,12 @@ const PokemonPokedexClassic = ({ portfolioData }) => {
               }
               title="Previous"
             />
-            <button className="dpad-btn" title="Up" />
-            <button className="dpad-btn" title="Right" />
-            <button className="dpad-btn" title="Left" />
+            <button type="button" className="dpad-btn" title="Up" />
+            <button type="button" className="dpad-btn" title="Right" />
+            <button type="button" className="dpad-btn" title="Left" />
             <div className="dpad-center" />
-            <button className="dpad-btn" title="Right" />
-            <button
+            <button type="button" className="dpad-btn" title="Right" />
+            <button type="button"
               className="dpad-btn"
               onClick={() =>
                 setSelectedIndex((prev) =>
@@ -460,14 +460,14 @@ const PokemonPokedexClassic = ({ portfolioData }) => {
               }
               title="Down"
             />
-            <button className="dpad-btn" title="Right" />
-            <button className="dpad-btn" title="Right" />
+            <button type="button" className="dpad-btn" title="Right" />
+            <button type="button" className="dpad-btn" title="Right" />
           </div>
 
           {/* Buttons */}
           {/* EDIT 4: Changed click triggers to use fully sanitized, absolute links safely */}
           <div className="button-section">
-            <button 
+            <button type="button" 
               className="pokedex-btn" 
               onClick={() => {
                 if (currentEntry.links?.github) {
@@ -479,7 +479,7 @@ const PokemonPokedexClassic = ({ portfolioData }) => {
             >
               GitHub
             </button>
-            <button 
+            <button type="button" 
               className="pokedex-btn" 
               onClick={() => {
                 if (currentEntry.links?.live) {
@@ -518,7 +518,7 @@ const PokemonPokedexClassic = ({ portfolioData }) => {
             <div style={{ color: "#000", fontSize: "8px", fontWeight: "bold" }}>
               PORTFOLIO
             </div>
-            <button className="red-btn" title="View All Projects">
+            <button type="button" className="red-btn" title="View All Projects">
               PROJ
             </button>
           </div>

--- a/frontend/src/components/portfolio/templates/Psychedelic_Swirl/index.jsx
+++ b/frontend/src/components/portfolio/templates/Psychedelic_Swirl/index.jsx
@@ -515,7 +515,7 @@ function Nav() {
           </a>
 
           {/* Mobile hamburger */}
-          <button onClick={() => setOpen(o => !o)} style={{
+          <button type="button" onClick={() => setOpen(o => !o)} style={{
             background: 'none', border: 'none', color: C.text, cursor: 'pointer', padding: 6,
           }} className="flex md:hidden">
             {open ? <X size={26} /> : <Menu size={26} />}
@@ -1151,7 +1151,7 @@ function Contact() {
                     Far Out! ✿
                   </h3>
                   <p style={{ color: C.sub }}>Thanks for reaching out! I'll get back to you soon.</p>
-                  <button onClick={() => { setStatus('idle'); setForm({ name: '', email: '', message: '' }); }}
+                  <button type="button" onClick={() => { setStatus('idle'); setForm({ name: '', email: '', message: '' }); }}
                     style={{ marginTop: 24, background: 'none', border: `1.5px solid ${C.border}`,
                       color: C.muted, padding: '8px 20px', borderRadius: 20, cursor: 'pointer',
                       fontSize: '0.88rem', transition: 'color 0.2s' }}

--- a/frontend/src/components/portfolio/templates/Rainbow_Gradient/index.jsx
+++ b/frontend/src/components/portfolio/templates/Rainbow_Gradient/index.jsx
@@ -213,7 +213,7 @@ export default function RainbowGradient() {
       <nav className="rg-nav">
         <div className="rg-nav-rainbow" />
         <div className="rg-nav-inner">
-          <button style={{ background: "none", border: "none", cursor: "pointer", fontFamily: "'Outfit',sans-serif", fontWeight: 800, fontSize: 18, color: "#fff" }}
+          <button type="button" style={{ background: "none", border: "none", cursor: "pointer", fontFamily: "'Outfit',sans-serif", fontWeight: 800, fontSize: 18, color: "#fff" }}
             onClick={() => scrollTo("hero")}>
             <span style={{ background: "linear-gradient(90deg,#FF2D2D,#FF8C00,#FFD700,#00C97A,#2196F3,#4B3FEE,#CC44FF)", WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent", backgroundClip: "text" }}>
               {data.personal.name.split(" ")[0]}
@@ -223,7 +223,7 @@ export default function RainbowGradient() {
             {sections.map((s, i) => {
               const r = getRainbow(s.toLowerCase());
               return (
-                <button key={s} className="rg-nav-link" onClick={() => scrollTo(s.toLowerCase())}
+                <button type="button" key={s} className="rg-nav-link" onClick={() => scrollTo(s.toLowerCase())}
                   style={{ "--c": r?.color || "#fff" }}>
                   <style>{`.rg-nav-link:nth-child(${i+1}):hover::after { background:${r?.color || "#fff"}; }`}</style>
                   {s}
@@ -231,7 +231,7 @@ export default function RainbowGradient() {
               );
             })}
           </div>
-          <button className="rg-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+          <button type="button" className="rg-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
             {[0,1,2].map(i => (
               <div key={i} style={{ width: 22, height: 2, margin: "4px 0", transition: "all .2s",
                 background: `linear-gradient(90deg,${RAINBOW[i*2]?.color},${RAINBOW[i*2+1]?.color || RAINBOW[6].color})`,
@@ -249,7 +249,7 @@ export default function RainbowGradient() {
             {sections.map((s, i) => {
               const r = getRainbow(s.toLowerCase());
               return (
-                <button key={s} style={{ background: "none", border: "none", cursor: "pointer", textAlign: "left", padding: "10px 0", fontSize: 12, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", color: r?.color || "#fff", fontFamily: "'Outfit',sans-serif" }}
+                <button type="button" key={s} style={{ background: "none", border: "none", cursor: "pointer", textAlign: "left", padding: "10px 0", fontSize: 12, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", color: r?.color || "#fff", fontFamily: "'Outfit',sans-serif" }}
                   onClick={() => scrollTo(s.toLowerCase())}>
                   <span style={{ opacity: 0.5, marginRight: 8 }}>{r?.section}</span>{s}
                 </button>
@@ -282,10 +282,10 @@ export default function RainbowGradient() {
           </motion.p>
           <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.4 }}
             style={{ display: "flex", flexWrap: "wrap", gap: 16, justifyContent: "center", marginBottom: 48 }}>
-            <button onClick={() => scrollTo("projects")} style={{ padding: "14px 28px", borderRadius: 99, background: `linear-gradient(135deg,${RAINBOW[0].color},${RAINBOW[1].color})`, color: "#fff", border: "none", fontSize: 13, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", cursor: "pointer", transition: "all .2s" }}>
+            <button type="button" onClick={() => scrollTo("projects")} style={{ padding: "14px 28px", borderRadius: 99, background: `linear-gradient(135deg,${RAINBOW[0].color},${RAINBOW[1].color})`, color: "#fff", border: "none", fontSize: 13, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", cursor: "pointer", transition: "all .2s" }}>
               View Work
             </button>
-            <button onClick={() => scrollTo("contact")} style={{ padding: "14px 28px", borderRadius: 99, background: "transparent", color: "#fff", border: "1px solid rgba(255,255,255,.2)", fontSize: 13, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", cursor: "pointer" }}>
+            <button type="button" onClick={() => scrollTo("contact")} style={{ padding: "14px 28px", borderRadius: 99, background: "transparent", color: "#fff", border: "1px solid rgba(255,255,255,.2)", fontSize: 13, fontWeight: 700, letterSpacing: 2, textTransform: "uppercase", cursor: "pointer" }}>
               Say Hello
             </button>
           </motion.div>

--- a/frontend/src/components/portfolio/templates/Scrapbook/Contact.jsx
+++ b/frontend/src/components/portfolio/templates/Scrapbook/Contact.jsx
@@ -54,7 +54,7 @@ export default function Contact({ personal, socials }) {
                    <label className="sb-body text-[#a07850] block mb-1">Message:</label>
                    <textarea placeholder="Write something nice..." rows="3" className="w-full bg-transparent border-b-[1.5px] border-[#d4b896] focus:border-[#e05a3a] outline-none sb-hand text-[22px] text-[#4a3828] px-2 py-1 resize-none placeholder-[#d4b896]" />
                  </div>
-                 <button className="flex items-center gap-2 sb-marker text-xl bg-[#2d1f0e] text-[#fffdf5] px-6 py-3 hover:bg-[#e05a3a] transition-colors transform hover:-rotate-2 w-fit mt-4 shadow-[3px_3px_0px_rgba(224,90,58,0.5)] border border-[#2d1f0e]">
+                 <button type="button" className="flex items-center gap-2 sb-marker text-xl bg-[#2d1f0e] text-[#fffdf5] px-6 py-3 hover:bg-[#e05a3a] transition-colors transform hover:-rotate-2 w-fit mt-4 shadow-[3px_3px_0px_rgba(224,90,58,0.5)] border border-[#2d1f0e]">
                    <Send size={20} /> Send Mail
                  </button>
                </form>

--- a/frontend/src/components/portfolio/templates/Scrapbook/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Scrapbook/Hero.jsx
@@ -91,14 +91,14 @@ export default function Hero() {
               </div>
 
               <div className="flex items-center gap-6 mt-4">
-                <button className="relative group inline-block">
+                <button type="button" className="relative group inline-block">
                   <div className="absolute inset-0 bg-stone-800 transform translate-x-1.5 translate-y-1.5 transition-transform group-hover:translate-x-2.5 group-hover:translate-y-2.5 rounded-sm" />
                   <div className="relative px-8 py-4 bg-white border-2 border-stone-800 text-stone-800 font-bold text-lg flex items-center gap-3 transform transition-transform group-hover:-translate-x-0.5 group-hover:-translate-y-0.5 rounded-sm">
                     <Send className="w-5 h-5 group-hover:rotate-12 transition-transform" />
                     Contact Me
                   </div>
                 </button>
-                <button className="font-bold text-stone-600 hover:text-rose-500 transition-colors underline decoration-2 underline-offset-4 decoration-stone-300 hover:decoration-rose-300">
+                <button type="button" className="font-bold text-stone-600 hover:text-rose-500 transition-colors underline decoration-2 underline-offset-4 decoration-stone-300 hover:decoration-rose-300">
                   View Projects
                 </button>
               </div>

--- a/frontend/src/components/portfolio/templates/Scrapbook/MemoryPolaroids.jsx
+++ b/frontend/src/components/portfolio/templates/Scrapbook/MemoryPolaroids.jsx
@@ -234,7 +234,7 @@ export default function MemoryPolaroids() {
               </div>
 
               {/* Like button */}
-              <button
+              <button type="button"
                 onClick={() => toggleLike(p.id)}
                 className="absolute bottom-2 right-3 transition-transform duration-150 hover:scale-125 active:scale-90"
                 aria-label="Like"

--- a/frontend/src/components/portfolio/templates/Scroll_Tape/index.jsx
+++ b/frontend/src/components/portfolio/templates/Scroll_Tape/index.jsx
@@ -145,19 +145,19 @@ const TapeTransport = ({ progress }) => {
 
       {/* Controls */}
       <div className="flex items-center gap-2">
-        <button onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        <button type="button" onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           className="text-[#00ffaa] hover:text-white transition-colors" aria-label="rewind">
           <Rewind size={14} />
         </button>
-        <button onClick={() => setPlaying(p => !p)}
+        <button type="button" onClick={() => setPlaying(p => !p)}
           className="text-[#00ffaa] hover:text-white transition-colors" aria-label="play/pause">
           {playing ? <Pause size={14} /> : <Play size={14} />}
         </button>
-        <button onClick={() => window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' })}
+        <button type="button" onClick={() => window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' })}
           className="text-[#00ffaa] hover:text-white transition-colors" aria-label="skip forward">
           <SkipForward size={14} />
         </button>
-        <button onClick={() => setMuted(m => !m)}
+        <button type="button" onClick={() => setMuted(m => !m)}
           className="text-[#00ffaa] hover:text-white transition-colors" aria-label="mute">
           {muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
         </button>

--- a/frontend/src/components/portfolio/templates/Smoke_Mist/index.jsx
+++ b/frontend/src/components/portfolio/templates/Smoke_Mist/index.jsx
@@ -279,15 +279,15 @@ export default function SmokeMist() {
 
       {/* ── Navbar ── */}
       <nav className="sm-nav">
-        <button className="sm-nav-link sm-serif" onClick={() => scrollTo("hero")} style={{ color: C.accent, fontSize: 13, letterSpacing: 4 }}>
+        <button type="button" className="sm-nav-link sm-serif" onClick={() => scrollTo("hero")} style={{ color: C.accent, fontSize: 13, letterSpacing: 4 }}>
           {data.personal.name.split(" ")[0].toUpperCase()}
         </button>
         <div className="sm-nav-desktop">
           {sections.map((s) => (
-            <button key={s} className="sm-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
+            <button type="button" key={s} className="sm-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
           ))}
         </div>
-        <button className="sm-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+        <button type="button" className="sm-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
           {[0,1,2].map(i => (
             <div key={i} style={{ width: 22, height: 1.5, background: i === 1 ? C.accent : C.ghost, margin: "5px 0", transition: "all .3s",
               transform: menuOpen ? (i === 0 ? "rotate(45deg) translate(4px,5px)" : i === 2 ? "rotate(-45deg) translate(4px,-5px)" : "none") : "none",
@@ -300,7 +300,7 @@ export default function SmokeMist() {
         {menuOpen && (
           <motion.div className="sm-mobile-menu" initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}>
             {sections.map((s) => (
-              <button key={s} className="sm-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
+              <button type="button" key={s} className="sm-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
                 <span style={{ color: C.accent, marginRight: 8 }}>~</span>{s}
               </button>
             ))}
@@ -329,10 +329,10 @@ export default function SmokeMist() {
           </motion.p>
           <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.8 }}
             style={{ display: "flex", flexWrap: "wrap", gap: 16, marginBottom: 48 }}>
-            <button className="sm-btn sm-btn-ghost" onClick={() => scrollTo("projects")}>
+            <button type="button" className="sm-btn sm-btn-ghost" onClick={() => scrollTo("projects")}>
               <span>Through the Mist</span>
             </button>
-            <button className="sm-btn sm-btn-solid" onClick={() => scrollTo("contact")}>
+            <button type="button" className="sm-btn sm-btn-solid" onClick={() => scrollTo("contact")}>
               <span>Connect</span>
             </button>
           </motion.div>

--- a/frontend/src/components/portfolio/templates/Solar_Eclipse/index.jsx
+++ b/frontend/src/components/portfolio/templates/Solar_Eclipse/index.jsx
@@ -66,7 +66,7 @@ function MobileMenu({ navItems }) {
 
   return (
     <div className="md:hidden">
-      <button
+      <button type="button"
         onClick={() => setOpen(!open)}
         className="p-2 rounded-lg text-gray-400 hover:text-orange-400 transition-colors"
         aria-label="Toggle menu"

--- a/frontend/src/components/portfolio/templates/Sound_Reactive/index.jsx
+++ b/frontend/src/components/portfolio/templates/Sound_Reactive/index.jsx
@@ -319,7 +319,7 @@ export default function SoundReactive() {
 
       {/* Mic Control Fab */}
       <div className="fixed bottom-8 right-8 z-50">
-        <button
+        <button type="button"
           onClick={isListening ? stopListening : startListening}
           className={`flex items-center justify-center p-4 rounded-full backdrop-blur-md border ${
             isListening 

--- a/frontend/src/components/portfolio/templates/Stand_up_Comedy_Brick_Wall_Mic/index.jsx
+++ b/frontend/src/components/portfolio/templates/Stand_up_Comedy_Brick_Wall_Mic/index.jsx
@@ -393,7 +393,7 @@ export default function StandUpComedyBrickWallMic() {
             {/* Desktop Navigation Links */}
             <nav className="hidden lg:flex items-center gap-6 bg-black/40 px-6 py-2.5 rounded-full border border-orange-950/30">
               {sections.map((sect) => (
-                <button
+                <button type="button"
                   key={sect}
                   onClick={() => handleNavClick(sect)}
                   className={`text-xs font-semibold uppercase tracking-wider transition-all duration-200 ${
@@ -409,7 +409,7 @@ export default function StandUpComedyBrickWallMic() {
 
             {/* Right Booking CTA */}
             <div className="flex items-center gap-3">
-              <button 
+              <button type="button" 
                 onClick={() => handleNavClick("contact")}
                 className="hidden sm:inline-flex items-center gap-1.5 text-xs font-bold tracking-widest text-red-500 border border-red-500/80 rounded-md px-4 py-2 hover:bg-red-500 hover:text-white transition-all select-none uppercase hover:shadow-[0_0_15px_rgba(239,68,68,0.6)]"
               >
@@ -417,7 +417,7 @@ export default function StandUpComedyBrickWallMic() {
               </button>
 
               {/* Hamburger Mobile Menu toggle */}
-              <button 
+              <button type="button" 
                 onClick={() => setMobileMenuOpen(prev => !prev)}
                 className="lg:hidden p-2 text-zinc-400 hover:text-white focus:outline-none"
                 aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
@@ -439,7 +439,7 @@ export default function StandUpComedyBrickWallMic() {
               >
                 <div className="py-4 px-6 flex flex-col gap-4 font-heading">
                   {sections.map((sect) => (
-                    <button
+                    <button type="button"
                       key={sect}
                       onClick={() => handleNavClick(sect)}
                       className={`text-left text-lg tracking-widest uppercase transition-colors ${
@@ -449,7 +449,7 @@ export default function StandUpComedyBrickWallMic() {
                       {sect}
                     </button>
                   ))}
-                  <button 
+                  <button type="button" 
                     onClick={() => handleNavClick("contact")}
                     className="w-full text-center py-2.5 mt-2 bg-red-500 text-white font-bold rounded-lg uppercase text-sm tracking-wider"
                   >
@@ -523,7 +523,7 @@ export default function StandUpComedyBrickWallMic() {
                 className="flex flex-wrap gap-4"
               >
                 {/* View My Set button */}
-                <button 
+                <button type="button" 
                   onClick={() => handleNavClick("projects")}
                   className="inline-flex items-center gap-2 text-sm font-bold tracking-widest text-red-500 border border-red-500 rounded-lg px-6 py-3 select-none uppercase hover:bg-red-500 hover:text-white transition-all shadow-[0_0_10px_rgba(239,68,68,0.35)] hover:shadow-[0_0_20px_rgba(239,68,68,0.75)] hover:scale-[1.02]"
                 >
@@ -531,7 +531,7 @@ export default function StandUpComedyBrickWallMic() {
                   View My Set
                 </button>
                 {/* Get In Touch button */}
-                <button 
+                <button type="button" 
                   onClick={() => handleNavClick("contact")}
                   className="inline-flex items-center gap-2 text-sm font-bold tracking-widest text-zinc-300 border border-zinc-700 rounded-lg px-6 py-3 hover:border-amber-500 hover:text-amber-400 hover:shadow-[0_0_15px_rgba(245,158,11,0.4)] transition-all select-none uppercase hover:scale-[1.02]"
                 >
@@ -831,7 +831,7 @@ export default function StandUpComedyBrickWallMic() {
                   {/* Buttons with red neon borders */}
                   <div className="grid grid-cols-2 gap-3 pt-4 border-t border-zinc-900/60">
                     {project.liveUrl && (
-                      <button
+                      <button type="button"
                         onClick={() => handleLinkClick(project.liveUrl)}
                         className="inline-flex items-center justify-center gap-1.5 text-xs font-bold text-red-500 border border-red-500/50 rounded-lg py-2 hover:bg-red-500 hover:text-white transition-all shadow-[0_0_5px_rgba(239,68,68,0.2)] hover:shadow-[0_0_12px_rgba(239,68,68,0.6)]"
                       >
@@ -840,7 +840,7 @@ export default function StandUpComedyBrickWallMic() {
                       </button>
                     )}
                     {project.githubUrl && (
-                      <button
+                      <button type="button"
                         onClick={() => handleLinkClick(project.githubUrl)}
                         className="inline-flex items-center justify-center gap-1.5 text-xs font-bold text-zinc-300 border border-zinc-800 rounded-lg py-2 hover:border-amber-500 hover:text-amber-400 hover:shadow-[0_0_8px_rgba(245,158,11,0.3)] transition-all"
                       >
@@ -996,7 +996,7 @@ export default function StandUpComedyBrickWallMic() {
                   {/* Social links row */}
                   <div className="flex gap-3 mt-4">
                     {data.socials?.github && (
-                      <button
+                      <button type="button"
                         onClick={() => handleLinkClick(data.socials.github)}
                         className="p-3 bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-white hover:border-red-500 rounded-xl transition-all shadow-[0_0_8px_rgba(0,0,0,0.6)]"
                       >
@@ -1004,7 +1004,7 @@ export default function StandUpComedyBrickWallMic() {
                       </button>
                     )}
                     {data.socials?.linkedin && (
-                      <button
+                      <button type="button"
                         onClick={() => handleLinkClick(data.socials.linkedin)}
                         className="p-3 bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-white hover:border-red-500 rounded-xl transition-all shadow-[0_0_8px_rgba(0,0,0,0.6)]"
                       >
@@ -1012,7 +1012,7 @@ export default function StandUpComedyBrickWallMic() {
                       </button>
                     )}
                     {data.socials?.twitter && (
-                      <button
+                      <button type="button"
                         onClick={() => handleLinkClick(data.socials.twitter)}
                         className="p-3 bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-white hover:border-red-500 rounded-xl transition-all shadow-[0_0_8px_rgba(0,0,0,0.6)]"
                       >

--- a/frontend/src/components/portfolio/templates/Stripe_Gradient/components/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Stripe_Gradient/components/Hero.jsx
@@ -63,7 +63,7 @@ export default function Hero() {
             <ArrowRight size={18} />
           </a>
 
-          <button className="px-6 py-3 rounded-full border border-white/20 backdrop-blur-md flex items-center gap-2">
+          <button type="button" className="px-6 py-3 rounded-full border border-white/20 backdrop-blur-md flex items-center gap-2">
             Resume
             <Download size={18} />
           </button>

--- a/frontend/src/components/portfolio/templates/Sunset_Warm/index.jsx
+++ b/frontend/src/components/portfolio/templates/Sunset_Warm/index.jsx
@@ -297,15 +297,15 @@ export default function SunsetWarm() {
 
       {/* ── Navbar ── */}
       <nav className="sw-nav">
-        <button className="sw-nav-link" onClick={() => scrollTo("hero")} style={{ color: C.amber, fontSize: 14, fontWeight: 700, fontFamily: "'Playfair Display',serif" }}>
+        <button type="button" className="sw-nav-link" onClick={() => scrollTo("hero")} style={{ color: C.amber, fontSize: 14, fontWeight: 700, fontFamily: "'Playfair Display',serif" }}>
           {data.personal.name.split(" ")[0]}
         </button>
         <div className="sw-nav-desktop">
           {sections.map((s) => (
-            <button key={s} className="sw-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
+            <button type="button" key={s} className="sw-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
           ))}
         </div>
-        <button className="sw-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+        <button type="button" className="sw-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
           {[0,1,2].map(i => (
             <div key={i} style={{ width: 22, height: 2, background: i === 1 ? C.orange : C.text, margin: "4px 0", transition: "all .2s",
               transform: menuOpen ? (i === 0 ? "rotate(45deg) translate(4px,5px)" : i === 2 ? "rotate(-45deg) translate(4px,-5px)" : "none") : "none",
@@ -318,7 +318,7 @@ export default function SunsetWarm() {
         {menuOpen && (
           <motion.div className="sw-mobile-menu" initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}>
             {sections.map((s) => (
-              <button key={s} className="sw-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
+              <button type="button" key={s} className="sw-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
                 <span style={{ color: C.amber, marginRight: 8 }}>◆</span>{s}
               </button>
             ))}
@@ -352,8 +352,8 @@ export default function SunsetWarm() {
             </motion.p>
             <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.4 }}
               style={{ display: "flex", flexWrap: "wrap", gap: 16, justifyContent: "center", marginBottom: 48 }}>
-              <button className="sw-btn sw-btn-warm" onClick={() => scrollTo("projects")}>View Work</button>
-              <button className="sw-btn sw-btn-outline" onClick={() => scrollTo("contact")}>Say Hello</button>
+              <button type="button" className="sw-btn sw-btn-warm" onClick={() => scrollTo("projects")}>View Work</button>
+              <button type="button" className="sw-btn sw-btn-outline" onClick={() => scrollTo("contact")}>Say Hello</button>
             </motion.div>
 
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.5 }}>

--- a/frontend/src/components/portfolio/templates/Swipe_Right_Dating_App/index.jsx
+++ b/frontend/src/components/portfolio/templates/Swipe_Right_Dating_App/index.jsx
@@ -167,7 +167,7 @@ export default function SwipeRightDatingApp() {
             </span>
           </div>
           <div className="flex gap-2">
-            <button
+            <button type="button"
               onClick={() => setActiveTab("match")}
               className="p-2 text-rose-400 hover:bg-rose-50 rounded-full transition-colors"
               title="Connect"
@@ -211,7 +211,7 @@ export default function SwipeRightDatingApp() {
             const Icon = tab.icon;
             const isActive = activeTab === tab.id;
             return (
-              <button
+              <button type="button"
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
                 className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all ${
@@ -230,7 +230,7 @@ export default function SwipeRightDatingApp() {
 
           {/* Matches / Testimonials trigger list */}
           <div className="space-y-1">
-            <button
+            <button type="button"
               onClick={() => setActiveTab("testimonials")}
               className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all ${
                 activeTab === "testimonials"
@@ -243,7 +243,7 @@ export default function SwipeRightDatingApp() {
             </button>
             <div className="flex gap-2 px-3 py-1 overflow-x-auto scrollbar-none">
               {testimonials.map((testi, i) => (
-                <button
+                <button type="button"
                   key={i}
                   onClick={() => {
                     setActiveTestimonialIdx(i);
@@ -271,7 +271,7 @@ export default function SwipeRightDatingApp() {
 
           {/* DMs / Experience list */}
           <div className="space-y-1 pt-2">
-            <button
+            <button type="button"
               onClick={() => setActiveTab("chats")}
               className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all ${
                 activeTab === "chats"
@@ -284,7 +284,7 @@ export default function SwipeRightDatingApp() {
             </button>
             <div className="space-y-1">
               {experienceList.map((exp, i) => (
-                <button
+                <button type="button"
                   key={i}
                   onClick={() => {
                     setActiveChatIdx(i);
@@ -306,7 +306,7 @@ export default function SwipeRightDatingApp() {
 
         {/* Sidebar Footer */}
         <div className="p-4 border-t border-rose-50 text-center">
-          <button
+          <button type="button"
             onClick={() => setActiveTab("match")}
             className="w-full py-2 bg-gradient-to-r from-rose-500 to-pink-500 text-white text-sm font-bold rounded-xl shadow-md hover:from-rose-600 hover:to-pink-600 transition-all flex items-center justify-center gap-2"
           >
@@ -326,7 +326,7 @@ export default function SwipeRightDatingApp() {
           </span>
         </div>
         <div className="flex items-center gap-3">
-          <button
+          <button type="button"
             onClick={() => setActiveTab("profile")}
             className="w-8 h-8 rounded-full overflow-hidden border-2 border-pink-400"
           >
@@ -443,7 +443,7 @@ export default function SwipeRightDatingApp() {
                 {/* Tinder Action Buttons */}
                 <div className="p-5 bg-gradient-to-t from-rose-50/50 to-white flex items-center justify-around border-t border-rose-50/50">
                   {/* Rewind */}
-                  <button
+                  <button type="button"
                     onClick={() => {
                       setActiveTab("profile");
                     }}
@@ -454,7 +454,7 @@ export default function SwipeRightDatingApp() {
                   </button>
 
                   {/* Pass */}
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("profile")}
                     className="w-14 h-14 bg-white text-rose-500 hover:bg-rose-50 rounded-full flex items-center justify-center border border-gray-100 shadow-md transition-all active:scale-95 hover:scale-105"
                     title="Nope"
@@ -463,7 +463,7 @@ export default function SwipeRightDatingApp() {
                   </button>
 
                   {/* Super Like */}
-                  <button
+                  <button type="button"
                     onClick={triggerSuperLike}
                     className="w-12 h-12 bg-white text-sky-400 hover:bg-sky-50 rounded-full flex items-center justify-center border border-gray-100 shadow-md transition-all active:scale-95 hover:scale-105"
                     title="Super Like"
@@ -472,7 +472,7 @@ export default function SwipeRightDatingApp() {
                   </button>
 
                   {/* Like */}
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("match")}
                     className="w-14 h-14 bg-gradient-to-r from-rose-500 to-pink-500 text-white rounded-full flex items-center justify-center shadow-lg shadow-rose-500/20 hover:shadow-rose-500/30 transition-all active:scale-95 hover:scale-105"
                     title="Like & Match"
@@ -481,7 +481,7 @@ export default function SwipeRightDatingApp() {
                   </button>
 
                   {/* Boost */}
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("skills")}
                     className="w-12 h-12 bg-white text-purple-500 hover:text-purple-600 rounded-full flex items-center justify-center border border-gray-100 shadow-md transition-all active:scale-95 group"
                     title="Developer Interests / Skills"
@@ -509,7 +509,7 @@ export default function SwipeRightDatingApp() {
                     <h2 className="text-2xl font-extrabold">Dating Profile Info</h2>
                     <p className="text-rose-100 text-xs">Let's check if we match requirements ❤️</p>
                   </div>
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("discover")}
                     className="p-2 bg-white/20 hover:bg-white/30 text-white rounded-full transition-colors"
                   >
@@ -578,7 +578,7 @@ export default function SwipeRightDatingApp() {
                 </div>
 
                 <div className="p-4 bg-rose-50/50 border-t border-rose-50 flex gap-3">
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("skills")}
                     className="flex-1 py-3 bg-gradient-to-r from-rose-500 to-pink-500 text-white font-bold rounded-2xl hover:opacity-90 shadow-md text-sm transition-all flex items-center justify-center gap-2"
                   >
@@ -605,7 +605,7 @@ export default function SwipeRightDatingApp() {
                     <h2 className="text-2xl font-extrabold">My Interests & Badges</h2>
                     <p className="text-rose-100 text-xs">These are the stacks I swiped right on ⚡</p>
                   </div>
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("discover")}
                     className="p-2 bg-white/20 hover:bg-white/30 text-white rounded-full transition-colors"
                   >
@@ -660,7 +660,7 @@ export default function SwipeRightDatingApp() {
                 </div>
 
                 <div className="p-4 bg-rose-50/50 border-t border-rose-50">
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("projects")}
                     className="w-full py-3 bg-gradient-to-r from-rose-500 to-pink-500 text-white font-bold rounded-2xl hover:opacity-90 shadow-md text-sm transition-all flex items-center justify-center gap-2"
                   >
@@ -707,7 +707,7 @@ export default function SwipeRightDatingApp() {
                     <p className="text-slate-500 text-sm mt-2 max-w-xs mx-auto">
                       You've swiped through all of my projects. Reset the stack to review them again or check out my employment chats.
                     </p>
-                    <button
+                    <button type="button"
                       onClick={() => setProjectIndex(0)}
                       className="mt-6 px-6 py-2.5 bg-gradient-to-r from-rose-500 to-pink-500 text-white font-bold rounded-full shadow-md text-sm transition-all hover:opacity-90 flex items-center gap-2 mx-auto"
                     >
@@ -758,7 +758,7 @@ export default function SwipeRightDatingApp() {
               <div className="bg-white rounded-[32px] shadow-xl overflow-hidden border border-rose-100 flex flex-col h-[75vh]">
                 {/* Chat Header */}
                 <div className="p-4 bg-gradient-to-r from-rose-500 to-pink-500 text-white flex items-center gap-3">
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("discover")}
                     className="p-1 hover:bg-white/20 rounded-full transition-colors lg:hidden"
                   >
@@ -855,7 +855,7 @@ export default function SwipeRightDatingApp() {
                 {/* Mobile Chat Switcher Buttons */}
                 {experienceList.length > 1 && (
                   <div className="p-3 bg-white border-t border-rose-100 flex items-center justify-between text-xs text-slate-500 shrink-0">
-                    <button
+                    <button type="button"
                       disabled={activeChatIdx === 0}
                       onClick={() => setActiveChatIdx(prev => prev - 1)}
                       className="px-3 py-1.5 rounded-lg border border-gray-200 hover:bg-slate-50 disabled:opacity-50 disabled:hover:bg-white flex items-center gap-1 font-bold"
@@ -865,7 +865,7 @@ export default function SwipeRightDatingApp() {
                     <span className="font-semibold text-slate-400">
                       {activeChatIdx + 1} / {experienceList.length}
                     </span>
-                    <button
+                    <button type="button"
                       disabled={activeChatIdx === experienceList.length - 1}
                       onClick={() => setActiveChatIdx(prev => prev + 1)}
                       className="px-3 py-1.5 rounded-lg border border-gray-200 hover:bg-slate-50 disabled:opacity-50 disabled:hover:bg-white flex items-center gap-1 font-bold"
@@ -894,7 +894,7 @@ export default function SwipeRightDatingApp() {
                     <h2 className="text-2xl font-extrabold">My Matches (Feedback)</h2>
                     <p className="text-rose-100 text-xs">Inbox recommendations from collaborators ⭐</p>
                   </div>
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("discover")}
                     className="p-2 bg-white/20 hover:bg-white/30 text-white rounded-full transition-colors"
                   >
@@ -961,7 +961,7 @@ export default function SwipeRightDatingApp() {
                 </div>
 
                 <div className="p-4 bg-rose-50/50 border-t border-rose-50 shrink-0">
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("match")}
                     className="w-full py-3 bg-gradient-to-r from-rose-500 to-pink-500 text-white font-bold rounded-2xl hover:opacity-90 shadow-md text-sm transition-all flex items-center justify-center gap-2"
                   >
@@ -1086,7 +1086,7 @@ export default function SwipeRightDatingApp() {
                   </div>
 
                   {/* Reset Discovery */}
-                  <button
+                  <button type="button"
                     onClick={() => setActiveTab("discover")}
                     className="text-slate-400 hover:text-slate-200 text-xs font-semibold pt-4 flex items-center justify-center gap-1.5 mx-auto transition-colors"
                   >
@@ -1105,7 +1105,7 @@ export default function SwipeRightDatingApp() {
           const Icon = tab.icon;
           const isActive = activeTab === tab.id;
           return (
-            <button
+            <button type="button"
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className="flex flex-col items-center justify-center flex-1 h-full relative"
@@ -1257,7 +1257,7 @@ function ProjectCard({ project, isTop, indexOffset, onSwipeLeft, onSwipeRight, o
       {/* Card Action Buttons (only interactive on top card) */}
       <div className="p-4 bg-slate-50 border-t border-rose-50 flex items-center justify-around shrink-0">
         {/* Pass Button */}
-        <button
+        <button type="button"
           onClick={isTop ? onPass : undefined}
           className="w-10 h-10 bg-white hover:bg-rose-50 text-slate-400 hover:text-slate-600 rounded-full flex items-center justify-center border border-gray-200 shadow-sm transition-all active:scale-95"
           title="Pass Card"
@@ -1266,7 +1266,7 @@ function ProjectCard({ project, isTop, indexOffset, onSwipeLeft, onSwipeRight, o
         </button>
 
         {/* Like Button (opens Github) */}
-        <button
+        <button type="button"
           onClick={isTop ? () => {
             onSwipeLeft();
           } : undefined}
@@ -1277,7 +1277,7 @@ function ProjectCard({ project, isTop, indexOffset, onSwipeLeft, onSwipeRight, o
         </button>
 
         {/* Match Button (opens Live Link) */}
-        <button
+        <button type="button"
           onClick={isTop ? () => {
             onSwipeRight();
           } : undefined}

--- a/frontend/src/components/portfolio/templates/Tech_Startup/Experience.jsx
+++ b/frontend/src/components/portfolio/templates/Tech_Startup/Experience.jsx
@@ -21,7 +21,7 @@ export default function Experience({ experience }) {
           {/* Tabs */}
           <div className="flex md:flex-col overflow-x-auto hide-scrollbar md:w-48 border-b md:border-b-0 md:border-l border-[#233554]">
             {experience.map((exp, index) => (
-              <button
+              <button type="button"
                 key={index}
                 onClick={() => setActiveTabId(index)}
                 className={`text-left px-5 py-3 font-mono text-sm whitespace-nowrap transition-all duration-200 border-b-2 md:border-b-0 md:border-l-2 -ml-[2px] ${

--- a/frontend/src/components/portfolio/templates/Terminal_CLI/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Terminal_CLI/Hero.jsx
@@ -63,12 +63,12 @@ export default function Hero() {
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4">
-              <button className="flex items-center justify-center gap-2 px-6 py-3 border border-green-500 rounded-lg hover:bg-green-500 hover:text-black transition-all duration-300">
+              <button type="button" className="flex items-center justify-center gap-2 px-6 py-3 border border-green-500 rounded-lg hover:bg-green-500 hover:text-black transition-all duration-300">
                 $ ./view-projects
                 <ArrowRight size={18} />
               </button>
 
-              <button className="flex items-center justify-center gap-2 px-6 py-3 border border-green-500/40 rounded-lg hover:border-green-500 transition-all duration-300">
+              <button type="button" className="flex items-center justify-center gap-2 px-6 py-3 border border-green-500/40 rounded-lg hover:border-green-500 transition-all duration-300">
                 $ ./download-resume
                 <Download size={18} />
               </button>

--- a/frontend/src/components/portfolio/templates/Train_Journey/index.jsx
+++ b/frontend/src/components/portfolio/templates/Train_Journey/index.jsx
@@ -654,7 +654,7 @@ function BoardingIntro({ onDone, reduced }) {
         />
       </div>
 
-      <button
+      <button type="button"
         onClick={skip}
         className="absolute bottom-8 right-8 rounded-full border border-white/15 px-4 py-1.5 text-[11px] font-bold uppercase tracking-widest text-slate-400 transition-colors hover:border-amber-400/50 hover:text-amber-200"
       >
@@ -1345,7 +1345,7 @@ function TrainHUD({
             <div className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-amber-400">
               <Gauge className="h-4 w-4 animate-pulse" /> Cabin Instruments
             </div>
-            <button
+            <button type="button"
               onClick={() => {
                 setIsOpen(false);
                 playFlapClick();
@@ -1404,7 +1404,7 @@ function TrainHUD({
             <div className="space-y-1.5">
               <div className="flex items-center justify-between">
                 <div className="text-[10px] uppercase font-bold text-slate-400 tracking-wider">Window Presets</div>
-                <button
+                <button type="button"
                   onClick={() => {
                     setAutoSky(true);
                     playFlapClick();
@@ -1420,7 +1420,7 @@ function TrainHUD({
               </div>
               <div className="grid grid-cols-4 gap-1">
                 {Object.keys(PRESETS).map((key) => (
-                  <button
+                  <button type="button"
                     key={key}
                     onClick={() => {
                       setPreset(key);
@@ -1444,7 +1444,7 @@ function TrainHUD({
             <div className="border-t border-white/5 pt-3 space-y-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
-                  <button
+                  <button type="button"
                     onClick={() => {
                       if (!audioCtx) {
                         startAudio(volume);
@@ -1470,7 +1470,7 @@ function TrainHUD({
                   <span className="text-[10px] uppercase font-bold text-slate-400 tracking-wider">Ambient Engine</span>
                 </div>
 
-                <button
+                <button type="button"
                   onClick={() => {
                     if (!audioCtx) startAudio(volume);
                     onPlayHorn();

--- a/frontend/src/components/portfolio/templates/Transparent_Desktop_Overlay_OS/index.jsx
+++ b/frontend/src/components/portfolio/templates/Transparent_Desktop_Overlay_OS/index.jsx
@@ -89,7 +89,7 @@ function OSWindow({
       >
         {/* Left Windows Actions */}
         <div className="flex items-center space-x-2 shrink-0">
-          <button
+          <button type="button"
             onClick={(e) => {
               e.stopPropagation();
               onClose();
@@ -99,7 +99,7 @@ function OSWindow({
           >
             <X className="w-2.5 h-2.5 text-rose-950 opacity-0 group-hover:opacity-100 transition-opacity" />
           </button>
-          <button
+          <button type="button"
             onClick={(e) => {
               e.stopPropagation();
               onMinimize();
@@ -109,7 +109,7 @@ function OSWindow({
           >
             <Minus className="w-2.5 h-2.5 text-amber-950 opacity-0 group-hover:opacity-100 transition-opacity" />
           </button>
-          <button
+          <button type="button"
             onClick={(e) => {
               e.stopPropagation();
               onMaximize();
@@ -431,9 +431,9 @@ export default function TransparentDesktopOverlayOS() {
             <Globe className="w-3.5 h-3.5 animate-spin" style={{ animationDuration: '15s' }} />
             <span className="font-mono tracking-wider">CP_OS</span>
           </div>
-          <button className="hover:bg-white/10 px-2 py-0.5 rounded cursor-pointer transition-colors">File</button>
-          <button className="hover:bg-white/10 px-2 py-0.5 rounded cursor-pointer transition-colors">View</button>
-          <button
+          <button type="button" className="hover:bg-white/10 px-2 py-0.5 rounded cursor-pointer transition-colors">File</button>
+          <button type="button" className="hover:bg-white/10 px-2 py-0.5 rounded cursor-pointer transition-colors">View</button>
+          <button type="button"
             onClick={() => openWindow('contact')}
             className="hover:bg-white/10 px-2 py-0.5 rounded cursor-pointer transition-colors text-rose-400 hover:text-rose-300"
           >
@@ -467,7 +467,7 @@ export default function TransparentDesktopOverlayOS() {
                 const Icon = app.icon;
                 const isOpen = windowStates[app.id].isOpen && !windowStates[app.id].isMinimized;
                 return (
-                  <button
+                  <button type="button"
                     key={app.id}
                     onClick={() => openWindow(app.id)}
                     className="flex flex-col items-center justify-center p-2 rounded-xl border border-transparent hover:border-white/10 hover:bg-white/5 group transition-all text-center select-none cursor-pointer"
@@ -938,7 +938,7 @@ export default function TransparentDesktopOverlayOS() {
                       {app.title}
                     </div>
 
-                    <button
+                    <button type="button"
                       onClick={() => {
                         if (isOpen && !isMinimized && isFocused) {
                           minimizeWindow(app.id);
@@ -993,7 +993,7 @@ export default function TransparentDesktopOverlayOS() {
             {/* Mobile Tab Navigation */}
             <div className="flex overflow-x-auto py-1 space-x-2 scrollbar-none shrink-0 select-none">
               {apps.map((app) => (
-                <button
+                <button type="button"
                   key={app.id}
                   onClick={() => setActiveTab(app.id)}
                   className={`px-3 py-1.5 rounded-lg text-xs font-semibold whitespace-nowrap transition-colors cursor-pointer border ${
@@ -1196,7 +1196,7 @@ export default function TransparentDesktopOverlayOS() {
                 const Icon = app.icon;
                 const isActive = activeTab === app.id;
                 return (
-                  <button
+                  <button type="button"
                     key={app.id}
                     onClick={() => setActiveTab(app.id)}
                     className={`p-2 rounded-lg flex items-center justify-center transition-colors cursor-pointer ${

--- a/frontend/src/components/portfolio/templates/Twilight_Horizon/index.jsx
+++ b/frontend/src/components/portfolio/templates/Twilight_Horizon/index.jsx
@@ -247,15 +247,15 @@ export default function TwilightHorizon() {
 
       {/* ── Navbar ── */}
       <nav className="th-nav">
-        <button className="th-nav-link th-serif" onClick={() => scrollTo("hero")} style={{ color: C.amber, fontSize: 14, letterSpacing: 3, fontStyle: "italic" }}>
+        <button type="button" className="th-nav-link th-serif" onClick={() => scrollTo("hero")} style={{ color: C.amber, fontSize: 14, letterSpacing: 3, fontStyle: "italic" }}>
           {data.personal.name.split(" ")[0]}
         </button>
         <div className="th-nav-desktop">
           {sections.map((s) => (
-            <button key={s} className="th-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
+            <button type="button" key={s} className="th-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
           ))}
         </div>
-        <button className="th-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+        <button type="button" className="th-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
           {[0,1,2].map(i => (
             <div key={i} style={{ width: 22, height: 1.5, background: i === 1 ? C.amber : C.text, margin: "5px 0", transition: "all .25s",
               transform: menuOpen ? (i === 0 ? "rotate(45deg) translate(4px,5px)" : i === 2 ? "rotate(-45deg) translate(4px,-5px)" : "none") : "none",
@@ -268,7 +268,7 @@ export default function TwilightHorizon() {
         {menuOpen && (
           <motion.div className="th-mobile-menu" initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}>
             {sections.map((s) => (
-              <button key={s} className="th-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
+              <button type="button" key={s} className="th-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "10px 0" }}>
                 <span style={{ color: C.amber, marginRight: 8 }}>✦</span>{s}
               </button>
             ))}
@@ -332,8 +332,8 @@ export default function TwilightHorizon() {
           </motion.p>
           <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.6 }}
             style={{ display: "flex", flexWrap: "wrap", gap: 16, justifyContent: "center", marginBottom: 48 }}>
-            <button className="th-btn th-btn-primary" onClick={() => scrollTo("projects")}>Explore Work</button>
-            <button className="th-btn th-btn-ghost" onClick={() => scrollTo("contact")}>Connect</button>
+            <button type="button" className="th-btn th-btn-primary" onClick={() => scrollTo("projects")}>Explore Work</button>
+            <button type="button" className="th-btn th-btn-ghost" onClick={() => scrollTo("contact")}>Connect</button>
           </motion.div>
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.75 }}>
             <div className="th-stats">

--- a/frontend/src/components/portfolio/templates/Twitter_Profile/index.jsx
+++ b/frontend/src/components/portfolio/templates/Twitter_Profile/index.jsx
@@ -56,7 +56,7 @@ export default function TwitterProfile() {
             <NavItem icon={<User size={26} strokeWidth={2.5} />} label="Profile" isActive />
             <NavItem icon={<MoreHorizontal size={26} />} label="More" />
 
-            <button className="mt-4 bg-[#1d9bf0] hover:bg-[#1a8cd8] text-white rounded-full font-bold transition-colors w-[52px] h-[52px] xl:w-full xl:h-[52px] xl:px-8 text-[17px] flex items-center justify-center shadow-md">
+            <button type="button" className="mt-4 bg-[#1d9bf0] hover:bg-[#1a8cd8] text-white rounded-full font-bold transition-colors w-[52px] h-[52px] xl:w-full xl:h-[52px] xl:px-8 text-[17px] flex items-center justify-center shadow-md">
               <span className="hidden xl:inline">Post</span>
               <span className="xl:hidden">
                 <svg viewBox="0 0 24 24" className="w-6 h-6 fill-current"><g><path d="M23 3c-6.62-.1-10.38 2.421-13.05 6.03C7.29 12.61 6 17.331 6 22h2c0-1.007.07-2.012.19-3H12c4.1 0 7.48-3.082 7.94-7.054C22.79 10.147 23.17 6.359 23 3zm-7 8h-1.5v2H16c.63-.016 1.2-.08 1.72-.188C16.95 15.24 14.68 17 12 17H8.55c.57-2.512 1.57-4.851 3-6.78 2.16-2.912 5.29-4.911 9.45-5.187C20.95 8.079 19.9 11 16 11zM4 9V6H1V4h3V1h2v3h3v2H6v3H4z"></path></g></svg>
@@ -115,7 +115,7 @@ export default function TwitterProfile() {
                   <a href={`mailto:${data.socials.email}`} className="w-9 h-9 rounded-full border border-[#536471] flex items-center justify-center hover:bg-white/10 transition-colors">
                     <Mail size={18} className="text-white" />
                   </a>
-                  <button className="px-4 py-1.5 rounded-full border border-[#536471] text-white font-bold text-[15px] hover:bg-white/10 transition-colors">
+                  <button type="button" className="px-4 py-1.5 rounded-full border border-[#536471] text-white font-bold text-[15px] hover:bg-white/10 transition-colors">
                     Edit profile
                   </button>
                 </div>
@@ -174,7 +174,7 @@ export default function TwitterProfile() {
           {/* Tabs */}
           <div className="flex border-b border-[#2f3336] overflow-x-auto hide-scrollbar">
             {tabs.map((tab) => (
-              <button
+              <button type="button"
                 key={tab}
                 onClick={() => setActiveTab(tab)}
                 className="flex-1 min-w-[100px] hover:bg-white/10 transition-colors relative flex items-center justify-center h-[53px]"
@@ -337,7 +337,7 @@ function FollowItem({ name, handle, icon, href }) {
           <div className="text-[#71767b] text-[15px]">{handle}</div>
         </div>
       </div>
-      <button className="bg-white text-black font-bold text-sm px-4 py-1.5 rounded-full hover:bg-gray-200 transition-colors">
+      <button type="button" className="bg-white text-black font-bold text-sm px-4 py-1.5 rounded-full hover:bg-gray-200 transition-colors">
         Follow
       </button>
     </a>

--- a/frontend/src/components/portfolio/templates/Typewriter_Effect/index.jsx
+++ b/frontend/src/components/portfolio/templates/Typewriter_Effect/index.jsx
@@ -304,15 +304,15 @@ export default function TypewriterEffect() {
 
       {/* ── Navbar ── */}
       <nav className="tw-nav">
-        <button className="tw-nav-link tw-display" onClick={() => scrollTo("hero")} style={{ color: C.ribbon, fontSize: 13, letterSpacing: 3 }}>
+        <button type="button" className="tw-nav-link tw-display" onClick={() => scrollTo("hero")} style={{ color: C.ribbon, fontSize: 13, letterSpacing: 3 }}>
           {data.personal.name.split(" ")[0]}
         </button>
         <div className="tw-nav-desktop">
           {sections.map((s) => (
-            <button key={s} className="tw-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
+            <button type="button" key={s} className="tw-nav-link" onClick={() => scrollTo(s.toLowerCase())}>{s}</button>
           ))}
         </div>
-        <button className="tw-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+        <button type="button" className="tw-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
           {["---", "---", "---"].map((_, i) => (
             <div key={i} style={{ width: 20, height: 2, background: i === 1 ? C.ribbon : C.mid, margin: "4px 0", transition: "all .2s",
               transform: menuOpen ? (i === 0 ? "rotate(45deg) translate(3px,5px)" : i === 2 ? "rotate(-45deg) translate(3px,-5px)" : "none") : "none",
@@ -325,7 +325,7 @@ export default function TypewriterEffect() {
         {menuOpen && (
           <motion.div className="tw-mobile-menu" initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}>
             {sections.map((s) => (
-              <button key={s} className="tw-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "8px 0" }}>
+              <button type="button" key={s} className="tw-nav-link" onClick={() => scrollTo(s.toLowerCase())} style={{ textAlign: "left", padding: "8px 0" }}>
                 <span style={{ color: C.ribbon, marginRight: 6 }}>{">"}</span>{s}
               </button>
             ))}
@@ -359,8 +359,8 @@ export default function TypewriterEffect() {
             {bio.done && (
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.4 }}
                 style={{ display: "flex", flexWrap: "wrap", gap: 14, marginBottom: 48 }}>
-                <button className="tw-btn tw-btn-primary" onClick={() => scrollTo("projects")}>&gt; view_work</button>
-                <button className="tw-btn tw-btn-outline" onClick={() => scrollTo("contact")}>&gt; contact</button>
+                <button type="button" className="tw-btn tw-btn-primary" onClick={() => scrollTo("projects")}>&gt; view_work</button>
+                <button type="button" className="tw-btn tw-btn-outline" onClick={() => scrollTo("contact")}>&gt; contact</button>
               </motion.div>
             )}
           </AnimatePresence>
@@ -381,7 +381,7 @@ export default function TypewriterEffect() {
             </motion.div>
           )}
         </div>
-        <button onClick={() => scrollTo("about")} style={{ position: "absolute", bottom: 24, left: "50%", transform: "translateX(-50%)", background: "none", border: "none", cursor: "pointer", color: C.muted, fontSize: 12, letterSpacing: 2, fontFamily: "'Courier Prime',monospace" }}>
+        <button type="button" onClick={() => scrollTo("about")} style={{ position: "absolute", bottom: 24, left: "50%", transform: "translateX(-50%)", background: "none", border: "none", cursor: "pointer", color: C.muted, fontSize: 12, letterSpacing: 2, fontFamily: "'Courier Prime',monospace" }}>
           <motion.div animate={{ y: [0,5,0] }} transition={{ duration: 2, repeat: Infinity }}>
             &darr; scroll_down
           </motion.div>

--- a/frontend/src/components/portfolio/templates/Typewriter_Keystroke_Sequence/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Typewriter_Keystroke_Sequence/Hero.jsx
@@ -118,10 +118,10 @@ export default function Hero({ data, onScrollTo }) {
               transition={{ duration: 0.5 }}
               style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 56 }}
             >
-              <button className="tks-btn tks-btn-primary" onClick={() => onScrollTo('about')}>
+              <button type="button" className="tks-btn tks-btn-primary" onClick={() => onScrollTo('about')}>
                 &gt; Start Reading
               </button>
-              <button className="tks-btn tks-btn-outline" onClick={() => onScrollTo('contact')}>
+              <button type="button" className="tks-btn tks-btn-outline" onClick={() => onScrollTo('contact')}>
                 &gt; Contact Me
               </button>
             </motion.div>
@@ -158,7 +158,7 @@ export default function Hero({ data, onScrollTo }) {
       </div>
 
       {/* Scroll indicator */}
-      <button
+      <button type="button"
         onClick={() => onScrollTo('about')}
         style={{
           position: 'absolute', bottom: 28, left: '50%', transform: 'translateX(-50%)',

--- a/frontend/src/components/portfolio/templates/Typewriter_Keystroke_Sequence/index.jsx
+++ b/frontend/src/components/portfolio/templates/Typewriter_Keystroke_Sequence/index.jsx
@@ -39,7 +39,7 @@ function Navbar({ name, onScrollTo }) {
     <>
       <nav className="tks-nav" role="navigation" aria-label="Main navigation">
         {/* Brand */}
-        <button
+        <button type="button"
           className="tks-nav-brand"
           onClick={() => onScrollTo('hero')}
           aria-label="Back to top"
@@ -50,7 +50,7 @@ function Navbar({ name, onScrollTo }) {
         {/* Desktop links */}
         <div className="tks-nav-links" role="list">
           {NAV_SECTIONS.map(s => (
-            <button
+            <button type="button"
               key={s}
               className="tks-nav-link"
               onClick={() => onScrollTo(s.toLowerCase())}
@@ -62,7 +62,7 @@ function Navbar({ name, onScrollTo }) {
         </div>
 
         {/* Mobile hamburger */}
-        <button
+        <button type="button"
           onClick={() => setMenuOpen(v => !v)}
           aria-label={menuOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={menuOpen}
@@ -112,7 +112,7 @@ function Navbar({ name, onScrollTo }) {
             role="menu"
           >
             {NAV_SECTIONS.map(s => (
-              <button
+              <button type="button"
                 key={s}
                 className="tks-nav-link"
                 onClick={() => { onScrollTo(s.toLowerCase()); setMenuOpen(false); }}

--- a/frontend/src/components/portfolio/templates/Typographic_Wheatpaste_Poster_Wall/index.jsx
+++ b/frontend/src/components/portfolio/templates/Typographic_Wheatpaste_Poster_Wall/index.jsx
@@ -434,7 +434,7 @@ function Nav() {
           {/* Desktop links */}
           <div className="hidden md:flex items-center gap-6">
             {links.map((link) => (
-              <button
+              <button type="button"
                 key={link}
                 onClick={() => scrollTo(link)}
                 className="wp-nav-link"
@@ -476,7 +476,7 @@ function Nav() {
           </div>
 
           {/* Hamburger */}
-          <button
+          <button type="button"
             className="md:hidden"
             onClick={() => setOpen(!open)}
             aria-label="Toggle menu"

--- a/frontend/src/components/portfolio/templates/VHS_Rewind/index.jsx
+++ b/frontend/src/components/portfolio/templates/VHS_Rewind/index.jsx
@@ -95,28 +95,28 @@ function VCRControls() {
 
   return (
     <div className="flex items-center gap-3 vhs-font">
-      <button
+      <button type="button"
         onClick={() => setIsPlaying(false)}
         className="text-[#f0e6d3]/40 hover:text-[#00e5ff] transition-colors"
         aria-label="Rewind"
       >
         <Rewind size={16} />
       </button>
-      <button
+      <button type="button"
         onClick={() => setIsPlaying(!isPlaying)}
         className="text-[#00e5ff] hover:text-[#ff00aa] transition-colors"
         aria-label={isPlaying ? 'Pause' : 'Play'}
       >
         {isPlaying ? <Pause size={18} /> : <Play size={18} />}
       </button>
-      <button
+      <button type="button"
         onClick={() => setIsPlaying(false)}
         className="text-[#f0e6d3]/40 hover:text-[#00e5ff] transition-colors"
         aria-label="Fast Forward"
       >
         <FastForward size={16} />
       </button>
-      <button
+      <button type="button"
         className="text-[#f0e6d3]/40 hover:text-[#ff00aa] transition-colors"
         aria-label="Stop"
       >
@@ -224,7 +224,7 @@ function VHSNavbar() {
         {/* Desktop Nav Links — hidden on mobile */}
         <div className="hidden md:flex items-center gap-1 lg:gap-2">
           {sections.map((s) => (
-            <button
+            <button type="button"
               key={s.id}
               onClick={() => handleNavClick(s.id)}
               className="px-2 py-1 text-xs vhs-font text-[#f0e6d3]/50 hover:text-[#00e5ff] hover:bg-[#00e5ff]/5 rounded transition-all tracking-widest"
@@ -242,7 +242,7 @@ function VHSNavbar() {
           </div>
 
           {/* Mobile hamburger button */}
-          <button
+          <button type="button"
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             aria-label="Toggle menu"
             aria-expanded={isMobileMenuOpen}
@@ -881,7 +881,7 @@ function TestimonialsSection() {
         {/* Testimonial selector — tape thumbnails */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {data.testimonials.map((t, idx) => (
-            <button
+            <button type="button"
               key={idx}
               onClick={() => setActiveIdx(idx)}
               className={`p-3 rounded-lg text-left transition-all duration-300 vhs-tape-border ${

--- a/frontend/src/components/portfolio/templates/Vercel_Deploy/index.jsx
+++ b/frontend/src/components/portfolio/templates/Vercel_Deploy/index.jsx
@@ -58,7 +58,7 @@ function Navbar() {
           <a href={`mailto:${data.socials?.email ?? "#"}`} className="hidden sm:inline-flex bg-white text-black text-xs font-mono font-bold px-3 py-1.5 rounded-lg hover:opacity-80 transition-opacity">
             Hire Me →
           </a>
-          <button className="md:hidden text-zinc-400" onClick={() => setOpen(v => !v)}>
+          <button type="button" className="md:hidden text-zinc-400" onClick={() => setOpen(v => !v)}>
             {open ? <X size={18}/> : <Menu size={18}/>}
           </button>
         </div>
@@ -609,7 +609,7 @@ function Footer() {
           <span className="text-zinc-600 font-mono text-xs">© {new Date().getFullYear()} {data.personal?.name}</span>
         </div>
         <Badge status="ready"/>
-        <button onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+        <button type="button" onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
           className="w-8 h-8 bg-zinc-900 border border-zinc-800 rounded-lg flex items-center justify-center text-zinc-500 hover:text-emerald-400 hover:border-emerald-500/40 transition-all">
           <ArrowUp size={13}/>
         </button>

--- a/frontend/src/components/portfolio/templates/Virtual_Reality_Room_360/index.jsx
+++ b/frontend/src/components/portfolio/templates/Virtual_Reality_Room_360/index.jsx
@@ -141,7 +141,7 @@ function Nav({ personal }) {
         </div>
 
         {/* Hamburger button (mobile) */}
-        <button
+        <button type="button"
           className="vr-hamburger"
           onClick={() => setMenuOpen(prev => !prev)}
           aria-label={menuOpen ? 'Close menu' : 'Open menu'}
@@ -632,7 +632,7 @@ function Testimonials({ testimonials }) {
           </AnimatePresence>
           <div style={{ display: 'flex', gap: 8, marginTop: 20 }}>
             {testimonials.map((_, i) => (
-              <button key={i} onClick={() => setActive(i)} style={{
+              <button type="button" key={i} onClick={() => setActive(i)} style={{
                 width: i === active ? 26 : 8, height: 8, borderRadius: 99,
                 background: i === active ? T.indigo : T.border,
                 border: 'none', cursor: 'pointer', transition: 'all 0.3s',

--- a/frontend/src/components/portfolio/templates/Watercolor_Artistic/Hero.jsx
+++ b/frontend/src/components/portfolio/templates/Watercolor_Artistic/Hero.jsx
@@ -513,8 +513,8 @@ export default function Hero() {
 
           {/* CTAs */}
           <div style={{ opacity:mounted?1:0, transform:mounted?'none':'translateY(16px)', transition:'opacity 0.7s ease 0.55s, transform 0.7s ease 0.55s', display:'flex', flexWrap:'wrap', gap:12 }}>
-            <button className="cta-primary">View Portfolio</button>
-            <button className="cta-secondary">Get in Touch</button>
+            <button type="button" className="cta-primary">View Portfolio</button>
+            <button type="button" className="cta-secondary">Get in Touch</button>
           </div>
 
           {/* Stats */}

--- a/frontend/src/components/portfolio/templates/Weather_Mood/index.jsx
+++ b/frontend/src/components/portfolio/templates/Weather_Mood/index.jsx
@@ -698,7 +698,7 @@ function MoodPicker({ current, onChange }) {
 
   return (
     <div className="relative">
-      <button
+      <button type="button"
         onClick={() => setOpen(o => !o)}
         className="flex items-center gap-2 px-3 py-1.5 rounded-xl text-xs font-semibold border transition-all"
         style={{ background: theme.badgeBg, borderColor: theme.badgeBorder, color: theme.badgeText }}
@@ -720,7 +720,7 @@ function MoodPicker({ current, onChange }) {
           >
             <div className="p-2 grid grid-cols-3 gap-1 max-h-72 overflow-y-auto">
               {Object.entries(MOODS).map(([key, mood]) => (
-                <button
+                <button type="button"
                   key={key}
                   onClick={() => { onChange(key); setOpen(false); }}
                   className="flex flex-col items-center gap-1 px-2 py-2.5 rounded-xl text-center transition-all hover:scale-105"
@@ -765,7 +765,7 @@ function Navbar({ theme, active, moodKey, onMoodChange }) {
       className={`fixed top-0 left-0 right-0 z-50 px-5 py-2.5 flex items-center justify-between transition-shadow duration-300 ${scrolled ? 'shadow-xl' : ''}`}
       style={theme.nav}
     >
-      <button onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      <button type="button" onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         className="font-bold tracking-tight text-sm" style={{ color: theme.accent }}>
         {data.personal.name.split(' ')[0]}
         <span style={{ color: theme.muted }}>.dev</span>
@@ -773,7 +773,7 @@ function Navbar({ theme, active, moodKey, onMoodChange }) {
 
       <div className="hidden md:flex items-center gap-0.5">
         {NAV_ITEMS.map(item => (
-          <button key={item} onClick={() => scrollTo(item)}
+          <button type="button" key={item} onClick={() => scrollTo(item)}
             className="px-3 py-1.5 rounded-lg text-xs font-medium capitalize transition-all"
             style={{
               color: active === item ? theme.accent : theme.muted,

--- a/frontend/src/components/roast/RoastInput.jsx
+++ b/frontend/src/components/roast/RoastInput.jsx
@@ -126,7 +126,7 @@ export default function RoastInput({
           <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
             <FileText className="h-3.5 w-3.5" />
             {fileName}
-            <button
+            <button type="button"
               onClick={() => {
                 setFileName(null);
                 onChange('');

--- a/frontend/src/components/settings/AIProviderCard.jsx
+++ b/frontend/src/components/settings/AIProviderCard.jsx
@@ -204,7 +204,7 @@ export default function AIProviderCard({ providerId, isActive, onActivate }) {
         </div>
 
         {/* Expand toggle */}
-        <button
+        <button type="button"
           onClick={toggleExpand}
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           aria-label={expanded ? 'Collapse' : 'Expand'}
@@ -339,7 +339,7 @@ export default function AIProviderCard({ providerId, isActive, onActivate }) {
                 {/* Action Buttons */}
                 <div className="flex items-center gap-2">
                   {hasKey && (
-                    <button
+                    <button type="button"
                       onClick={handleDelete}
                       className="inline-flex items-center justify-center p-2 rounded-lg text-red-400 hover:text-red-300 hover:bg-red-400/10 transition-colors"
                       title="Delete API Key"
@@ -348,7 +348,7 @@ export default function AIProviderCard({ providerId, isActive, onActivate }) {
                     </button>
                   )}
                   {/* Validate & Save Button */}
-                  <button
+                  <button type="button"
                     onClick={handleValidate}
                     disabled={isValidating || !apiKey.trim()}
                     className={cn(

--- a/frontend/src/components/settings/AIProviderIndicator.jsx
+++ b/frontend/src/components/settings/AIProviderIndicator.jsx
@@ -56,7 +56,7 @@ export default function AIProviderIndicator({ open, animate }) {
   return (
     <div className="relative">
       {/* Trigger button */}
-      <button
+      <button type="button"
         ref={buttonRef}
         onClick={() => setShowPopover((prev) => !prev)}
         className={cn(
@@ -135,7 +135,7 @@ export default function AIProviderIndicator({ open, animate }) {
                 const isActive = activeProvider === key;
 
                 return (
-                  <button
+                  <button type="button"
                     key={key}
                     onClick={() => handleSelect(key)}
                     className={cn(
@@ -166,7 +166,7 @@ export default function AIProviderIndicator({ open, animate }) {
 
             {/* Divider + Manage Keys link */}
             <div className="border-t border-border px-2 py-2">
-              <button
+              <button type="button"
                 onClick={() => {
                   setShowPopover(false);
                   navigate("/settings");

--- a/frontend/src/components/settings/GithubTokenCard.jsx
+++ b/frontend/src/components/settings/GithubTokenCard.jsx
@@ -129,7 +129,7 @@ export default function GithubTokenCard() {
       )}
     >
       {/* Header */}
-      <button
+      <button type="button"
         onClick={() => setExpanded((p) => !p)}
         className="flex w-full items-center justify-between gap-3 p-5 text-left"
       >
@@ -296,7 +296,7 @@ export default function GithubTokenCard() {
                         </span>
                       )}
                     </div>
-                    <button
+                    <button type="button"
                       onClick={handleRemove}
                       className="text-muted-foreground hover:text-destructive transition-colors"
                       aria-label="Remove PAT"

--- a/frontend/src/components/settings/MissingApiKeyModal.jsx
+++ b/frontend/src/components/settings/MissingApiKeyModal.jsx
@@ -47,7 +47,7 @@ export default function MissingApiKeyModal() {
                   <KeyRound className="w-6 h-6" />
                   <h2 className="text-lg font-bold">API Key Required</h2>
                 </div>
-                <button
+                <button type="button"
                   onClick={() => setIsOpen(false)}
                   className="text-muted-foreground hover:text-foreground hover:bg-muted p-2 rounded-xl transition-colors"
                 >
@@ -62,13 +62,13 @@ export default function MissingApiKeyModal() {
                 </p>
 
                 <div className="flex justify-end gap-3">
-                  <button
+                  <button type="button"
                     onClick={() => setIsOpen(false)}
                     className="px-4 py-2 font-semibold text-muted-foreground hover:text-foreground hover:bg-muted rounded-xl transition-all"
                   >
                     Cancel
                   </button>
-                  <button
+                  <button type="button"
                     onClick={handleGoToSettings}
                     className="flex items-center gap-2 px-5 py-2 font-bold text-primary-foreground bg-primary hover:bg-primary/90 rounded-xl transition-all shadow-lg hover:shadow-primary/25"
                   >

--- a/frontend/src/components/ui/LandingNavbar.jsx
+++ b/frontend/src/components/ui/LandingNavbar.jsx
@@ -30,7 +30,7 @@ export default function LandingNavbar() {
           </div>
 
           {/* Mobile Menu Button */}
-          <button 
+          <button type="button" 
             className="md:hidden text-gray-900 cursor-pointer"
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             aria-label="Toggle menu"

--- a/frontend/src/components/ui/PortfolioShowcaseSection.jsx
+++ b/frontend/src/components/ui/PortfolioShowcaseSection.jsx
@@ -263,7 +263,7 @@ export default function PortfolioShowcaseSection() {
             {/* Theme switcher dots */}
             <div className="mt-6 flex justify-center gap-3">
               {themes.map((t, i) => (
-                <button
+                <button type="button"
                   key={t.id}
                   onClick={() => setActive(i)}
                   aria-label={`Show ${t.name} theme`}

--- a/frontend/src/components/ui/Sidebar.jsx
+++ b/frontend/src/components/ui/Sidebar.jsx
@@ -146,7 +146,7 @@ export const MobileSidebar = ({
                 {...props}
             >
                 <div className="flex justify-end z-20 w-full">
-                    <button
+                    <button type="button"
                         onClick={() => setOpen(!open)}
                         className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
                         aria-label={open ? "Close sidebar menu" : "Open sidebar menu"}
@@ -170,7 +170,7 @@ export const MobileSidebar = ({
                                 className
                             )}
                         >
-                            <button
+                            <button type="button"
                                 className="absolute right-6 top-6 z-50 p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
                                 onClick={() => setOpen(!open)}
                                 aria-label="Close sidebar menu"

--- a/frontend/src/components/visualizer/ActivityTab.jsx
+++ b/frontend/src/components/visualizer/ActivityTab.jsx
@@ -272,7 +272,7 @@ const ActivityTab = () => {
       <div className="flex flex-col items-center justify-center h-96 gap-3 text-slate-400">
         <ActivityIcon className="w-10 h-10 text-rose-400" />
         <p className="text-rose-300">{activityError}</p>
-        <button
+        <button type="button"
           onClick={handleRefresh}
           className="flex items-center gap-2 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-white text-sm"
         >
@@ -318,7 +318,7 @@ const ActivityTab = () => {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <button
+          <button type="button"
             onClick={() => setShowLines((v) => !v)}
             className={cn(
               'flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors',
@@ -330,7 +330,7 @@ const ActivityTab = () => {
             <BarChart3 className="w-3.5 h-3.5" />
             {showLines ? 'Hide' : 'Show'} code volume
           </button>
-          <button
+          <button type="button"
             onClick={handleRefresh}
             disabled={activityLoading}
             className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium bg-white/5 hover:bg-white/10 border border-white/10 text-slate-300 disabled:opacity-50"
@@ -512,7 +512,7 @@ const ActivityTab = () => {
             <Sparkles className="w-5 h-5 text-violet-400" /> AI Insight
           </h3>
           {!activityDetailed && (
-            <button
+            <button type="button"
               onClick={handleExplainDeeper}
               disabled={loadingDetailed}
               className="flex items-center gap-1.5 text-xs font-medium text-violet-300 hover:text-violet-200 disabled:opacity-50"

--- a/frontend/src/components/visualizer/ArchitectureCanvas.jsx
+++ b/frontend/src/components/visualizer/ArchitectureCanvas.jsx
@@ -134,7 +134,7 @@ const ArchitectureCanvas = () => {
         
         {/* View Toggles */}
         <div className="bg-[#0f172a]/90 backdrop-blur border border-white/10 rounded-lg p-1 flex gap-1 pointer-events-auto">
-          <button
+          <button type="button"
             onClick={() => setViewMode('modules')}
             className={cn(
               "px-3 py-1.5 rounded-md text-sm font-medium flex items-center gap-2 transition-colors",
@@ -143,7 +143,7 @@ const ArchitectureCanvas = () => {
           >
             <Box className="w-4 h-4" /> Modules
           </button>
-          <button
+          <button type="button"
             onClick={() => setViewMode('files')}
             className={cn(
               "px-3 py-1.5 rounded-md text-sm font-medium flex items-center gap-2 transition-colors",

--- a/frontend/src/components/visualizer/CodeViewer.jsx
+++ b/frontend/src/components/visualizer/CodeViewer.jsx
@@ -26,7 +26,7 @@ const CodeViewer = ({ code, language, fileName, onExplain }) => {
         
         <div className="flex items-center gap-2">
           {onExplain && (
-            <button
+            <button type="button"
               onClick={onExplain}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-violet-500/10 text-violet-400 hover:bg-violet-500/20 transition-colors border border-violet-500/20"
             >
@@ -34,7 +34,7 @@ const CodeViewer = ({ code, language, fileName, onExplain }) => {
               Explain File
             </button>
           )}
-          <button
+          <button type="button"
             onClick={handleCopy}
             className="p-1.5 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-white/10 transition-colors"
             title="Copy Code"

--- a/frontend/src/components/visualizer/ContributionGuide.jsx
+++ b/frontend/src/components/visualizer/ContributionGuide.jsx
@@ -72,7 +72,7 @@ const ContributionGuide = () => {
       <div className="flex flex-col items-center justify-center h-96">
         <GitPullRequest className="w-16 h-16 text-slate-500 mb-4" />
         <p className="text-slate-400 mb-4">No contribution guide available.</p>
-        <button 
+        <button type="button" 
           onClick={fetchGuide}
           className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-white transition-colors"
         >
@@ -96,21 +96,21 @@ const ContributionGuide = () => {
         </div>
         
         <div className="flex items-center gap-2">
-          <button 
+          <button type="button" 
             onClick={fetchGuide}
             className="p-2 rounded-lg bg-white/5 hover:bg-white/10 text-slate-400 transition-colors"
             title="Regenerate"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
-          <button 
+          <button type="button" 
             onClick={handleCopy}
             className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-slate-300 transition-colors text-sm font-medium"
           >
             {copied ? <Check className="w-4 h-4 text-emerald-400" /> : <Copy className="w-4 h-4" />}
             Copy
           </button>
-          <button 
+          <button type="button" 
             onClick={handleDownload}
             className="flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-white transition-colors text-sm font-bold"
           >

--- a/frontend/src/components/visualizer/EnhancedFileViewer.jsx
+++ b/frontend/src/components/visualizer/EnhancedFileViewer.jsx
@@ -75,7 +75,7 @@ const EnhancedFileViewer = () => {
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-white/10 bg-[#0f172a]">
         <div className="flex items-center gap-3 overflow-hidden">
-          <button 
+          <button type="button" 
             onClick={handleBack}
             className="p-1 hover:bg-white/10 rounded mr-1 text-slate-400 hover:text-white"
             title="Back to Module"
@@ -94,14 +94,14 @@ const EnhancedFileViewer = () => {
         </div>
         
         <div className="flex items-center gap-2 shrink-0 ml-4">
-          <button
+          <button type="button"
             onClick={handleCopy}
             disabled={loading || !content}
             className="p-2 rounded hover:bg-white/10 text-slate-400 hover:text-white transition-colors"
           >
             {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
           </button>
-          <button
+          <button type="button"
             onClick={() => setInspectorOpen(false)}
             className="p-2 rounded hover:bg-white/10 text-slate-400 hover:text-white transition-colors"
           >

--- a/frontend/src/components/visualizer/FileExplorer.jsx
+++ b/frontend/src/components/visualizer/FileExplorer.jsx
@@ -230,7 +230,7 @@ const FileExplorer = () => {
                     <FileJson className="w-4 h-4 text-violet-400" />
                     AI Explanation
                   </h3>
-                  <button 
+                  <button type="button" 
                     onClick={() => setExplanation(null)}
                     className="text-xs text-slate-400 hover:text-white"
                   >
@@ -276,7 +276,7 @@ const FileExplorer = () => {
                       )}
                       
                       <div className="pt-4 border-t border-white/10">
-                        <button 
+                        <button type="button" 
                           onClick={startFileChat}
                           className="w-full py-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-sm text-white transition-colors"
                         >

--- a/frontend/src/components/visualizer/InterviewPrep.jsx
+++ b/frontend/src/components/visualizer/InterviewPrep.jsx
@@ -68,7 +68,7 @@ const InterviewPrep = () => {
       <div className="flex flex-col items-center justify-center h-96">
         <ShieldAlert className="w-16 h-16 text-slate-500 mb-4" />
         <p className="text-slate-400 mb-4">No questions available.</p>
-        <button 
+        <button type="button" 
           onClick={fetchQuestions}
           className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-white transition-colors"
         >
@@ -90,7 +90,7 @@ const InterviewPrep = () => {
               <BrainCircuit className="w-5 h-5 text-red-400" />
               Categories
             </h3>
-            <button 
+            <button type="button" 
               onClick={fetchQuestions}
               className="p-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-slate-400 transition-colors"
               title="Regenerate Questions"
@@ -100,7 +100,7 @@ const InterviewPrep = () => {
           </div>
           <div className="space-y-2">
             {questions.map((cat, i) => (
-              <button
+              <button type="button"
                 key={i}
                 onClick={() => setActiveCategory(i)}
                 className={cn(
@@ -166,7 +166,7 @@ const InterviewPrep = () => {
                 )}
                 
                 <div className="flex items-center gap-3 border-t border-white/5 pt-4 mt-4">
-                  <button
+                  <button type="button"
                     onClick={() => toggleAnswer(idx)}
                     className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-sm font-medium text-slate-300 transition-colors"
                   >
@@ -176,7 +176,7 @@ const InterviewPrep = () => {
                       <><Eye className="w-4 h-4" /> Reveal Answer</>
                     )}
                   </button>
-                  <button
+                  <button type="button"
                     onClick={() => startMockInterview(q.question)}
                     className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded-xl text-sm font-medium text-red-400 transition-colors"
                   >

--- a/frontend/src/components/visualizer/ModuleInspector.jsx
+++ b/frontend/src/components/visualizer/ModuleInspector.jsx
@@ -40,7 +40,7 @@ const ModuleInspector = () => {
               <span className="text-slate-400">{loc?.toLocaleString()} LOC</span>
             </div>
           </div>
-          <button 
+          <button type="button" 
             onClick={() => setInspectorOpen(false)}
             className="p-1.5 rounded-md hover:bg-white/10 text-slate-400 hover:text-white transition-colors"
           >
@@ -80,7 +80,7 @@ const ModuleInspector = () => {
                   // extract relative path or filename
                   const fileName = file.split('/').pop();
                   return (
-                    <button
+                    <button type="button"
                       key={file}
                       onClick={() => setSelectedFile({ relativePath: file, fileName })}
                       className="text-left px-3 py-2 rounded-lg hover:bg-cyan-500/10 text-sm text-slate-400 hover:text-cyan-400 border border-transparent hover:border-cyan-500/20 transition-colors flex items-center gap-2 group"
@@ -97,7 +97,7 @@ const ModuleInspector = () => {
 
         {/* Bottom Actions */}
         <div className="pt-5 mt-auto border-t border-white/10">
-          <button
+          <button type="button"
             onClick={handleAskAI}
             className="w-full py-3 px-4 rounded-xl bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-500 hover:to-indigo-500 text-white font-medium flex items-center justify-center gap-2 transition-all shadow-lg shadow-violet-500/25 active:scale-95"
           >

--- a/frontend/src/components/visualizer/RiskCard.jsx
+++ b/frontend/src/components/visualizer/RiskCard.jsx
@@ -50,7 +50,7 @@ const RiskCard = ({ risk }) => {
           </div>
           <div>
             <h4 className="font-semibold text-white capitalize">{type.replace('-', ' ')}</h4>
-            <button 
+            <button type="button" 
               onClick={handleFileClick}
               className="text-xs font-mono text-slate-400 hover:text-cyan-400 truncate max-w-[200px] sm:max-w-sm text-left"
               title={file}

--- a/frontend/src/components/visualizer/SuggestionCard.jsx
+++ b/frontend/src/components/visualizer/SuggestionCard.jsx
@@ -66,7 +66,7 @@ const SuggestionCard = ({ suggestion, index }) => {
             <span className="font-mono bg-black/30 px-2 py-0.5 rounded text-xs border border-white/5">{module}</span>
           </div>
           
-          <button 
+          <button type="button" 
             onClick={handleModuleClick}
             className="flex items-center gap-1 text-sm font-medium text-violet-400 hover:text-violet-300 transition-colors"
           >

--- a/frontend/src/components/visualizer/VisualizerChat.jsx
+++ b/frontend/src/components/visualizer/VisualizerChat.jsx
@@ -152,7 +152,7 @@ const VisualizerChat = () => {
               { id: 'qa', icon: Search, label: 'Q&A Engine', color: 'text-cyan-400' },
               { id: 'interview', icon: ShieldAlert, label: 'Principal Interview', color: 'text-red-400' }
             ].map(mode => (
-              <button
+              <button type="button"
                 key={mode.id}
                 onClick={() => setChatMode(mode.id)}
                 className={cn(
@@ -167,7 +167,7 @@ const VisualizerChat = () => {
               </button>
             ))}
           </div>
-          <button 
+          <button type="button" 
             onClick={() => setChatExpanded(false)}
             className="p-1.5 rounded-md hover:bg-white/10 text-slate-400 hover:text-white"
           >
@@ -238,7 +238,7 @@ const VisualizerChat = () => {
       {/* Input Area */}
       <div className="p-4 bg-[#0a0f1c] mt-auto flex items-center gap-4 max-w-6xl mx-auto w-full h-[80px]">
         {!chatExpanded && (
-          <button 
+          <button type="button" 
             onClick={() => setChatExpanded(true)}
             className="p-3 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-slate-300 transition-colors shrink-0"
           >
@@ -249,7 +249,7 @@ const VisualizerChat = () => {
         {!chatExpanded && messages.length === 0 && (
           <div className="hidden md:flex items-center gap-2 mr-4 shrink-0 overflow-x-auto custom-scrollbar pb-2">
             {quickActions.map(action => (
-              <button
+              <button type="button"
                 key={action}
                 onClick={() => handleSubmit(null, action)}
                 className="whitespace-nowrap px-4 py-2 rounded-full bg-white/5 border border-white/10 hover:bg-white/10 hover:border-violet-500/50 text-sm text-slate-300 transition-colors"

--- a/frontend/src/pages/Community.jsx
+++ b/frontend/src/pages/Community.jsx
@@ -279,7 +279,7 @@ export default function Community() {
 <div className={`${sidebarOpen ? 'w-72' : 'w-0'} bg-background border-r border-border flex flex-col transition-all duration-300 overflow-hidden shrink-0`}>          {/* View Tabs */}
           <div className="p-3 border-b border-border">
 <div className="flex gap-1 bg-muted p-1 rounded-lg w-full">
-                <button
+                <button type="button"
                 onClick={() => handleTabChange('channels')}
                 className={`flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-md text-sm font-medium transition-colors ${activeView === 'channels' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
                   }`}
@@ -287,7 +287,7 @@ export default function Community() {
                 <MessageSquare className="w-4 h-4" />
                 <span className="inline">Chat</span>
               </button>
-              <button
+              <button type="button"
                 onClick={() => handleTabChange('posts')}
                 className={`flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-md text-sm font-medium transition-colors ${activeView === 'posts' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
                   }`}
@@ -295,7 +295,7 @@ export default function Community() {
                 <FileText className="w-4 h-4" />
                 <span className="inline">Posts</span>
               </button>
-              <button
+              <button type="button"
                 onClick={() => handleTabChange('dms')}
                 className={`flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-md text-sm font-medium transition-colors ${activeView === 'dms' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
                   }`}
@@ -333,7 +333,7 @@ export default function Community() {
         </div>
 
         {/* Sidebar Toggle */}
-        <button
+        <button type="button"
           onClick={() => setSidebarOpen(!sidebarOpen)}
           className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-card border border-border rounded-r-lg p-1.5 shadow-md hover:bg-muted lg:hidden"
         >
@@ -384,7 +384,7 @@ export default function Community() {
 
         {/* Members Toggle */}
         {activeView === 'channels' && (
-          <button
+          <button type="button"
             onClick={() => setMembersOpen(!membersOpen)}
             className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-card border border-border rounded-l-lg p-1.5 shadow-md hover:bg-muted hidden lg:block"
           >
@@ -441,7 +441,7 @@ function CreateChannelModal({ onClose, onCreate }) {
             <Hash className="w-5 h-5 text-primary" />
             Create Channel
           </h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
             <X className="w-5 h-5" />
           </button>
         </div>

--- a/frontend/src/pages/CoverLetter.jsx
+++ b/frontend/src/pages/CoverLetter.jsx
@@ -263,7 +263,7 @@ const CoverLetter = () => {
                       </option>
                     ))}
                   </select>
-                  <button
+                  <button type="button"
                     onClick={() => handleSelectSavedResume(selectedResumeId)}
                     disabled={!selectedResumeId}
                     className="px-6 py-3 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:hover:bg-blue-600 text-white font-medium rounded-xl transition-colors whitespace-nowrap"
@@ -360,7 +360,7 @@ const CoverLetter = () => {
                   Resume extracted successfully
                 </p>
               </div>
-              <button
+              <button type="button"
                 onClick={() => {
                   setStep(1);
                   setResumeFile(null);
@@ -423,7 +423,7 @@ const CoverLetter = () => {
               </p>
               <div className="flex gap-3">
                 {TONES.map((t) => (
-                  <button
+                  <button type="button"
                     key={t}
                     onClick={() => setTone(t)}
                     className={`px-5 py-2 rounded-full text-sm font-medium capitalize transition-all duration-200 ${
@@ -440,7 +440,7 @@ const CoverLetter = () => {
 
             {error && <p className="text-red-400 text-sm px-1">{error}</p>}
 
-            <button
+            <button type="button"
               onClick={handleGenerate}
               disabled={loading}
               className="w-full py-4 rounded-2xl font-semibold text-white text-base transition-all duration-200 disabled:opacity-50"
@@ -471,19 +471,19 @@ const CoverLetter = () => {
                 Your Cover Letter
               </h2>
               <div className="flex gap-2">
-                <button
+                <button type="button"
                   onClick={() => setStep(2)}
                   className="px-4 py-2 text-sm rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white transition-all"
                 >
                   ← Edit
                 </button>
-                <button
+                <button type="button"
                   onClick={handleCopy}
                   className="px-4 py-2 text-sm rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 text-gray-300 hover:text-white transition-all"
                 >
                   {copied ? "✓ Copied!" : "Copy"}
                 </button>
-                <button
+                <button type="button"
                   onClick={handleDownloadPDF}
                   className="px-4 py-2 text-sm rounded-xl font-medium text-white transition-all"
                   style={{

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -275,7 +275,7 @@ export default function Dashboard() {
             {fetchError && (
               <div className="mb-8 rounded-2xl border border-destructive/20 bg-destructive/5 px-6 py-4 text-sm text-destructive flex items-center justify-between backdrop-blur-md">
                 <span className="font-semibold">{fetchError}</span>
-                <button
+                <button type="button"
                   onClick={fetchData}
                   className="px-4 py-1.5 bg-destructive text-foreground rounded-lg font-bold hover:opacity-90 transition-opacity"
                 >

--- a/frontend/src/pages/Enhance.jsx
+++ b/frontend/src/pages/Enhance.jsx
@@ -872,7 +872,7 @@ export default function Enhance() {
                 className="flex-1 px-4 py-3 bg-muted/50 border border-border rounded-xl text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                 onKeyPress={(e) => e.key === 'Enter' && handleAnalyze()}
               />
-              <button
+              <button type="button"
                 onClick={handleAnalyze}
                 disabled={analyzing || !jobRole.trim()}
                 className="px-8 py-3 bg-gradient-to-r from-indigo-600 to-purple-600 text-foreground rounded-xl font-medium hover:from-primary hover:to-secondary transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
@@ -911,7 +911,7 @@ export default function Enhance() {
                     </p>
                     <p className="text-sm text-muted-foreground">for {jobRole}</p>
                   </div>
-                  <button
+                  <button type="button"
                     onClick={() => {
                       setHasAnalyzed(false)
                       setAtsAnalysis(null)
@@ -923,7 +923,7 @@ export default function Enhance() {
                     <RefreshCw className="w-4 h-4" />
                     Analyze Different Role
                   </button>
-                  <button
+                  <button type="button"
                     onClick={handleScoreResume}
                     disabled={scoring}
                     className="mt-2 text-sm text-purple-400 hover:text-purple-300 flex items-center gap-1"
@@ -1069,7 +1069,7 @@ export default function Enhance() {
                     { id: 'tips', label: 'Senior Tips', icon: Lightbulb },
                     { id: 'score', label: 'Resume Score', icon: ClipboardList }
                   ].map(tab => (
-                    <button
+                    <button type="button"
                       key={tab.id}
                       onClick={() => setActiveTab(tab.id)}
                       className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all ${activeTab === tab.id
@@ -1265,7 +1265,7 @@ export default function Enhance() {
                         </div>
                         <h3 className="text-xl font-semibold text-foreground mb-2">Resume Score</h3>
                         <p className="text-muted-foreground mb-6">Get an overall score and section-by-section breakdown with 3 tailored improvement tips.</p>
-                        <button
+                        <button type="button"
                           onClick={handleScoreResume}
                           disabled={scoring}
                           className="px-8 py-3 bg-gradient-to-r from-indigo-600 to-purple-600 text-white rounded-xl font-medium hover:from-primary hover:to-secondary transition-all flex items-center gap-2 mx-auto"
@@ -1300,7 +1300,7 @@ export default function Enhance() {
                 </div>
                 <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row">
                   {enhancementComplete && (
-                    <button
+                    <button type="button"
                       onClick={handleGeneratePortfolio}
                       disabled={generatingPortfolio}
                       className="w-full md:w-auto px-8 py-4 bg-secondary text-secondary-foreground rounded-xl font-semibold hover:bg-secondary/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
@@ -1318,7 +1318,7 @@ export default function Enhance() {
                       )}
                     </button>
                   )}
-                  <button
+                  <button type="button"
                     onClick={handleEnhanceWithAI}
                     disabled={enhancing}
                     className="w-full md:w-auto px-8 py-4 bg-gradient-to-r from-indigo-600 to-purple-600 text-foreground rounded-xl font-semibold hover:from-primary hover:to-secondary transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 shadow-lg shadow-indigo-500/25"
@@ -1527,7 +1527,7 @@ export default function Enhance() {
 
       <div className="flex items-center gap-3">
         {!enhancing && (
-          <button
+          <button type="button"
             onClick={() => setStreamedText('')}
             className="
               rounded-xl

--- a/frontend/src/pages/GitHubDashboard.jsx
+++ b/frontend/src/pages/GitHubDashboard.jsx
@@ -204,7 +204,7 @@ export default function GitHubDashboard() {
                 )}
 
                 <div className="pt-6 border-t border-white/10 flex justify-end">
-                  <button
+                  <button type="button"
                     onClick={handleImport}
                     disabled={isImporting}
                     className="px-8 py-3 bg-primary text-primary-foreground rounded-full font-medium hover:bg-primary/90 hover:scale-105 active:scale-95 transition-all flex items-center gap-2 shadow-lg shadow-primary/25 disabled:opacity-50 disabled:pointer-events-none"

--- a/frontend/src/pages/InterviewHistory.jsx
+++ b/frontend/src/pages/InterviewHistory.jsx
@@ -102,7 +102,7 @@ export default function InterviewHistory() {
           <Trophy className="w-16 h-16 text-muted-foreground/30 mx-auto mb-4" />
           <h2 className="text-xl font-semibold text-foreground mb-2">No Interviews Yet</h2>
           <p className="text-muted-foreground mb-6">Start your first mock interview to see your history and analytics here.</p>
-          <button 
+          <button type="button" 
             onClick={() => navigate('/interview-prep')}
             className="px-6 py-2.5 bg-primary text-primary-foreground font-medium rounded-lg hover:bg-primary/90 transition-colors"
           >
@@ -122,7 +122,7 @@ export default function InterviewHistory() {
                   <FilterX className="w-4 h-4 text-muted-foreground" />
                   Filters
                 </h3>
-                <button onClick={clearFilters} className="text-xs text-primary hover:underline font-medium">
+                <button type="button" onClick={clearFilters} className="text-xs text-primary hover:underline font-medium">
                   Clear All
                 </button>
               </div>

--- a/frontend/src/pages/InterviewPrep.jsx
+++ b/frontend/src/pages/InterviewPrep.jsx
@@ -1641,7 +1641,7 @@ ${updatedProgress.level}`
                 {isCoding ? <span className="inline-flex items-center gap-1"><Code2 className="w-3.5 h-3.5" /> Coding Question</span> : `Question ${currentQuestionIndex + 1} of ${formData.questionCount}`}
               </span>
               <div className="flex items-center gap-3">
-                <button
+                <button type="button"
                   onClick={() => setShowSwitchProvider(true)}
                   className="text-xs inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-muted/50 border border-border text-muted-foreground hover:text-foreground hover:border-primary/30"
                   title="Re-analyze with a different AI provider"
@@ -1690,18 +1690,18 @@ ${updatedProgress.level}`
                   </div>
 
                   <div className="flex justify-center gap-3">
-                    <button onClick={toggleVideo} className={`p-3 rounded-xl border transition-colors cursor-pointer ${videoEnabled ? 'bg-muted border-border text-foreground hover:bg-muted/80' : 'bg-red-500/20 border-red-500/30 text-red-400'}`}>
+                    <button type="button" onClick={toggleVideo} className={`p-3 rounded-xl border transition-colors cursor-pointer ${videoEnabled ? 'bg-muted border-border text-foreground hover:bg-muted/80' : 'bg-red-500/20 border-red-500/30 text-red-400'}`}>
                       {videoEnabled ? <Video className="w-5 h-5" /> : <VideoOff className="w-5 h-5" />}
                     </button>
-                    <button onClick={toggleAudio} className={`p-3 rounded-xl border transition-colors cursor-pointer ${audioEnabled ? 'bg-muted border-border text-foreground hover:bg-muted/80' : 'bg-red-500/20 border-red-500/30 text-red-400'}`}>
+                    <button type="button" onClick={toggleAudio} className={`p-3 rounded-xl border transition-colors cursor-pointer ${audioEnabled ? 'bg-muted border-border text-foreground hover:bg-muted/80' : 'bg-red-500/20 border-red-500/30 text-red-400'}`}>
                       {audioEnabled ? <Mic className="w-5 h-5" /> : <MicOff className="w-5 h-5" />}
                     </button>
                     {isSpeaking ? (
-                      <button onClick={stopSpeaking} className="p-3 rounded-xl bg-amber-500/20 border border-amber-500/30 text-amber-400 transition-colors cursor-pointer hover:bg-amber-500/30">
+                      <button type="button" onClick={stopSpeaking} className="p-3 rounded-xl bg-amber-500/20 border border-amber-500/30 text-amber-400 transition-colors cursor-pointer hover:bg-amber-500/30">
                         <VolumeX className="w-5 h-5" />
                       </button>
                     ) : (
-                      <button onClick={replayQuestion} className="p-3 rounded-xl bg-primary/20 border border-primary/30 text-primary transition-colors cursor-pointer hover:bg-primary/90/30" title="Replay question">
+                      <button type="button" onClick={replayQuestion} className="p-3 rounded-xl bg-primary/20 border border-primary/30 text-primary transition-colors cursor-pointer hover:bg-primary/90/30" title="Replay question">
                         <RotateCcw className="w-5 h-5" />
                       </button>
                     )}
@@ -1850,7 +1850,7 @@ ${updatedProgress.level}`
                       </Button>
                     </div>
                   ) : (
-                    <button onClick={stopRecording} disabled={loading} className="flex-1 w-full py-4 rounded-xl bg-red-500 hover:bg-red-600 text-foreground font-medium flex items-center justify-center gap-2 transition-colors cursor-pointer disabled:opacity-50">
+                    <button type="button" onClick={stopRecording} disabled={loading} className="flex-1 w-full py-4 rounded-xl bg-red-500 hover:bg-red-600 text-foreground font-medium flex items-center justify-center gap-2 transition-colors cursor-pointer disabled:opacity-50">
                       <XCircle className="w-5 h-5" />
                       {loading ? 'Submitting...' : 'Stop & Submit'}
                     </button>
@@ -1878,7 +1878,7 @@ ${updatedProgress.level}`
             </p>
             <div className="space-y-2 max-h-64 overflow-y-auto">
               {Object.entries(configuredProviders).map(([key, val]) => (
-                <button
+                <button type="button"
                   key={key}
                   onClick={async () => {
                     useAIConfigStore.getState().setActiveProvider(key);

--- a/frontend/src/pages/InterviewReplay.jsx
+++ b/frontend/src/pages/InterviewReplay.jsx
@@ -72,7 +72,7 @@ export default function InterviewReplay() {
       <div className="max-w-4xl mx-auto px-4 py-16 text-center">
         <h2 className="text-2xl font-bold text-foreground mb-4">Error Loading Interview</h2>
         <p className="text-muted-foreground mb-6">{error}</p>
-        <button
+        <button type="button"
           onClick={() => navigate('/interview-history')}
           className="inline-flex items-center gap-2 text-primary hover:underline"
         >
@@ -87,7 +87,7 @@ export default function InterviewReplay() {
     return (
       <div className="max-w-4xl mx-auto px-4 py-16 text-center">
         <h2 className="text-2xl font-bold text-foreground mb-4">Interview Not Found</h2>
-        <button
+        <button type="button"
           onClick={() => navigate('/interview-history')}
           className="inline-flex items-center gap-2 text-primary hover:underline"
         >
@@ -102,7 +102,7 @@ export default function InterviewReplay() {
     <div className="max-w-4xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
       {/* Header and Back Button */}
       <div className="mb-6">
-        <button
+        <button type="button"
           onClick={() => navigate('/interview-history')}
           className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-4 transition-colors text-sm font-medium"
         >
@@ -341,7 +341,7 @@ function AnswerWithExtras({ interviewId, answer, index }) {
               rows={2}
               className="flex-1 text-sm bg-muted/40 border border-border rounded-lg px-3 py-2 text-foreground focus:ring-2 focus:ring-primary focus:border-primary/50 resize-y"
             />
-            <button
+            <button type="button"
               onClick={saveAnnotation}
               disabled={!annotation.trim() || saving}
               className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium disabled:opacity-50 hover:bg-primary/90 transition-colors"

--- a/frontend/src/pages/JetLandingPage.jsx
+++ b/frontend/src/pages/JetLandingPage.jsx
@@ -80,7 +80,7 @@ const menuItemVariants = {
               </div>
 
               {/* Mobile Menu Button */}
-              <button 
+              <button type="button" 
                 className="md:hidden text-gray-400 cursor-pointer mr-8 "
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
                 aria-label="Toggle menu"
@@ -131,12 +131,12 @@ const menuItemVariants = {
             </p>
 
             <div className="flex items-center gap-4">
-              <button 
+              <button type="button" 
                 onClick={() => window.location.href='/jobs'}
                 className="px-6 py-3 rounded-full bg-gray-300 text-gray-800 font-medium hover:bg-gray-400 transition-colors">
                 Explore Jobs
               </button>
-              <button 
+              <button type="button" 
                 onClick={() => window.location.href='/register'}
                 className="px-6 py-3 rounded-full text-white font-medium transition-colors" 
                 style={{ backgroundColor: '#202A36' }} 

--- a/frontend/src/pages/JobAlerts.jsx
+++ b/frontend/src/pages/JobAlerts.jsx
@@ -97,7 +97,7 @@ export default function JobAlerts() {
                 We'll email you when new jobs match your criteria.
               </p>
             </div>
-            <button
+            <button type="button"
               onClick={() => setIsModalOpen(true)}
               className="flex items-center gap-2 px-6 py-3 bg-card text-foreground border border-border rounded-xl font-semibold hover:bg-muted/20 transition-all cursor-pointer"
             >
@@ -153,7 +153,7 @@ export default function JobAlerts() {
             { id: 'alerts', label: 'My Alerts', icon: Bell },
             { id: 'search', label: 'Search Jobs', icon: Search },
           ].map(tab => (
-            <button
+            <button type="button"
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className={`flex items-center gap-2 px-6 py-3 rounded-t-xl font-medium transition-all cursor-pointer ${
@@ -210,7 +210,7 @@ export default function JobAlerts() {
                     <p className="text-sm text-muted-foreground">
                       Want to get notified about "{searchQuery}" jobs?
                     </p>
-                    <button
+                    <button type="button"
                       onClick={handleCreateAlertFromSearch}
                       className="text-sm text-primary font-medium hover:text-primary/85 flex items-center gap-1 cursor-pointer"
                     >
@@ -311,7 +311,7 @@ function JobCard({ job, index }) {
             {/* Action Buttons */}
             <div className="flex gap-2 shrink-0">
               {job.applyLink && (
-                <button
+                <button type="button"
                   onClick={handleApply}
                   className="flex items-center gap-1.5 px-4 py-2 bg-card text-foreground rounded-lg border border-border font-medium hover:bg-muted/20 transition-colors text-sm cursor-pointer"
                 >
@@ -320,7 +320,7 @@ function JobCard({ job, index }) {
                 </button>
               )}
               {job.recruiterEmail && (
-                <button
+                <button type="button"
                   onClick={handleEmail}
                   className="flex items-center gap-1.5 px-4 py-2 bg-card text-foreground rounded-lg border border-border font-medium hover:bg-muted/60 transition-colors text-sm cursor-pointer"
                 >

--- a/frontend/src/pages/JobSearch.jsx
+++ b/frontend/src/pages/JobSearch.jsx
@@ -441,7 +441,7 @@ className="w-full pl-12 pr-10 py-4 bg-muted/50 border border-border rounded-xl t
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {POPULAR_SEARCHES.map(search => (
-                    <button
+                    <button type="button"
                       key={search}
                       onMouseEnter={() => prefetchJobSearch(search, filters)}
                       onFocus={() => prefetchJobSearch(search, filters)}
@@ -582,7 +582,7 @@ className="w-full pl-12 pr-10 py-4 bg-muted/50 border border-border rounded-xl t
 
                       {/* Actions */}
                       <div className="flex flex-col gap-2 ml-4">
-                        <button
+                        <button type="button"
                           onClick={() => handleSaveJob(job)}
                           className={`p-2 rounded-lg transition-colors cursor-pointer ${savedJobs.has(job.job_id || job.id)
                             ? 'bg-primary/20 text-primary border border-primary/30'

--- a/frontend/src/pages/JobTracker.jsx
+++ b/frontend/src/pages/JobTracker.jsx
@@ -518,7 +518,7 @@ const JobTracker = () => {
 
           {/* Filter Buttons */}
           <div className="flex flex-wrap gap-2 mb-6">
-            <button
+            <button type="button"
               onClick={() => setFilterStatus("all")}
               className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                 filterStatus === "all"
@@ -529,7 +529,7 @@ const JobTracker = () => {
               All Columns
             </button>
             {statusOptions.map((status) => (
-              <button
+              <button type="button"
                 key={status.value}
                 onClick={() => setFilterStatus(status.value)}
                 className={`px-4 py-2 rounded-lg font-medium transition-colors ${
@@ -605,7 +605,7 @@ const JobTracker = () => {
                                         <h4 className="font-bold text-foreground text-sm line-clamp-2 leading-tight pr-4">
                                           {job.title}
                                         </h4>
-                                        <button
+                                        <button type="button"
                                           onClick={() => handleDelete(job.id)}
                                           className="text-muted-foreground/50 hover:text-red-500 transition-colors absolute top-4 right-4"
                                           title="Remove Job"
@@ -645,7 +645,7 @@ const JobTracker = () => {
                                             <ExternalLink className="w-3 h-3" /> Apply
                                           </a>
                                         )}
-                                        <button
+                                        <button type="button"
                                           onClick={() =>
                                             setResearchCompany({
                                               name: job.company,
@@ -656,20 +656,20 @@ const JobTracker = () => {
                                         >
                                           <Sparkles className="w-3 h-3" /> AI Research
                                         </button>
-                                        <button
+                                        <button type="button"
                                           onClick={() => setEmailGeneratorJob(job)}
                                           className="flex-1 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 py-1.5 rounded-md text-[11px] font-bold text-center transition-colors flex items-center justify-center gap-1"
                                         >
                                           <Mail className="w-3 h-3" /> Draft Email
                                         </button>
-                                        <button
+                                        <button type="button"
                                           onClick={() => setOutreachJob(job)}
                                           className="flex-1 bg-indigo-500/10 hover:bg-indigo-500/20 text-indigo-600 py-1.5 rounded-md text-[11px] font-bold text-center transition-colors flex items-center justify-center gap-1"
                                         >
                                           <Send className="w-3 h-3" /> Outreach
                                         </button>
                                         {/* Notes toggle button */}
-                                        <button
+                                        <button type="button"
                                           onClick={(e) => {
                                             e.stopPropagation();
                                             if (noteEditing === job.id) {
@@ -746,7 +746,7 @@ const JobTracker = () => {
                                               className="flex-1 text-[11px] bg-background border border-amber-500/30 focus:border-amber-500/60 rounded-lg px-2.5 py-1.5 text-foreground placeholder:text-muted-foreground/40 resize-none outline-none transition-colors"
                                             />
                                             <div className="flex flex-col gap-1">
-                                              <button
+                                              <button type="button"
                                                 onClick={() => handleSaveNote(job.id, noteText)}
                                                 disabled={!noteText.trim()}
                                                 title="Save note (⌘↵)"
@@ -754,7 +754,7 @@ const JobTracker = () => {
                                               >
                                                 <Send className="w-3 h-3" />
                                               </button>
-                                              <button
+                                              <button type="button"
                                                 onClick={() => { setNoteEditing(null); setNoteText(""); }}
                                                 title="Cancel"
                                                 className="p-1.5 bg-muted hover:bg-muted/80 text-muted-foreground rounded-lg transition-colors flex items-center justify-center"

--- a/frontend/src/pages/LinkedInDashboard.jsx
+++ b/frontend/src/pages/LinkedInDashboard.jsx
@@ -266,7 +266,7 @@ export default function LinkedInDashboard() {
                 )}
 
                 <div className="pt-6 border-t border-white/10 flex justify-end">
-                  <button
+                  <button type="button"
                     onClick={handleImport}
                     disabled={isImporting}
                     className="px-8 py-3 bg-[#0077b5] text-white rounded-full font-medium hover:bg-[#005885] hover:scale-105 active:scale-95 transition-all flex items-center gap-2 shadow-lg shadow-[#0077b5]/25 disabled:opacity-50 disabled:pointer-events-none"

--- a/frontend/src/pages/LinkedInOptimizer.jsx
+++ b/frontend/src/pages/LinkedInOptimizer.jsx
@@ -64,7 +64,7 @@ function HeadlineCard({ headline, index, copied, onCopy }) {
         {index + 1}
       </span>
       <p className="text-sm text-foreground font-medium flex-1 leading-relaxed">{headline}</p>
-      <button
+      <button type="button"
         onClick={() => onCopy(headline, `hl-${index}`)}
         className="ml-2 text-muted-foreground hover:text-primary transition shrink-0"
         title="Copy"
@@ -391,13 +391,13 @@ export default function LinkedInOptimizer() {
                       <Linkedin className="w-5 h-5 text-blue-400" /> Rewritten About Section
                     </h2>
                     <div className="flex gap-2">
-                      <button
+                      <button type="button"
                         onClick={copyAbout}
                         className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg bg-primary/10 text-primary hover:bg-primary/20 border border-primary/20 transition font-medium"
                       >
                         {aboutCopied ? <><Check className="w-3.5 h-3.5" /> Copied</> : <><Copy className="w-3.5 h-3.5" /> Copy All</>}
                       </button>
-                      <button
+                      <button type="button"
                         onClick={() => setAboutExpanded(!aboutExpanded)}
                         className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition"
                       >
@@ -409,7 +409,7 @@ export default function LinkedInOptimizer() {
                     {results.aboutRewrite}
                   </div>
                   {!aboutExpanded && (
-                    <button onClick={() => setAboutExpanded(true)} className="text-xs text-primary hover:text-primary/80 mt-2 font-medium">
+                    <button type="button" onClick={() => setAboutExpanded(true)} className="text-xs text-primary hover:text-primary/80 mt-2 font-medium">
                       Show full rewrite →
                     </button>
                   )}

--- a/frontend/src/pages/OpenRouterCallback.jsx
+++ b/frontend/src/pages/OpenRouterCallback.jsx
@@ -82,7 +82,7 @@ export default function OpenRouterCallback() {
         {error ? (
           <div className="text-red-500 mb-4">
             <p className="mb-4">{error}</p>
-            <button 
+            <button type="button" 
               onClick={() => navigate('/')} 
               className="px-6 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
             >

--- a/frontend/src/pages/ProjectVisualizer/Dashboard.jsx
+++ b/frontend/src/pages/ProjectVisualizer/Dashboard.jsx
@@ -143,7 +143,7 @@ const Dashboard = () => {
         <AlertCircle className="w-16 h-16 text-red-500 mb-6" />
         <h2 className="text-2xl font-bold text-white mb-2">Analysis Error</h2>
         <p className="text-slate-400 mb-8 max-w-md text-center">{error}</p>
-        <button 
+        <button type="button" 
           onClick={() => navigate('/project-visualizer')}
           className="px-6 py-3 bg-white/10 hover:bg-white/20 text-white rounded-xl transition-colors"
         >
@@ -171,7 +171,7 @@ const Dashboard = () => {
       {/* Header */}
       <header className="shrink-0 bg-[#0a0f1c] border-b border-white/5 py-4 px-6 flex flex-col md:flex-row md:items-center justify-between gap-4 sticky top-0 z-30 shadow-xl">
         <div className="flex flex-col gap-2">
-          <button 
+          <button type="button" 
             onClick={() => navigate('/project-visualizer')}
             className="flex items-center gap-1.5 text-sm font-medium text-slate-400 hover:text-white transition-colors group w-max"
           >
@@ -196,7 +196,7 @@ const Dashboard = () => {
         {/* Tab Navigation */}
         <div className="flex items-center p-1 bg-black/40 rounded-xl border border-white/5 overflow-x-auto custom-scrollbar md:w-auto w-full">
           {tabs.map(tab => (
-            <button
+            <button type="button"
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className={cn(
@@ -394,7 +394,7 @@ const Dashboard = () => {
                     
                     <div className="flex items-center gap-2 bg-black/30 p-1 rounded-lg border border-white/10">
                       {['all', 'critical', 'high', 'medium', 'low'].map(f => (
-                        <button
+                        <button type="button"
                           key={f}
                           onClick={() => setRiskFilter(f)}
                           className={cn(

--- a/frontend/src/pages/ProjectVisualizer/Landing.jsx
+++ b/frontend/src/pages/ProjectVisualizer/Landing.jsx
@@ -302,7 +302,7 @@ const Landing = () => {
                     </div>
                   </div>
                   
-                  <button
+                  <button type="button"
                     onClick={(e) => handleDeleteHistory(item._id, e)}
                     className="p-2 rounded-lg text-muted-foreground hover:text-red-400 hover:bg-red-400/10 transition-colors opacity-0 group-hover:opacity-100"
                   >

--- a/frontend/src/pages/RepoAnalyzer/Workspace.jsx
+++ b/frontend/src/pages/RepoAnalyzer/Workspace.jsx
@@ -39,7 +39,7 @@ export default function RepoAnalyzerWorkspace() {
         </div>
 
         <div className="flex items-center gap-3">
-          <button
+          <button type="button"
             onClick={() => navigate('/repo-analyzer/dashboard')}
             className="px-3 py-1.5 text-sm font-medium rounded-md bg-slate-800 hover:bg-slate-700 text-slate-300 transition-all cursor-pointer mr-2"
           >
@@ -47,13 +47,13 @@ export default function RepoAnalyzerWorkspace() {
           </button>
           <span className="text-sm text-slate-400 font-medium">Mode:</span>
           <div className="flex items-center bg-[#0f172a] rounded-lg p-1 border border-slate-700">
-            <button
+            <button type="button"
               onClick={() => setIsInterviewMode(false)}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all cursor-pointer ${!isInterviewMode ? 'bg-blue-600 text-white' : 'text-slate-400 hover:text-slate-200'}`}
             >
               QA Engine
             </button>
-            <button
+            <button type="button"
               onClick={() => setIsInterviewMode(true)}
               className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all cursor-pointer ${isInterviewMode ? 'bg-red-600 text-white' : 'text-slate-400 hover:text-slate-200'}`}
             >

--- a/frontend/src/pages/ResumeBuilder.jsx
+++ b/frontend/src/pages/ResumeBuilder.jsx
@@ -962,7 +962,7 @@ useEffect(() => {
                               <div {...provided.dragHandleProps} className="absolute top-4 left-4 text-muted-foreground hover:text-foreground cursor-grab">
                                 <GripVertical className="w-4 h-4" />
                               </div>
-                              <button
+                              <button type="button"
                                 onClick={() => removeEducation(index)}
                                 className="absolute top-4 right-4 text-muted-foreground hover:text-red-500 transition-colors"
                                 aria-label="Remove education entry"
@@ -1055,7 +1055,7 @@ useEffect(() => {
                 )}
               </Droppable>
             </DragDropContext>
-            <button onClick={addEducation} className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
+            <button type="button" onClick={addEducation} className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
               <Plus className="w-4 h-4" /> Add Education
             </button>
           </div>
@@ -1084,7 +1084,7 @@ useEffect(() => {
                               <div {...provided.dragHandleProps} className="absolute top-4 left-4 text-muted-foreground hover:text-foreground cursor-grab">
                                 <GripVertical className="w-4 h-4" />
                               </div>
-                              <button
+                              <button type="button"
                                 onClick={() => removeExperience(index)}
                                 className="absolute top-4 right-4 text-muted-foreground hover:text-red-500 transition-colors"
                                 aria-label="Remove experience entry"
@@ -1199,7 +1199,7 @@ useEffect(() => {
                 )}
               </Droppable>
             </DragDropContext>
-            <button onClick={addExperience} className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
+            <button type="button" onClick={addExperience} className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
               <Plus className="w-4 h-4" /> Add Experience
             </button>
           </div>
@@ -1225,7 +1225,7 @@ useEffect(() => {
                             <div {...provided.dragHandleProps} className="absolute top-4 left-4 text-muted-foreground hover:text-foreground cursor-grab">
                               <GripVertical className="w-4 h-4" />
                             </div>
-                            <button
+                            <button type="button"
                               onClick={() => removeProject(index)}
                               className="absolute top-4 right-4 text-muted-foreground hover:text-red-500 transition-colors"
                               aria-label="Remove project"
@@ -1282,7 +1282,7 @@ useEffect(() => {
                 )}
               </Droppable>
             </DragDropContext>
-            <button onClick={addProject} className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
+            <button type="button" onClick={addProject} className="flex items-center gap-2 text-primary hover:text-primary/80 transition-colors">
               <Plus className="w-4 h-4" /> Add Project
             </button>
           </div>
@@ -1344,7 +1344,7 @@ useEffect(() => {
             </div>
 
             <div className="flex justify-end mb-4">
-  <button
+  <button type="button"
     onClick={saveVersion}
     className="px-4 py-2 rounded-lg bg-primary text-primary-foreground"
   >
@@ -1622,7 +1622,7 @@ useEffect(() => {
             {version.timestamp}
           </span>
 
-          <button
+          <button type="button"
             onClick={() => restoreVersion(version)}
             className="text-primary text-sm font-medium"
           >
@@ -1920,7 +1920,7 @@ useEffect(() => {
 
         {/* Navigation Actions */}
         <div className="mt-8 flex flex-wrap justify-between items-center gap-3">
-          <button
+          <button type="button"
             onClick={handlePrev}
             disabled={currentStep === 0}
             className="px-6 py-2.5 rounded-full bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center gap-2"
@@ -1930,7 +1930,7 @@ useEffect(() => {
 
           {currentStep === STEPS.length - 1 ? (
             <div className="flex flex-wrap gap-2">
-              <button
+              <button type="button"
                 onClick={() => navigate('/resume-templates', {
                   state: {
                     builderData: {
@@ -1970,7 +1970,7 @@ useEffect(() => {
               >
                 <LayoutTemplate className="w-4 h-4" /> Choose Resume Template
               </button>
-              <button
+              <button type="button"
                 onClick={handleGenerate}
                 disabled={isSubmitting}
                 className="px-6 py-2.5 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 hover:scale-105 active:scale-95 disabled:opacity-50 disabled:hover:scale-100 transition-all shadow-lg shadow-primary/25 flex items-center gap-2 font-medium"
@@ -1988,7 +1988,7 @@ useEffect(() => {
               </button>
             </div>
           ) : (
-            <button
+            <button type="button"
               onClick={handleNext}
               className="px-6 py-2.5 rounded-full bg-foreground text-background hover:bg-foreground/90 hover:scale-105 active:scale-95 transition-all shadow-lg flex items-center gap-2 font-medium"
             >

--- a/frontend/src/pages/ResumeView.jsx
+++ b/frontend/src/pages/ResumeView.jsx
@@ -307,7 +307,7 @@ export default function ResumeView() {
         {/* Tab Navigation */}
         <div className="border-b border-border mb-6">
           <nav className="flex gap-8">
-            <button
+            <button type="button"
               onClick={() => setActiveTab('preview')}
               className={`pb-4 text-sm font-semibold border-b-2 transition-all cursor-pointer ${activeTab === 'preview'
                   ? 'border-primary text-primary'
@@ -316,7 +316,7 @@ export default function ResumeView() {
             >
               Resume Preview
             </button>
-            <button
+            <button type="button"
               onClick={() => setActiveTab('versions')}
               className={`pb-4 text-sm font-semibold border-b-2 transition-all cursor-pointer ${activeTab === 'versions'
                   ? 'border-primary text-primary'
@@ -325,7 +325,7 @@ export default function ResumeView() {
             >
               Versions & Snapshots
             </button>
-            <button
+            <button type="button"
               onClick={() => setActiveTab('ats')}
               className={`pb-4 text-sm font-semibold border-b-2 transition-all cursor-pointer ${activeTab === 'ats'
                   ? 'border-primary text-primary'
@@ -348,7 +348,7 @@ export default function ResumeView() {
                   </h2>
                   {resume?.enhancedText && (
                     <div className="flex bg-muted rounded-xl p-0.5 border border-border">
-                      <button
+                      <button type="button"
                         onClick={() => setPreviewTab('enhanced')}
                         className={`px-3 py-1 text-xs font-semibold rounded-lg transition-all ${
                           previewTab === 'enhanced' ? 'bg-primary text-primary-foreground shadow' : 'text-muted-foreground hover:text-foreground'
@@ -356,7 +356,7 @@ export default function ResumeView() {
                       >
                         AI Enhanced
                       </button>
-                      <button
+                      <button type="button"
                         onClick={() => setPreviewTab('original')}
                         className={`px-3 py-1 text-xs font-semibold rounded-lg transition-all ${
                           previewTab === 'original' ? 'bg-primary text-primary-foreground shadow' : 'text-muted-foreground hover:text-foreground'

--- a/frontend/src/pages/SecuritySettings.jsx
+++ b/frontend/src/pages/SecuritySettings.jsx
@@ -409,7 +409,7 @@ export default function SecuritySettings() {
                   onCopy={() => handleCopyCodes(newCodes)}
                   onDownload={() => handleDownloadCodes(newCodes)}
                 />
-                <button
+                <button type="button"
                   onClick={() => { setNewCodes([]); setShowCodesFor(null) }}
                   className="mt-3 text-xs text-muted-foreground hover:text-muted-foreground/80 transition-colors"
                 >

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -52,7 +52,7 @@ export default function Settings() {
   }
 
   const Toggle = ({ value, onChange }) => (
-    <button
+    <button type="button"
       role="switch"
       aria-checked={value}
       onClick={() => onChange(!value)}
@@ -96,7 +96,7 @@ export default function Settings() {
           {/* Tab Navigation */}
           <div className="flex gap-1 p-1 rounded-xl bg-muted/50 border border-border mb-8 w-fit">
             {tabs.map(tab => (
-              <button
+              <button type="button"
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
                 className={`flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 ${

--- a/frontend/src/pages/SharedResumeView.jsx
+++ b/frontend/src/pages/SharedResumeView.jsx
@@ -71,7 +71,7 @@ export default function SharedResumeView() {
           </select>
           <textarea className="w-full border rounded p-2 text-sm mb-2" rows={3} placeholder="Your comment..."
             value={form.text} onChange={e => setForm(f => ({ ...f, text: e.target.value }))} />
-          <button onClick={submitComment}
+          <button type="button" onClick={submitComment}
             className="w-full bg-blue-600 text-white rounded py-2 text-sm hover:bg-blue-700 transition">
             {submitted ? '✓ Submitted!' : 'Submit Feedback'}
           </button>

--- a/frontend/src/pages/TemplateGallery.jsx
+++ b/frontend/src/pages/TemplateGallery.jsx
@@ -291,7 +291,7 @@ function TemplateCard({ template, hovered, onHover, onLeave, onUse, aiDraft }) {
               }}
               className="flex gap-2 w-full mt-4"
             >
-              <button
+              <button type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onUse(template.title, false, template.id);
@@ -300,7 +300,7 @@ function TemplateCard({ template, hovered, onHover, onLeave, onUse, aiDraft }) {
               >
                 Use Theme
               </button>
-              <button
+              <button type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onUse(template.id, true, template.id);
@@ -338,7 +338,7 @@ const TemplatePreviewModal = ({ templateId, isOpen, onClose, portfolioData }) =>
             <span className="text-sm font-semibold text-foreground/70 uppercase tracking-widest">
               Preview — {templateId?.replace(/_/g, " ")}
             </span>
-            <button
+            <button type="button"
               onClick={onClose}
               className="p-2 rounded-xl hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
             >
@@ -488,7 +488,7 @@ export default function TemplateGallery() {
                 automatically inject your experience and projects!
               </p>
             </div>
-            <button
+            <button type="button"
               onClick={clearDraft}
               className="p-2 hover:bg-emerald-500/20 text-emerald-400 rounded-lg transition-colors"
               title="Discard Draft"
@@ -500,7 +500,7 @@ export default function TemplateGallery() {
 
         <div className="flex justify-between items-center mb-8">
           <h1 className="text-4xl font-bold">Template Gallery</h1>
-          <button
+          <button type="button"
             onClick={toggleTheme}
             className="p-2 rounded-xl bg-muted hover:bg-accent border border-border text-foreground transition-all cursor-pointer overflow-hidden relative group"
             aria-label="Toggle theme"
@@ -560,7 +560,7 @@ export default function TemplateGallery() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
             {search && (
-              <button
+              <button type="button"
                 onClick={() => setSearch("")}
                 className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
               >
@@ -602,7 +602,7 @@ export default function TemplateGallery() {
               {search ? `No results for "${search}" — try a different keyword` : "No templates match the selected filters"}
             </div>
             {search && (
-              <button onClick={() => setSearch("")} className="mt-4 text-cyan-400 hover:text-cyan-300 text-sm underline">
+              <button type="button" onClick={() => setSearch("")} className="mt-4 text-cyan-400 hover:text-cyan-300 text-sm underline">
                 Clear search
               </button>
             )}

--- a/frontend/src/pages/TextToResume.jsx
+++ b/frontend/src/pages/TextToResume.jsx
@@ -88,7 +88,7 @@ export default function TextToResume() {
             </div>
 
             <div className="flex justify-end pt-4">
-              <button
+              <button type="button"
                 onClick={handleConvert}
                 disabled={isLoading || !text.trim()}
                 className="px-8 py-3 rounded-full bg-primary text-primary-foreground font-medium flex items-center gap-2 hover:bg-primary/90 hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 disabled:pointer-events-none shadow-lg shadow-primary/20"

--- a/frontend/src/pages/admin/views/AdminBugs.jsx
+++ b/frontend/src/pages/admin/views/AdminBugs.jsx
@@ -91,7 +91,7 @@ const AdminBugs = () => {
         {/* Pagination */}
         {!loading && totalPages > 1 && (
           <div className="flex items-center justify-between p-4 border-t border-gray-100 dark:border-gray-700">
-            <button
+            <button type="button"
               disabled={page === 1}
               onClick={() => setPage(page - 1)}
               className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
@@ -101,7 +101,7 @@ const AdminBugs = () => {
             <span className="text-sm text-gray-500 dark:text-gray-400">
               Page <span className="font-semibold text-gray-900 dark:text-white">{page}</span> of <span className="font-semibold text-gray-900 dark:text-white">{totalPages}</span>
             </span>
-            <button
+            <button type="button"
               disabled={page === totalPages}
               onClick={() => setPage(page + 1)}
               className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"

--- a/frontend/src/pages/admin/views/AdminLogins.jsx
+++ b/frontend/src/pages/admin/views/AdminLogins.jsx
@@ -86,7 +86,7 @@ const AdminLogins = () => {
         {/* Pagination */}
         {!loading && totalPages > 1 && (
           <div className="flex items-center justify-between p-4 border-t border-gray-100 dark:border-gray-700">
-            <button
+            <button type="button"
               disabled={page === 1}
               onClick={() => setPage(page - 1)}
               className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
@@ -96,7 +96,7 @@ const AdminLogins = () => {
             <span className="text-sm text-gray-500 dark:text-gray-400">
               Page <span className="font-semibold text-gray-900 dark:text-white">{page}</span> of <span className="font-semibold text-gray-900 dark:text-white">{totalPages}</span>
             </span>
-            <button
+            <button type="button"
               disabled={page === totalPages}
               onClick={() => setPage(page + 1)}
               className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-800 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"

--- a/frontend/src/pages/admin/views/AdminUsers.jsx
+++ b/frontend/src/pages/admin/views/AdminUsers.jsx
@@ -92,7 +92,7 @@ const AdminUsers = () => {
                       {user.createdAt ? formatDistanceToNow(new Date(user.createdAt), { addSuffix: true }) : '-'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                      <button className="text-primary hover:underline transition-colors">Edit</button>
+                      <button type="button" className="text-primary hover:underline transition-colors">Edit</button>
                     </td>
                   </tr>
                 ))
@@ -108,14 +108,14 @@ const AdminUsers = () => {
               Showing page <span className="font-medium text-foreground">{page}</span> of <span className="font-medium text-foreground">{totalPages}</span>
             </div>
             <div className="flex gap-2">
-              <button
+              <button type="button"
                 onClick={() => setPage(p => Math.max(1, p - 1))}
                 disabled={page === 1}
                 className="p-2 text-foreground bg-card border border-border rounded-xl disabled:opacity-50 hover:bg-muted transition-colors"
               >
                 <ChevronLeft className="w-5 h-5" />
               </button>
-              <button
+              <button type="button"
                 onClick={() => setPage(p => Math.min(totalPages, p + 1))}
                 disabled={page === totalPages}
                 className="p-2 text-foreground bg-card border border-border rounded-xl disabled:opacity-50 hover:bg-muted transition-colors"

--- a/frontend/src/pages/auth/GithubCallback.jsx
+++ b/frontend/src/pages/auth/GithubCallback.jsx
@@ -85,12 +85,12 @@ export default function GithubCallback() {
             </p>
             <div className="flex gap-2 justify-center">
               <Link to="/settings">
-                <button className="rounded-xl border border-border px-4 py-2 text-sm font-semibold hover:bg-muted">
+                <button type="button" className="rounded-xl border border-border px-4 py-2 text-sm font-semibold hover:bg-muted">
                   Open Settings
                 </button>
               </Link>
               <Link to="/portfolio/github">
-                <button className="rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90">
+                <button type="button" className="rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90">
                   Try again
                 </button>
               </Link>

--- a/frontend/src/pages/fellowship/ChallengeDetail.jsx
+++ b/frontend/src/pages/fellowship/ChallengeDetail.jsx
@@ -100,7 +100,7 @@ export default function ChallengeDetail() {
 
     return (
         <div className="max-w-3xl mx-auto space-y-6">
-            <button
+            <button type="button"
                 onClick={() => navigate(-1)}
                 className="flex items-center gap-2 text-muted-foreground hover:text-foreground text-sm"
             >
@@ -204,7 +204,7 @@ export default function ChallengeDetail() {
                         <h3 className="font-semibold text-amber-300">Verify to Apply</h3>
                         <p className="text-sm text-amber-400/70">You need to verify your student status first</p>
                     </div>
-                    <button
+                    <button type="button"
                         onClick={() => navigate('/fellowship/verify')}
                         className="ml-auto px-4 py-2 bg-amber-600 text-foreground rounded-lg text-sm hover:bg-amber-500"
                     >
@@ -214,7 +214,7 @@ export default function ChallengeDetail() {
             )}
 
             {canApply && !showApplyForm && (
-                <button
+                <button type="button"
                     onClick={() => setShowApplyForm(true)}
                     className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-2xl font-semibold flex items-center justify-center gap-2"
                 >
@@ -280,13 +280,13 @@ export default function ChallengeDetail() {
                     </div>
 
                     <div className="flex gap-3 pt-2">
-                        <button
+                        <button type="button"
                             onClick={() => setShowApplyForm(false)}
                             className="px-6 py-3 bg-muted text-foreground rounded-xl font-medium hover:bg-muted/80"
                         >
                             Cancel
                         </button>
-                        <button
+                        <button type="button"
                             onClick={handleApply}
                             disabled={applying}
                             className="flex-1 py-3 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium disabled:opacity-50 flex items-center justify-center gap-2"

--- a/frontend/src/pages/fellowship/ChallengeProposals.jsx
+++ b/frontend/src/pages/fellowship/ChallengeProposals.jsx
@@ -203,7 +203,7 @@ export default function ChallengeProposals() {
 
     return (
         <div className="max-w-4xl mx-auto space-y-6">
-            <button
+            <button type="button"
                 onClick={() => navigate('/fellowship/my-challenges')}
                 className="flex items-center gap-2 text-muted-foreground hover:text-foreground text-sm"
             >
@@ -323,7 +323,7 @@ export default function ChallengeProposals() {
                                                         className="w-full px-4 py-3 bg-muted border border-border rounded-xl text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-emerald-500 resize-none"
                                                     />
                                                     <div className="flex gap-2">
-                                                        <button
+                                                        <button type="button"
                                                             onClick={() => handleUpdateStatus(proposal._id, 'accepted')}
                                                             disabled={updating === proposal._id}
                                                             className="flex-1 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-lg font-medium disabled:opacity-50 flex items-center justify-center gap-2"
@@ -331,7 +331,7 @@ export default function ChallengeProposals() {
                                                             {updating === proposal._id ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle className="w-4 h-4" />}
                                                             Accept
                                                         </button>
-                                                        <button
+                                                        <button type="button"
                                                             onClick={() => handleUpdateStatus(proposal._id, 'rejected')}
                                                             disabled={updating === proposal._id}
                                                             className="flex-1 py-2.5 bg-red-600 hover:bg-red-500 text-foreground rounded-lg font-medium disabled:opacity-50 flex items-center justify-center gap-2"
@@ -340,7 +340,7 @@ export default function ChallengeProposals() {
                                                             Reject
                                                         </button>
                                                     </div>
-                                                    <button
+                                                    <button type="button"
                                                         onClick={() => { setShowFeedbackFor(null); setFeedback('') }}
                                                         className="w-full py-2 text-muted-foreground hover:text-foreground text-sm"
                                                     >
@@ -348,7 +348,7 @@ export default function ChallengeProposals() {
                                                     </button>
                                                 </div>
                                             ) : (
-                                                <button
+                                                <button type="button"
                                                     onClick={() => setShowFeedbackFor(proposal._id)}
                                                     className="w-full py-2.5 bg-muted hover:bg-muted/80 text-foreground rounded-lg font-medium"
                                                 >
@@ -360,7 +360,7 @@ export default function ChallengeProposals() {
 
                                     {proposal.status === 'accepted' && (
                                         <div className="mt-6 pt-4 border-t border-border">
-                                            <button
+                                            <button type="button"
                                                 onClick={() => handleMessageClick(proposal._id)}
                                                 disabled={!hasRoom}
                                                 className="w-full py-2.5 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-lg font-medium flex items-center justify-center gap-2"

--- a/frontend/src/pages/fellowship/Challenges.jsx
+++ b/frontend/src/pages/fellowship/Challenges.jsx
@@ -168,7 +168,7 @@ export default function Challenges() {
                 </div>
                 <div className="flex flex-wrap gap-2">
                     {CATEGORIES.map(cat => (
-                        <button
+                        <button type="button"
                             key={cat.id}
                             onClick={() => setSelectedCategory(cat.id)}
                             className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${selectedCategory === cat.id

--- a/frontend/src/pages/fellowship/CreateChallenge.jsx
+++ b/frontend/src/pages/fellowship/CreateChallenge.jsx
@@ -95,7 +95,7 @@ export default function CreateChallenge() {
 
     return (
         <div className="max-w-2xl mx-auto space-y-6">
-            <button
+            <button type="button"
                 onClick={() => navigate(-1)}
                 className="flex items-center gap-2 text-muted-foreground hover:text-foreground text-sm"
             >
@@ -213,7 +213,7 @@ export default function CreateChallenge() {
                             {requirements.map((req, i) => (
                                 <span key={i} className="flex items-center gap-1 px-3 py-1 bg-muted text-foreground rounded-lg text-sm">
                                     {req}
-                                    <button onClick={() => handleRemoveRequirement(i)} className="hover:text-red-400">
+                                    <button type="button" onClick={() => handleRemoveRequirement(i)} className="hover:text-red-400">
                                         <X className="w-3 h-3" />
                                     </button>
                                 </span>
@@ -223,13 +223,13 @@ export default function CreateChallenge() {
                 </div>
 
                 <div className="flex gap-3 pt-4 border-t border-border">
-                    <button
+                    <button type="button"
                         onClick={() => navigate(-1)}
                         className="px-6 py-3 bg-muted text-foreground rounded-xl font-medium hover:bg-muted/80"
                     >
                         Cancel
                     </button>
-                    <button
+                    <button type="button"
                         onClick={handleSubmit}
                         disabled={!isValid || loading}
                         className="flex-1 py-3 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"

--- a/frontend/src/pages/fellowship/FellowshipChat.jsx
+++ b/frontend/src/pages/fellowship/FellowshipChat.jsx
@@ -168,7 +168,7 @@ export default function FellowshipChat() {
     return (
         <div className="flex flex-col h-[calc(100vh-8rem)]">
             <div className="flex items-center gap-4 pb-4 border-b border-border">
-                <button
+                <button type="button"
                     onClick={() => navigate('/fellowship/messages')}
                     className="p-2 hover:bg-muted rounded-lg text-muted-foreground hover:text-foreground"
                 >
@@ -200,7 +200,7 @@ export default function FellowshipChat() {
 
                     {/* Release Funds Button - Only for corporate when in escrow */}
                     {canReleaseFunds && (
-                        <button
+                        <button type="button"
                             onClick={() => setShowReleaseConfirm(true)}
                             className="flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-lg text-sm font-medium transition-colors"
                         >
@@ -253,14 +253,14 @@ export default function FellowshipChat() {
                         </div>
 
                         <div className="flex gap-3">
-                            <button
+                            <button type="button"
                                 onClick={() => setShowReleaseConfirm(false)}
                                 disabled={releasingFunds}
                                 className="flex-1 py-2.5 bg-muted hover:bg-muted/80 text-foreground rounded-lg font-medium disabled:opacity-50"
                             >
                                 Cancel
                             </button>
-                            <button
+                            <button type="button"
                                 onClick={handleReleaseFunds}
                                 disabled={releasingFunds}
                                 className="flex-1 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-lg font-medium flex items-center justify-center gap-2 disabled:opacity-50"

--- a/frontend/src/pages/fellowship/FellowshipLayout.jsx
+++ b/frontend/src/pages/fellowship/FellowshipLayout.jsx
@@ -80,13 +80,13 @@ export default function FellowshipLayout() {
                 <div className="max-w-md text-center space-y-4">
                     <p className="text-foreground">{error}</p>
                     <div className="flex flex-wrap justify-center gap-3">
-                        <button
+                        <button type="button"
                             onClick={loadProfile}
                             className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-lg"
                         >
                             Retry
                         </button>
-                        <button
+                        <button type="button"
                             onClick={() => navigate('/dashboard')}
                             className="px-4 py-2 bg-muted text-foreground rounded-lg hover:bg-muted/80"
                         >
@@ -200,7 +200,7 @@ export default function FellowshipLayout() {
             <div className="flex flex-1 flex-col overflow-hidden">
                 <header className="flex h-16 items-center justify-between border-b border-border bg-background px-4 lg:px-6">
                     <div className="flex items-center gap-4">
-                        <button
+                        <button type="button"
                             className="lg:hidden p-2 text-muted-foreground hover:text-foreground"
                             onClick={() => setSidebarOpen(true)}
                         >
@@ -210,7 +210,7 @@ export default function FellowshipLayout() {
                     </div>
 
                     <div className="flex items-center gap-3">
-                        <button
+                        <button type="button"
                             onClick={handleLogout}
                             className="flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
                         >

--- a/frontend/src/pages/fellowship/FellowshipMessages.jsx
+++ b/frontend/src/pages/fellowship/FellowshipMessages.jsx
@@ -64,7 +64,7 @@ export default function FellowshipMessages() {
                             ? 'Once a company accepts your proposal, you can chat with them here.'
                             : 'Accept a student proposal to start a conversation with them.'}
                     </p>
-                    <button
+                    <button type="button"
                         onClick={() => navigate('/fellowship/challenges')}
                         className="mt-4 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium"
                     >

--- a/frontend/src/pages/fellowship/MyChallenges.jsx
+++ b/frontend/src/pages/fellowship/MyChallenges.jsx
@@ -82,7 +82,7 @@ export default function MyChallenges() {
                     <h1 className="text-2xl font-bold text-foreground">My Challenges</h1>
                     <p className="text-muted-foreground">Manage your posted challenges</p>
                 </div>
-                <button
+                <button type="button"
                     onClick={() => navigate('/fellowship/create-challenge')}
                     className="flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium"
                 >
@@ -96,7 +96,7 @@ export default function MyChallenges() {
                     <FolderKanban className="h-12 w-12 text-muted-foreground/80" />
                     <h3 className="mt-4 text-lg font-semibold text-foreground">No challenges yet</h3>
                     <p className="mt-2 text-sm text-muted-foreground">Post your first challenge to find student talent</p>
-                    <button
+                    <button type="button"
                         onClick={() => navigate('/fellowship/create-challenge')}
                         className="mt-4 flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium"
                     >
@@ -149,14 +149,14 @@ export default function MyChallenges() {
                                 </div>
 
                                 <div className="mt-4 flex gap-2">
-                                    <button
+                                    <button type="button"
                                         onClick={() => navigate(`/fellowship/challenges/${challenge._id}`)}
                                         className="px-4 py-2 bg-muted text-foreground rounded-lg text-sm hover:bg-muted/80"
                                     >
                                         View Details
                                     </button>
                                     {challenge.proposalCount > 0 && (
-                                        <button
+                                        <button type="button"
                                             onClick={() => navigate(`/fellowship/challenges/${challenge._id}/proposals`)}
                                             className="px-4 py-2 bg-emerald-600 text-foreground rounded-lg text-sm hover:bg-emerald-500"
                                         >
@@ -166,7 +166,7 @@ export default function MyChallenges() {
 
                                     {confirmDelete === challenge._id ? (
                                         <div className="flex gap-2 ml-auto">
-                                            <button
+                                            <button type="button"
                                                 onClick={() => handleDelete(challenge._id)}
                                                 disabled={deleting === challenge._id}
                                                 className="px-4 py-2 bg-red-600 text-foreground rounded-lg text-sm hover:bg-red-500 disabled:opacity-50 flex items-center gap-2"
@@ -177,7 +177,7 @@ export default function MyChallenges() {
                                                     'Confirm'
                                                 )}
                                             </button>
-                                            <button
+                                            <button type="button"
                                                 onClick={() => setConfirmDelete(null)}
                                                 className="px-4 py-2 bg-card text-foreground rounded-lg text-sm hover:bg-muted/60"
                                             >
@@ -185,7 +185,7 @@ export default function MyChallenges() {
                                             </button>
                                         </div>
                                     ) : (
-                                        <button
+                                        <button type="button"
                                             onClick={() => setConfirmDelete(challenge._id)}
                                             className="px-3 py-2 bg-muted text-red-400 rounded-lg text-sm hover:bg-red-950 ml-auto"
                                             title="Delete challenge"

--- a/frontend/src/pages/fellowship/Onboarding.jsx
+++ b/frontend/src/pages/fellowship/Onboarding.jsx
@@ -201,7 +201,7 @@ export default function Onboarding() {
                                 <p className="mt-1 text-right text-xs text-muted-foreground">{bio.length}/500 characters</p>
                             </div>
 
-                            <button
+                            <button type="button"
                                 onClick={handleCompanySubmit}
                                 disabled={loading || !companyName.trim()}
                                 className="w-full py-3 bg-blue-600 hover:bg-blue-500 text-foreground rounded-xl font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
@@ -257,7 +257,7 @@ export default function Onboarding() {
                                 />
                             </div>
 
-                            <button
+                            <button type="button"
                                 onClick={handleSendVerification}
                                 disabled={loading || !email.trim()}
                                 className="w-full py-3 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
@@ -265,7 +265,7 @@ export default function Onboarding() {
                                 {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Send Verification Code'}
                             </button>
 
-                            <button
+                            <button type="button"
                                 onClick={handleSkipVerification}
                                 disabled={loading}
                                 className="w-full py-2 text-muted-foreground hover:text-foreground text-sm disabled:opacity-50"
@@ -296,7 +296,7 @@ export default function Onboarding() {
                                 className="w-full px-4 py-4 bg-background border border-border rounded-xl text-foreground text-center text-2xl tracking-widest placeholder:text-muted-foreground/80 focus:outline-none focus:border-emerald-500"
                             />
 
-                            <button
+                            <button type="button"
                                 onClick={handleVerifyCode}
                                 disabled={loading || verificationCode.length !== 6}
                                 className="w-full py-3 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
@@ -304,7 +304,7 @@ export default function Onboarding() {
                                 {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Verify'}
                             </button>
 
-                            <button
+                            <button type="button"
                                 onClick={handleSendVerification}
                                 disabled={loading}
                                 className="w-full py-2 text-muted-foreground hover:text-foreground text-sm"

--- a/frontend/src/pages/fellowship/Verify.jsx
+++ b/frontend/src/pages/fellowship/Verify.jsx
@@ -41,7 +41,7 @@ export default function Verify() {
                     </div>
                     <h2 className="mt-4 text-xl font-semibold text-foreground">Already Verified!</h2>
                     <p className="mt-2 text-muted-foreground">Your student status has been verified.</p>
-                    <button
+                    <button type="button"
                         onClick={() => navigate('/fellowship/challenges')}
                         className="mt-6 px-6 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium"
                     >
@@ -57,7 +57,7 @@ export default function Verify() {
             <div className="max-w-lg mx-auto">
                 <div className="bg-background border border-border rounded-2xl p-8 text-center">
                     <p className="text-muted-foreground">Verification is only required for student accounts.</p>
-                    <button
+                    <button type="button"
                         onClick={() => navigate('/fellowship/challenges')}
                         className="mt-4 text-emerald-400 hover:text-emerald-300"
                     >
@@ -113,7 +113,7 @@ export default function Verify() {
 
     return (
         <div className="max-w-lg mx-auto">
-            <button
+            <button type="button"
                 onClick={() => navigate(-1)}
                 className="flex items-center gap-2 text-muted-foreground hover:text-foreground text-sm mb-6"
             >
@@ -148,7 +148,7 @@ export default function Verify() {
                                 />
                             </div>
 
-                            <button
+                            <button type="button"
                                 onClick={handleSendCode}
                                 disabled={loading || !email.trim()}
                                 className="w-full py-3 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
@@ -179,7 +179,7 @@ export default function Verify() {
                                 className="w-full px-4 py-4 bg-muted border border-border rounded-xl text-foreground text-center text-2xl tracking-widest placeholder:text-muted-foreground/80 focus:outline-none focus:border-emerald-500"
                             />
 
-                            <button
+                            <button type="button"
                                 onClick={handleVerify}
                                 disabled={loading || verificationCode.length !== 6}
                                 className="w-full py-3 bg-emerald-600 hover:bg-emerald-500 text-foreground rounded-xl font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
@@ -187,7 +187,7 @@ export default function Verify() {
                                 {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Verify'}
                             </button>
 
-                            <button
+                            <button type="button"
                                 onClick={handleSendCode}
                                 disabled={loading}
                                 className="w-full py-2 text-muted-foreground hover:text-foreground text-sm"

--- a/frontend/src/pages/hubs/GithubPortfolioHub.jsx
+++ b/frontend/src/pages/hubs/GithubPortfolioHub.jsx
@@ -71,14 +71,14 @@ export default function GithubPortfolioHub() {
             </p>
             <div className="flex flex-wrap gap-2">
               <Link to="/settings">
-                <button className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold hover:bg-muted">
+                <button type="button" className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold hover:bg-muted">
                   <Key className="h-3.5 w-3.5" />
                   Manage GitHub settings
                 </button>
               </Link>
               {!oauthConnected && (
                 <Link to="/settings">
-                  <button className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90">
+                  <button type="button" className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90">
                     <ShieldCheck className="h-3.5 w-3.5" />
                     Connect with OAuth
                   </button>
@@ -126,7 +126,7 @@ export default function GithubPortfolioHub() {
                     {new Date(b.createdAt).toLocaleDateString()}
                   </p>
                 </Link>
-                <button
+                <button type="button"
                   onClick={() => removeBuild(b._id)}
                   className="absolute top-3 right-3 text-xs text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
                 >

--- a/frontend/src/pages/hubs/ResumeHub.jsx
+++ b/frontend/src/pages/hubs/ResumeHub.jsx
@@ -201,7 +201,7 @@ export default function ResumeHub() {
                     <Eye className="w-3.5 h-3.5 inline mr-1" />
                     View
                   </Link>
-                  <button
+                  <button type="button"
                     onClick={() => handleDelete(resume._id)}
                     className="text-xs font-semibold px-3 py-2 rounded-lg bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
                   >

--- a/frontend/src/pages/hubs/RoastHub.jsx
+++ b/frontend/src/pages/hubs/RoastHub.jsx
@@ -68,7 +68,7 @@ export default function RoastHub() {
                     {new Date(r.createdAt).toLocaleDateString()}
                   </p>
                 </Link>
-                <button
+                <button type="button"
                   onClick={(e) => {
                     e.preventDefault();
                     removeFromHistory(r._id || r.id);


### PR DESCRIPTION
Hi, closing this in favor of smaller focused PRs so the review bots and CI can handle them properly:

- #4394: portfolio templates buttons only
- #4395: shared components buttons only
- #4396: pages buttons only

Same change, just split by folder so each diff is reasonable.