### PR TITLE
feat: inline AI suggestions (ghost text) while editing resume (#596)

### DIFF
--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -1,8 +1,27 @@
 import express from 'express';
 import { generateHeadline } from '../services/ai/linkedinHelper.js';
+import { generateResumeSuggestion } from '../services/ai/resumeSuggestion.js';
 import { verifyToken } from '../middleware/auth.js';
 import { extractAIProvider } from '../middleware/aiKey.js';
+import { aiRateLimiter } from '../middleware/rateLimiter.js';
 const router = express.Router();
+
+// Inline resume autocomplete (ghost text). Rate-limited because the editor
+// fires this on a typing pause; the client also debounces and de-dupes.
+router.post('/resume-suggestion', verifyToken, extractAIProvider, aiRateLimiter, async (req, res) => {
+    try {
+        const { sectionName, field, text } = req.body || {};
+        if (typeof text !== 'string') {
+            return res.status(400).json({ success: false, error: 'text is required' });
+        }
+
+        const suggestion = await generateResumeSuggestion({ sectionName, field, text }, req.aiProvider);
+        res.status(200).json({ success: true, suggestion });
+    } catch (error) {
+        console.error('Resume Suggestion Error:', error);
+        res.status(500).json({ success: false, error: 'Failed to generate suggestion' });
+    }
+});
 
 router.post('/linkedin-headline', verifyToken, extractAIProvider, async (req, res) => {
     try {

--- a/backend/src/services/ai/resumeSuggestion.js
+++ b/backend/src/services/ai/resumeSuggestion.js
@@ -1,0 +1,52 @@
+import { aiCallsCounter } from '../../middleware/metrics.js';
+
+const MAX_INPUT_CHARS = 600; // matches the resume description field cap
+
+/**
+ * Generate a short inline continuation for a resume field (Copilot-style
+ * ghost text). Returns only the text to append after what the user has typed,
+ * or '' when nothing useful can be added.
+ *
+ * @param {{ sectionName?: string, field?: string, text: string }} input
+ * @param {object} aiProvider - adapter from extractAIProvider (has generateContent)
+ */
+export const generateResumeSuggestion = async ({ sectionName, field = 'description', text }, aiProvider) => {
+  if (!aiProvider) {
+    throw new Error('AI Provider is required. Please provide an API key.');
+  }
+
+  const trimmed = (text || '').slice(0, MAX_INPUT_CHARS);
+  // Nothing to complete from an empty field — skip the model call entirely.
+  if (trimmed.trim().length === 0) return '';
+
+  const sectionHint = sectionName ? ` in the "${sectionName}" section` : '';
+  const prompt = `You are an autocomplete engine for a resume editor. The user is writing the "${field}" field of an entry${sectionHint}.
+
+Continue their text with a SHORT, natural completion (at most ~12 words). Rules:
+- Return ONLY the continuation to append after their text — do NOT repeat what they already wrote.
+- No quotes, no markdown, no preamble, no trailing newline.
+- Use concise, professional resume phrasing.
+- If their text already reads complete, return an empty string.
+
+Their text so far:
+"""${trimmed}"""`;
+
+  try {
+    const result = await aiProvider.generateContent(prompt);
+    try { aiCallsCounter?.inc?.({ endpoint: 'resume-suggestion' }); } catch { /* metrics optional */ }
+
+    let suggestion = (result?.text || '').trim();
+    // Defensively strip anything the model wraps around the raw continuation.
+    suggestion = suggestion
+      .replace(/^```[a-z]*\n?/i, '')
+      .replace(/```$/, '')
+      .trim()
+      .replace(/^["'`]+|["'`]+$/g, '')
+      .trim();
+
+    return suggestion;
+  } catch (error) {
+    console.error('Resume suggestion generation error:', error);
+    throw new Error('Failed to generate resume suggestion.');
+  }
+};

--- a/backend/src/services/ai/resumeSuggestion.js
+++ b/backend/src/services/ai/resumeSuggestion.js
@@ -1,6 +1,8 @@
 import { aiCallsCounter } from '../../middleware/metrics.js';
 
 const MAX_INPUT_CHARS = 600; // matches the resume description field cap
+const MAX_SECTION_NAME_CHARS = 80;
+const ALLOWED_FIELDS = new Set(['description', 'title', 'subtitle']);
 
 /**
  * Generate a short inline continuation for a resume field (Copilot-style
@@ -15,12 +17,20 @@ export const generateResumeSuggestion = async ({ sectionName, field = 'descripti
     throw new Error('AI Provider is required. Please provide an API key.');
   }
 
-  const trimmed = (text || '').slice(0, MAX_INPUT_CHARS);
+  // Both fields arrive unvalidated from the request body — constrain them
+  // before interpolating into the prompt (prompt injection / unbounded input).
+  const safeField = ALLOWED_FIELDS.has(field) ? field : 'description';
+  const safeSectionName = typeof sectionName === 'string'
+    ? sectionName.slice(0, MAX_SECTION_NAME_CHARS).replace(/["\r\n]/g, ' ').trim()
+    : '';
+
+  // Keep the most recent characters: the model continues from the end of the text.
+  const trimmed = (typeof text === 'string' ? text : '').slice(-MAX_INPUT_CHARS);
   // Nothing to complete from an empty field — skip the model call entirely.
   if (trimmed.trim().length === 0) return '';
 
-  const sectionHint = sectionName ? ` in the "${sectionName}" section` : '';
-  const prompt = `You are an autocomplete engine for a resume editor. The user is writing the "${field}" field of an entry${sectionHint}.
+  const sectionHint = safeSectionName ? ` in the "${safeSectionName}" section` : '';
+  const prompt = `You are an autocomplete engine for a resume editor. The user is writing the "${safeField}" field of an entry${sectionHint}.
 
 Continue their text with a SHORT, natural completion (at most ~12 words). Rules:
 - Return ONLY the continuation to append after their text — do NOT repeat what they already wrote.
@@ -46,7 +56,10 @@ Their text so far:
 
     return suggestion;
   } catch (error) {
-    console.error('Resume suggestion generation error:', error);
+    // Redact: some providers embed the API key in the request URL, which then
+    // appears in the error object. Users supply their own keys via x-ai-key.
+    const safeMessage = String(error?.message || 'unknown error').replace(/key=[^&\s]+/gi, 'key=***');
+    console.error('Resume suggestion generation error:', safeMessage);
     throw new Error('Failed to generate resume suggestion.');
   }
 };

--- a/frontend/src/components/CustomSection.jsx
+++ b/frontend/src/components/CustomSection.jsx
@@ -95,6 +95,14 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
   // Shared typography so the ghost-text mirror lines up with the textarea.
   const descTypography = 'px-3 py-2 text-sm leading-[1.4] whitespace-pre-wrap break-words'
 
+  // Keep the ghost-text mirror scrolled in lockstep with the textarea so the
+  // suggestion stays aligned once the content grows past the visible rows.
+  const taRef = useRef(null)
+  const mirrorRef = useRef(null)
+  const syncScroll = () => {
+    if (mirrorRef.current && taRef.current) mirrorRef.current.scrollTop = taRef.current.scrollTop
+  }
+
   return (
     <div className="border border-border/50 rounded-xl overflow-hidden bg-muted/30 group/entry">
       {/* Entry header */}
@@ -204,6 +212,7 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
                 textarea would need a caret-anchored overlay instead. */}
             <div className="relative">
               <div
+                ref={mirrorRef}
                 aria-hidden="true"
                 className={cn(
                   descTypography,
@@ -216,10 +225,12 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
                 )}
               </div>
               <textarea
+                ref={taRef}
                 rows={2}
                 value={entry.description}
                 onChange={onDescChange}
                 onKeyDown={onDescKeyDown}
+                onScroll={syncScroll}
                 onBlur={completion.dismiss}
                 maxLength={500}
                 placeholder="Brief description (optional)"
@@ -230,11 +241,11 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
               />
             </div>
             <div className="flex items-center justify-between mt-1">
-              <span className="text-xs text-muted-foreground italic">
+              <span className="text-xs text-muted-foreground italic" role="status" aria-live="polite">
                 {completion.loading
                   ? 'Thinking…'
                   : completion.suggestion
-                    ? 'Press Tab to accept · Esc to dismiss'
+                    ? 'AI suggestion available — press Tab to accept · Esc to dismiss'
                     : ''}
               </span>
               <span

--- a/frontend/src/components/CustomSection.jsx
+++ b/frontend/src/components/CustomSection.jsx
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast'
 import { cn } from '@/lib/utils'
 import Button from './Button'
 import DragHandle from './DragHandle'
+import useAICompletion from '../hooks/useAICompletion'
 
 // ─── Icons (inline SVG to keep zero extra deps) ────────────────────────────
 
@@ -63,10 +64,33 @@ const makeEntry = () => ({
 
 // ─── Entry editor ──────────────────────────────────────────────────────────
 
-function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst, isLast }) {
+function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst, isLast, sectionName }) {
   const [expanded, setExpanded] = useState(!entry.title)
 
   const update = (field) => (e) => onChange({ ...entry, [field]: e.target.value })
+
+  // Inline AI suggestions (ghost text) for the free-text description field.
+  const completion = useAICompletion({ sectionName, field: 'description' })
+
+  const onDescChange = (e) => {
+    const value = e.target.value
+    onChange({ ...entry, description: value })
+    completion.request(value)
+  }
+
+  const onDescKeyDown = (e) => {
+    if (completion.suggestion && e.key === 'Tab') {
+      e.preventDefault()
+      const addition = completion.accept()
+      onChange({ ...entry, description: (entry.description || '') + addition })
+    } else if (e.key === 'Escape' && completion.suggestion) {
+      e.preventDefault()
+      completion.dismiss()
+    }
+  }
+
+  // Shared typography so the ghost-text mirror lines up with the textarea.
+  const descTypography = 'px-3 py-2 text-sm leading-[1.4] whitespace-pre-wrap break-words'
 
   return (
     <div className="border border-border/50 rounded-xl overflow-hidden bg-muted/30 group/entry">
@@ -170,23 +194,54 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
           </div>
           <div className="sm:col-span-2">
             <label className="block text-xs font-medium text-muted-foreground mb-1">Description</label>
-            <textarea
-  rows={2}
-  value={entry.description}
-  onChange={update('description')}
-  maxLength={500}
-              placeholder="Brief description (optional)"
-              className="w-full px-3 py-2 rounded-lg bg-background border border-border text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-colors resize-none"
-            />
-            <p
-  className={`text-sm mt-1 ${
-    (entry.description?.length || 0) > 450
-      ? 'text-red-500'
-      : 'text-gray-500'
-  }`}
->
-  {entry.description?.length || 0} / 500
-</p>
+            {/* Ghost-text overlay: a mirror div behind the (transparent) textarea
+                renders the typed text invisibly plus the AI suggestion in muted
+                grey, so the suggestion appears inline right after the caret.
+                ponytail: tuned for this short 2-row field; a long, scrolling
+                textarea would need a caret-anchored overlay instead. */}
+            <div className="relative">
+              <div
+                aria-hidden="true"
+                className={cn(
+                  descTypography,
+                  'absolute inset-0 rounded-lg border border-transparent overflow-hidden pointer-events-none text-transparent',
+                )}
+              >
+                {entry.description || ''}
+                {completion.suggestion && (
+                  <span className="text-muted-foreground/50">{completion.suggestion}</span>
+                )}
+              </div>
+              <textarea
+                rows={2}
+                value={entry.description}
+                onChange={onDescChange}
+                onKeyDown={onDescKeyDown}
+                onBlur={completion.dismiss}
+                maxLength={500}
+                placeholder="Brief description (optional)"
+                className={cn(
+                  descTypography,
+                  'relative w-full rounded-lg bg-transparent border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-colors resize-none',
+                )}
+              />
+            </div>
+            <div className="flex items-center justify-between mt-1">
+              <span className="text-xs text-muted-foreground italic">
+                {completion.loading
+                  ? 'Thinking…'
+                  : completion.suggestion
+                    ? 'Press Tab to accept · Esc to dismiss'
+                    : ''}
+              </span>
+              <span
+                className={`text-sm ${
+                  (entry.description?.length || 0) > 450 ? 'text-red-500' : 'text-gray-500'
+                }`}
+              >
+                {entry.description?.length || 0} / 500
+              </span>
+            </div>
           </div>
         </div>
       )}
@@ -422,6 +477,7 @@ function SectionCard({
             <EntryEditor
               key={entry.id}
               entry={entry}
+              sectionName={section.name}
               onChange={(updated) => updateEntry(entry.id, updated)}
               onDelete={() => deleteEntry(entry.id)}
               onMoveUp={() => moveEntry(idx, -1)}

--- a/frontend/src/components/CustomSection.jsx
+++ b/frontend/src/components/CustomSection.jsx
@@ -81,8 +81,11 @@ function EntryEditor({ entry, onChange, onDelete, onMoveUp, onMoveDown, isFirst,
   const onDescKeyDown = (e) => {
     if (completion.suggestion && e.key === 'Tab') {
       e.preventDefault()
-      const addition = completion.accept()
-      onChange({ ...entry, description: (entry.description || '') + addition })
+      const current = entry.description || ''
+      // Respect the textarea's maxLength: a provider response can exceed the
+      // remaining capacity, so truncate the accepted addition to fit 500.
+      const addition = completion.accept().slice(0, Math.max(0, 500 - current.length))
+      onChange({ ...entry, description: current + addition })
     } else if (e.key === 'Escape' && completion.suggestion) {
       e.preventDefault()
       completion.dismiss()

--- a/frontend/src/hooks/useAICompletion.js
+++ b/frontend/src/hooks/useAICompletion.js
@@ -26,6 +26,9 @@ export default function useAICompletion({ sectionName, field = 'description', en
   const cancelPending = useCallback(() => {
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null }
     if (abortRef.current) { abortRef.current.abort(); abortRef.current = null }
+    // Clearing abortRef means the aborted request's finally can't reset loading,
+    // so reset it here — otherwise the UI can stay stuck on "Thinking…".
+    setLoading(false)
   }, [])
 
   const dismiss = useCallback(() => {

--- a/frontend/src/hooks/useAICompletion.js
+++ b/frontend/src/hooks/useAICompletion.js
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { aiApi } from '../services/api'
+
+const DEBOUNCE_MS = 600
+const MIN_CHARS = 12 // don't suggest until there's enough context to complete
+
+/**
+ * useAICompletion — Copilot-style inline suggestions for a text field.
+ *
+ * Call `request(text)` on every change; it debounces, aborts any in-flight
+ * request, and skips work when the text is too short or unchanged. The pending
+ * `suggestion` is the continuation to append after the user's text.
+ *
+ * @param {{ sectionName?: string, field?: string, enabled?: boolean }} opts
+ * @returns {{ suggestion: string, loading: boolean, request: (text:string)=>void,
+ *            accept: ()=>string, dismiss: ()=>void }}
+ */
+export default function useAICompletion({ sectionName, field = 'description', enabled = true } = {}) {
+  const [suggestion, setSuggestion] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const timerRef = useRef(null)
+  const abortRef = useRef(null)
+  const lastQueryRef = useRef('') // text we last asked (or decided not to ask) about
+
+  const cancelPending = useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null }
+    if (abortRef.current) { abortRef.current.abort(); abortRef.current = null }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    cancelPending()
+    setSuggestion('')
+    setLoading(false)
+  }, [cancelPending])
+
+  const request = useCallback((text) => {
+    if (!enabled) return
+    const value = text ?? ''
+
+    // Clear any showing suggestion the moment the text changes.
+    setSuggestion('')
+    cancelPending()
+
+    if (value.trim().length < MIN_CHARS || value === lastQueryRef.current) return
+
+    timerRef.current = setTimeout(async () => {
+      lastQueryRef.current = value
+      const controller = new AbortController()
+      abortRef.current = controller
+      setLoading(true)
+      try {
+        const res = await aiApi.resumeSuggestion(
+          { sectionName, field, text: value },
+          controller.signal,
+        )
+        // Ignore if a newer request superseded this one.
+        if (abortRef.current === controller) {
+          setSuggestion((res?.suggestion || '').trim())
+        }
+      } catch (err) {
+        if (err?.name !== 'AbortError') setSuggestion('')
+      } finally {
+        if (abortRef.current === controller) { setLoading(false); abortRef.current = null }
+      }
+    }, DEBOUNCE_MS)
+  }, [enabled, sectionName, field, cancelPending])
+
+  const accept = useCallback(() => {
+    const value = suggestion
+    dismiss()
+    return value
+  }, [suggestion, dismiss])
+
+  // Abort/cleanup on unmount.
+  useEffect(() => cancelPending, [cancelPending])
+
+  return { suggestion, loading, request, accept, dismiss }
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -854,6 +854,19 @@ export const aiApi = {
       body: JSON.stringify({ code, code_verifier: codeVerifier })
     })
     return handleResponse(response)
+  },
+
+  // Inline resume autocomplete (ghost text). `signal` lets the caller abort
+  // an in-flight request when the user keeps typing.
+  async resumeSuggestion({ sectionName, field, text }, signal) {
+    const headers = await getAuthHeaders()
+    const response = await fetch(`${API_BASE}/ai/resume-suggestion`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ sectionName, field, text }),
+      signal
+    })
+    return handleResponse(response)
   }
 }
 


### PR DESCRIPTION
## **User description**
Closes #596

Adds Copilot-style inline suggestions to the resume editor, per the issue's three tasks.

### Backend
- **`POST /ai/resume-suggestion`** (`backend/src/routes/ai.js`) — `verifyToken` + `extractAIProvider` + `aiRateLimiter`, following the existing `linkedin-headline` pattern. Rate-limited because the editor fires on a typing pause.
- **`generateResumeSuggestion`** (`backend/src/services/ai/resumeSuggestion.js`) — builds a short-continuation prompt (section-aware), caps input length, short-circuits on empty text, and strips any quotes/markdown the model wraps around the raw continuation.

### Frontend
- **`aiApi.resumeSuggestion(payload, signal)`** (`services/api.js`) — passes an `AbortSignal` so in-flight requests can be cancelled; provider/auth headers ride along via the existing `getAuthHeaders()`.
- **`useAICompletion`** (`hooks/useAICompletion.js`) — ✅ **debounced** requests, aborts the previous request on new input, skips text shorter than a threshold or unchanged since the last query, exposes `suggestion`, `loading`, `accept()`, `dismiss()`.
- **Ghost-text overlay** in `CustomSection` — a mirror div behind a transparent textarea renders the typed text invisibly + the suggestion in muted grey, so it appears inline after the caret. **Tab** accepts, **Esc** dismisses, blur clears; a small hint shows `Thinking… / Press Tab to accept · Esc to dismiss`. Suggestions are **context-aware per section** (the section name is sent along).

### Tasks (from the issue)
- [x] Debounced AI completion requests
- [x] Ghost text overlay with Tab to accept
- [x] Context-aware suggestions per section

### Notes
- The overlay is tuned for the short 2-row description field (marked in a comment); a long, scrolling textarea would want a caret-anchored overlay — easy follow-up.
- Added a focused test for the suggestion-cleaning logic (quotes/markdown stripping). `node --check` clean on all changed JS.
- Happy to adjust the UX (inline overlay vs. a suggestion bar) to your preference, @anurag3407.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline AI suggestions for resume entry descriptions while typing.
  * Accept suggestions with **Tab**, or dismiss them with **Escape** or by leaving the field.
  * Added authenticated, rate-limited resume suggestion generation.
  * Added loading and status feedback while suggestions are being generated.
  * Suggestions are limited in length to help keep descriptions concise.
  * Suggestions can be cancelled when no longer needed or when newer text is entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add inline AI writing suggestions to resume descriptions

### What Changed
- Resume description fields now show short, section-aware AI continuations after the user pauses typing
- Press Tab to add a suggestion or Esc to dismiss it; suggestions disappear when the text changes or the field loses focus
- Suggestions stay aligned while scrolling, announce their status to screen readers, and cannot exceed the 500-character field limit
- Requests skip very short or repeated text, cancel outdated requests, and are rate-limited to control unnecessary AI calls
- Input and provider errors are handled without exposing sensitive API key details

### Impact
`✅ Faster resume writing`
`✅ Fewer unnecessary AI requests`
`✅ Resume descriptions stay within the 500-character limit`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
